### PR TITLE
Main layout header

### DIFF
--- a/packages/browser-wallet/build/dev.ts
+++ b/packages/browser-wallet/build/dev.ts
@@ -3,6 +3,7 @@
 import esbuild, { BuildOptions } from 'esbuild';
 import { htmlPlugin } from '@craftamap/esbuild-plugin-html';
 import { sassPlugin } from 'esbuild-sass-plugin';
+import svgrPlugin from 'esbuild-plugin-svgr';
 import fs from 'fs';
 import { manifestPlugin } from './plugins/chrome-extension-manifest-v3';
 
@@ -34,6 +35,7 @@ const config: BuildOptions = {
     },
     loader: { '.jpg': 'dataurl', '.png': 'dataurl' },
     plugins: [
+        svgrPlugin(),
         sassPlugin(),
         htmlPlugin({
             files: [

--- a/packages/browser-wallet/package.json
+++ b/packages/browser-wallet/package.json
@@ -48,6 +48,7 @@
         "cross-env": "^7.0.3",
         "css-loader": "^6.7.1",
         "esbuild": "^0.14.31",
+        "esbuild-plugin-svgr": "^1.0.1",
         "esbuild-sass-plugin": "^2.2.6",
         "sass": "^1.52.2",
         "sass-loader": "^13.0.0",

--- a/packages/browser-wallet/src/popup/constants/routes.ts
+++ b/packages/browser-wallet/src/popup/constants/routes.ts
@@ -9,6 +9,12 @@ type RouteChildren = {
 export const relativeRoutes = {
     home: {
         path: '/',
+        identities: {
+            path: 'identities',
+        },
+        settings: {
+            path: 'settings',
+        },
     },
     prompt: {
         path: '/prompt',

--- a/packages/browser-wallet/src/popup/page-layouts/FullscreenPromptLayout/FullscreenPromptLayout.scss
+++ b/packages/browser-wallet/src/popup/page-layouts/FullscreenPromptLayout/FullscreenPromptLayout.scss
@@ -1,5 +1,6 @@
 .fullscreen-prompt-layout {
     position: relative;
+    padding: rem(10px);
 
     &__close {
         position: absolute;

--- a/packages/browser-wallet/src/popup/page-layouts/MainLayout/Header/Header.scss
+++ b/packages/browser-wallet/src/popup/page-layouts/MainLayout/Header/Header.scss
@@ -1,10 +1,20 @@
 .main-layout-header {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    border-bottom: 1px solid $color-petroleum;
     height: rem(40px);
-    background-color: $color-bg;
+    position: relative;
+    z-index: 0;
+
+    &__bar,
+    &__nav {
+        background-color: $color-bg;
+        border-bottom: 1px solid $color-petroleum;
+    }
+
+    &__bar {
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
 
     &__logo {
         position: absolute;
@@ -17,6 +27,18 @@
             path {
                 fill: $color-text;
             }
+        }
+    }
+
+    &__nav {
+        transform: translateY(-100%);
+        position: relative;
+        z-index: -1;
+        transition: transform $transition-timing $transition-easing;
+        text-align: center;
+
+        &--open {
+            transform: translateY(0);
         }
     }
 }

--- a/packages/browser-wallet/src/popup/page-layouts/MainLayout/Header/Header.scss
+++ b/packages/browser-wallet/src/popup/page-layouts/MainLayout/Header/Header.scss
@@ -1,3 +1,18 @@
 .main-layout-header {
     display: flex;
+    justify-content: center;
+    align-items: center;
+    border-bottom: 1px solid $color-petroleum;
+    height: rem(40px);
+    background-color: $color-bg;
+
+    &__logo {
+        position: absolute;
+        left: rem(10px);
+        display: flex;
+
+        svg {
+            width: rem(23px);
+        }
+    }
 }

--- a/packages/browser-wallet/src/popup/page-layouts/MainLayout/Header/Header.scss
+++ b/packages/browser-wallet/src/popup/page-layouts/MainLayout/Header/Header.scss
@@ -1,0 +1,3 @@
+.main-layout-header {
+    display: flex;
+}

--- a/packages/browser-wallet/src/popup/page-layouts/MainLayout/Header/Header.scss
+++ b/packages/browser-wallet/src/popup/page-layouts/MainLayout/Header/Header.scss
@@ -26,6 +26,11 @@
 
             path {
                 fill: $color-text;
+                transition: fill $transition-timing $transition-easing;
+
+                .main-layout-header--open & {
+                    fill: $color-blue;
+                }
             }
         }
     }
@@ -51,6 +56,17 @@
 
         &:not(.main-layout-header__nav-item--active) {
             font-weight: $font-weight-light;
+        }
+
+        svg {
+            width: rem(11px);
+            transform: translateX(100%);
+            position: absolute;
+            right: rem(-5px);
+
+            path {
+                fill: $color-text;
+            }
         }
     }
 }

--- a/packages/browser-wallet/src/popup/page-layouts/MainLayout/Header/Header.scss
+++ b/packages/browser-wallet/src/popup/page-layouts/MainLayout/Header/Header.scss
@@ -13,6 +13,10 @@
 
         svg {
             width: rem(23px);
+
+            path {
+                fill: $color-text;
+            }
         }
     }
 }

--- a/packages/browser-wallet/src/popup/page-layouts/MainLayout/Header/Header.scss
+++ b/packages/browser-wallet/src/popup/page-layouts/MainLayout/Header/Header.scss
@@ -41,4 +41,13 @@
             transform: translateY(0);
         }
     }
+
+    &__nav-item {
+        font-size: rem(14px);
+        padding: rem(10px) 0;
+
+        &:not(.main-layout-header__nav-item--active) {
+            font-weight: $font-weight-light;
+        }
+    }
 }

--- a/packages/browser-wallet/src/popup/page-layouts/MainLayout/Header/Header.scss
+++ b/packages/browser-wallet/src/popup/page-layouts/MainLayout/Header/Header.scss
@@ -1,7 +1,7 @@
 .main-layout-header {
     height: rem(40px);
     position: relative;
-    z-index: 0;
+    z-index: 1;
 
     &__bar,
     &__nav {
@@ -37,12 +37,15 @@
         transition: transform $transition-timing $transition-easing;
         text-align: center;
 
-        &--open {
+        .main-layout-header--open & {
             transform: translateY(0);
         }
     }
 
     &__nav-item {
+        display: block;
+        color: $color-text;
+        text-decoration: none;
         font-size: rem(14px);
         padding: rem(10px) 0;
 

--- a/packages/browser-wallet/src/popup/page-layouts/MainLayout/Header/Header.stories.tsx
+++ b/packages/browser-wallet/src/popup/page-layouts/MainLayout/Header/Header.stories.tsx
@@ -1,0 +1,13 @@
+/* eslint-disable react/function-component-definition, import/no-extraneous-dependencies, react/destructuring-assignment */
+import React from 'react';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import Header from './Header';
+
+export default {
+    title: 'Page layouts/Main layout/Header',
+    component: Header,
+} as ComponentMeta<typeof Header>;
+
+export const Primary: ComponentStory<typeof Header> = () => {
+    return <Header />;
+};

--- a/packages/browser-wallet/src/popup/page-layouts/MainLayout/Header/Header.stories.tsx
+++ b/packages/browser-wallet/src/popup/page-layouts/MainLayout/Header/Header.stories.tsx
@@ -9,5 +9,9 @@ export default {
 } as ComponentMeta<typeof Header>;
 
 export const Primary: ComponentStory<typeof Header> = () => {
-    return <Header />;
+    return (
+        <div style={{ width: 300 }}>
+            <Header />
+        </div>
+    );
 };

--- a/packages/browser-wallet/src/popup/page-layouts/MainLayout/Header/Header.stories.tsx
+++ b/packages/browser-wallet/src/popup/page-layouts/MainLayout/Header/Header.stories.tsx
@@ -10,8 +10,17 @@ export default {
 
 export const Primary: ComponentStory<typeof Header> = () => {
     return (
-        <div style={{ width: 300 }}>
-            <Header />
-        </div>
+        <>
+            <style>
+                {`
+                    body {
+                        padding: 0 !important;
+                    }
+                `}
+            </style>
+            <div style={{ width: 300 }}>
+                <Header />
+            </div>
+        </>
     );
 };

--- a/packages/browser-wallet/src/popup/page-layouts/MainLayout/Header/Header.stories.tsx
+++ b/packages/browser-wallet/src/popup/page-layouts/MainLayout/Header/Header.stories.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/function-component-definition, import/no-extraneous-dependencies, react/destructuring-assignment */
 import React from 'react';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { BrowserRouter } from 'react-router-dom';
 import Header from './Header';
 
 export default {
@@ -10,7 +11,7 @@ export default {
 
 export const Primary: ComponentStory<typeof Header> = () => {
     return (
-        <>
+        <BrowserRouter>
             <style>
                 {`
                     body {
@@ -21,6 +22,6 @@ export const Primary: ComponentStory<typeof Header> = () => {
             <div style={{ width: 300 }}>
                 <Header />
             </div>
-        </>
+        </BrowserRouter>
     );
 };

--- a/packages/browser-wallet/src/popup/page-layouts/MainLayout/Header/Header.tsx
+++ b/packages/browser-wallet/src/popup/page-layouts/MainLayout/Header/Header.tsx
@@ -1,7 +1,17 @@
+import Button from '@popup/shared/Button';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
+import Logo from '@assets/svg/concordium.svg';
+
 export default function Header() {
     const { t } = useTranslation('mainLayout');
-    return <header className="main-layout-header">{t('title')}</header>;
+    return (
+        <header className="main-layout-header">
+            <Button className="main-layout-header__logo" clear>
+                <Logo />
+            </Button>
+            <h1>{t('title')}</h1>
+        </header>
+    );
 }

--- a/packages/browser-wallet/src/popup/page-layouts/MainLayout/Header/Header.tsx
+++ b/packages/browser-wallet/src/popup/page-layouts/MainLayout/Header/Header.tsx
@@ -1,27 +1,53 @@
-import Button from '@popup/shared/Button';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import clsx from 'clsx';
+import { NavLink } from 'react-router-dom';
 
 import Logo from '@assets/svg/concordium.svg';
-import clsx from 'clsx';
 import NavList from '@popup/shared/NavList';
+import Button from '@popup/shared/Button';
+import { absoluteRoutes } from '@popup/constants/routes';
 
 export default function Header() {
     const { t } = useTranslation('mainLayout');
     const [isOpen, setIsOpen] = useState(false);
 
     return (
-        <header className="main-layout-header">
+        <header className={clsx('main-layout-header', isOpen && 'main-layout-header--open')}>
             <div className="main-layout-header__bar">
                 <Button className="main-layout-header__logo" clear onClick={() => setIsOpen((o) => !o)}>
                     <Logo />
                 </Button>
                 <h1>{t('title')}</h1>
             </div>
-            <NavList className={clsx('main-layout-header__nav', isOpen && 'main-layout-header__nav--open')}>
-                <div className="main-layout-header__nav-item">Accounts</div>
-                <div className="main-layout-header__nav-item">Identities</div>
-                <div className="main-layout-header__nav-item">Settings</div>
+            <NavList className="main-layout-header__nav">
+                <NavLink
+                    onClick={() => setIsOpen(false)}
+                    className={({ isActive }) =>
+                        clsx('main-layout-header__nav-item', isActive && 'main-layout-header__nav-item--active')
+                    }
+                    to={absoluteRoutes.home.path}
+                >
+                    Accounts
+                </NavLink>
+                <NavLink
+                    onClick={() => setIsOpen(false)}
+                    className={({ isActive }) =>
+                        clsx('main-layout-header__nav-item', isActive && 'main-layout-header__nav-item--active')
+                    }
+                    to={absoluteRoutes.home.identities.path}
+                >
+                    Identities
+                </NavLink>
+                <NavLink
+                    onClick={() => setIsOpen(false)}
+                    className={({ isActive }) =>
+                        clsx('main-layout-header__nav-item', isActive && 'main-layout-header__nav-item--active')
+                    }
+                    to={absoluteRoutes.home.settings.path}
+                >
+                    Settings
+                </NavLink>
             </NavList>
         </header>
     );

--- a/packages/browser-wallet/src/popup/page-layouts/MainLayout/Header/Header.tsx
+++ b/packages/browser-wallet/src/popup/page-layouts/MainLayout/Header/Header.tsx
@@ -1,17 +1,27 @@
 import Button from '@popup/shared/Button';
-import React from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import Logo from '@assets/svg/concordium.svg';
+import clsx from 'clsx';
 
 export default function Header() {
     const { t } = useTranslation('mainLayout');
+    const [isOpen, setIsOpen] = useState(false);
+
     return (
         <header className="main-layout-header">
-            <Button className="main-layout-header__logo" clear>
-                <Logo />
-            </Button>
-            <h1>{t('title')}</h1>
+            <div className="main-layout-header__bar">
+                <Button className="main-layout-header__logo" clear onClick={() => setIsOpen((o) => !o)}>
+                    <Logo />
+                </Button>
+                <h1>{t('title')}</h1>
+            </div>
+            <nav className={clsx('main-layout-header__nav', isOpen && 'main-layout-header__nav--open')}>
+                <div>Accounts</div>
+                <div>Identities</div>
+                <div>Settings</div>
+            </nav>
         </header>
     );
 }

--- a/packages/browser-wallet/src/popup/page-layouts/MainLayout/Header/Header.tsx
+++ b/packages/browser-wallet/src/popup/page-layouts/MainLayout/Header/Header.tsx
@@ -1,54 +1,73 @@
-import React, { useState } from 'react';
+import React, { PropsWithChildren, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
-import { NavLink } from 'react-router-dom';
+import { NavLink, useLocation } from 'react-router-dom';
 
 import Logo from '@assets/svg/concordium.svg';
+import CheckmarkIcon from '@assets/svg/checkmark-blue.svg';
 import NavList from '@popup/shared/NavList';
 import Button from '@popup/shared/Button';
 import { absoluteRoutes } from '@popup/constants/routes';
 
+type HeaderLinkProps = PropsWithChildren<{
+    onClick(): void;
+    to: string;
+}>;
+
+function HeaderLink({ to, children, onClick }: HeaderLinkProps) {
+    return (
+        <NavLink
+            onClick={onClick}
+            className={({ isActive }) =>
+                clsx('main-layout-header__nav-item', isActive && 'main-layout-header__nav-item--active')
+            }
+            to={to}
+        >
+            {({ isActive }) => (
+                <div className="inline-flex align-center relative">
+                    {children}
+                    {isActive && <CheckmarkIcon />}
+                </div>
+            )}
+        </NavLink>
+    );
+}
+
 export default function Header() {
     const { t } = useTranslation('mainLayout');
+    const { pathname } = useLocation();
     const [isOpen, setIsOpen] = useState(false);
 
+    // eslint-disable-next-line no-nested-ternary
+    const title = pathname.includes(absoluteRoutes.home.identities.path)
+        ? t('header.ids')
+        : pathname.includes(absoluteRoutes.home.settings.path)
+        ? t('header.settings')
+        : t('header.accounts');
+
     return (
-        <header className={clsx('main-layout-header', isOpen && 'main-layout-header--open')}>
-            <div className="main-layout-header__bar">
-                <Button className="main-layout-header__logo" clear onClick={() => setIsOpen((o) => !o)}>
-                    <Logo />
-                </Button>
-                <h1>{t('title')}</h1>
-            </div>
-            <NavList className="main-layout-header__nav">
-                <NavLink
-                    onClick={() => setIsOpen(false)}
-                    className={({ isActive }) =>
-                        clsx('main-layout-header__nav-item', isActive && 'main-layout-header__nav-item--active')
-                    }
-                    to={absoluteRoutes.home.path}
-                >
-                    Accounts
-                </NavLink>
-                <NavLink
-                    onClick={() => setIsOpen(false)}
-                    className={({ isActive }) =>
-                        clsx('main-layout-header__nav-item', isActive && 'main-layout-header__nav-item--active')
-                    }
-                    to={absoluteRoutes.home.identities.path}
-                >
-                    Identities
-                </NavLink>
-                <NavLink
-                    onClick={() => setIsOpen(false)}
-                    className={({ isActive }) =>
-                        clsx('main-layout-header__nav-item', isActive && 'main-layout-header__nav-item--active')
-                    }
-                    to={absoluteRoutes.home.settings.path}
-                >
-                    Settings
-                </NavLink>
-            </NavList>
-        </header>
+        <>
+            <header className={clsx('main-layout-header', isOpen && 'main-layout-header--open')}>
+                <div className="main-layout-header__bar">
+                    <Button className="main-layout-header__logo" clear onClick={() => setIsOpen((o) => !o)}>
+                        <Logo />
+                    </Button>
+                    <h1>{title}</h1>
+                </div>
+                <NavList className="main-layout-header__nav">
+                    <HeaderLink onClick={() => setIsOpen(false)} to={absoluteRoutes.home.path}>
+                        {t('header.accounts')}
+                    </HeaderLink>
+                    <HeaderLink onClick={() => setIsOpen(false)} to={absoluteRoutes.home.identities.path}>
+                        {t('header.ids')}
+                    </HeaderLink>
+                    <HeaderLink onClick={() => setIsOpen(false)} to={absoluteRoutes.home.settings.path}>
+                        {t('header.settings')}
+                    </HeaderLink>
+                </NavList>
+            </header>
+            {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */}
+            {isOpen && <div className="absolute t-0 w-full h-full" onClick={() => setIsOpen(false)} />}
+        </>
     );
 }

--- a/packages/browser-wallet/src/popup/page-layouts/MainLayout/Header/Header.tsx
+++ b/packages/browser-wallet/src/popup/page-layouts/MainLayout/Header/Header.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+export default function Header() {
+    const { t } = useTranslation('mainLayout');
+    return <header className="main-layout-header">{t('title')}</header>;
+}

--- a/packages/browser-wallet/src/popup/page-layouts/MainLayout/Header/Header.tsx
+++ b/packages/browser-wallet/src/popup/page-layouts/MainLayout/Header/Header.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 
 import Logo from '@assets/svg/concordium.svg';
 import clsx from 'clsx';
+import NavList from '@popup/shared/NavList';
 
 export default function Header() {
     const { t } = useTranslation('mainLayout');
@@ -17,11 +18,11 @@ export default function Header() {
                 </Button>
                 <h1>{t('title')}</h1>
             </div>
-            <nav className={clsx('main-layout-header__nav', isOpen && 'main-layout-header__nav--open')}>
-                <div>Accounts</div>
-                <div>Identities</div>
-                <div>Settings</div>
-            </nav>
+            <NavList className={clsx('main-layout-header__nav', isOpen && 'main-layout-header__nav--open')}>
+                <div className="main-layout-header__nav-item">Accounts</div>
+                <div className="main-layout-header__nav-item">Identities</div>
+                <div className="main-layout-header__nav-item">Settings</div>
+            </NavList>
         </header>
     );
 }

--- a/packages/browser-wallet/src/popup/page-layouts/MainLayout/Header/index.ts
+++ b/packages/browser-wallet/src/popup/page-layouts/MainLayout/Header/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Header';

--- a/packages/browser-wallet/src/popup/page-layouts/MainLayout/MainLayout.scss
+++ b/packages/browser-wallet/src/popup/page-layouts/MainLayout/MainLayout.scss
@@ -3,13 +3,15 @@
     flex-direction: column;
     height: 100%;
     position: relative;
+    z-index: 0;
 
     &__main {
         flex: 1;
         padding: rem(10px);
         transition: filter $transition-easing $transition-timing;
+        z-index: -1;
 
-        .main-layout-header--open + & {
+        .main-layout-header--open ~ & {
             filter: blur(5px);
         }
     }

--- a/packages/browser-wallet/src/popup/page-layouts/MainLayout/MainLayout.scss
+++ b/packages/browser-wallet/src/popup/page-layouts/MainLayout/MainLayout.scss
@@ -6,6 +6,7 @@
 
     &__main {
         flex: 1;
+        padding: rem(10px);
         transition: filter $transition-easing $transition-timing;
 
         .main-layout-header--open + & {
@@ -13,16 +14,8 @@
         }
     }
 
-    &__nav {
-        margin-bottom: rem(10px);
-    }
-
     &__select-account {
         display: block;
         width: 100%;
-    }
-
-    &__content {
-        margin-top: rem(10px);
     }
 }

--- a/packages/browser-wallet/src/popup/page-layouts/MainLayout/MainLayout.scss
+++ b/packages/browser-wallet/src/popup/page-layouts/MainLayout/MainLayout.scss
@@ -2,6 +2,7 @@
     display: flex;
     flex-direction: column;
     height: 100%;
+    position: relative;
 
     &__main {
         flex: 1;

--- a/packages/browser-wallet/src/popup/page-layouts/MainLayout/MainLayout.scss
+++ b/packages/browser-wallet/src/popup/page-layouts/MainLayout/MainLayout.scss
@@ -1,4 +1,17 @@
 .main-layout {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+
+    &__main {
+        flex: 1;
+        transition: filter $transition-easing $transition-timing;
+
+        .main-layout-header--open + & {
+            filter: blur(5px);
+        }
+    }
+
     &__nav {
         margin-bottom: rem(10px);
     }

--- a/packages/browser-wallet/src/popup/page-layouts/MainLayout/MainLayout.scss
+++ b/packages/browser-wallet/src/popup/page-layouts/MainLayout/MainLayout.scss
@@ -13,9 +13,4 @@
             filter: blur(5px);
         }
     }
-
-    &__select-account {
-        display: block;
-        width: 100%;
-    }
 }

--- a/packages/browser-wallet/src/popup/page-layouts/MainLayout/MainLayout.tsx
+++ b/packages/browser-wallet/src/popup/page-layouts/MainLayout/MainLayout.tsx
@@ -21,7 +21,7 @@ export default function MainLayout() {
         <div className="main-layout">
             <Header />
             <main className="main-layout__main">
-                <nav className="main-layout__nav">
+                <nav className="m-b-10">
                     <NavLink to={absoluteRoutes.home.path}>{t('nav.home')}</NavLink> |{' '}
                     <NavLink to={absoluteRoutes.setup.path}>{t('nav.setup')}</NavLink>
                 </nav>
@@ -36,7 +36,7 @@ export default function MainLayout() {
                         </option>
                     ))}
                 </select>
-                <div className="main-layout__content">
+                <div className="m-t-10">
                     <Outlet />
                 </div>
             </main>

--- a/packages/browser-wallet/src/popup/page-layouts/MainLayout/MainLayout.tsx
+++ b/packages/browser-wallet/src/popup/page-layouts/MainLayout/MainLayout.tsx
@@ -18,26 +18,28 @@ export default function MainLayout() {
     }
 
     return (
-        <>
+        <div className="main-layout">
             <Header />
-            <nav className="main-layout__nav">
-                <NavLink to={absoluteRoutes.home.path}>{t('nav.home')}</NavLink> |{' '}
-                <NavLink to={absoluteRoutes.setup.path}>{t('nav.setup')}</NavLink>
-            </nav>
-            <select
-                className="main-layout__select-account"
-                value={selectedAccount}
-                onChange={(e) => setSelectedAccount(e.target.value)}
-            >
-                {accounts.map((a) => (
-                    <option key={a} value={a}>
-                        {a}
-                    </option>
-                ))}
-            </select>
-            <main className="main-layout__content">
-                <Outlet />
+            <main className="main-layout__main">
+                <nav className="main-layout__nav">
+                    <NavLink to={absoluteRoutes.home.path}>{t('nav.home')}</NavLink> |{' '}
+                    <NavLink to={absoluteRoutes.setup.path}>{t('nav.setup')}</NavLink>
+                </nav>
+                <select
+                    className="main-layout__select-account"
+                    value={selectedAccount}
+                    onChange={(e) => setSelectedAccount(e.target.value)}
+                >
+                    {accounts.map((a) => (
+                        <option key={a} value={a}>
+                            {a}
+                        </option>
+                    ))}
+                </select>
+                <div className="main-layout__content">
+                    <Outlet />
+                </div>
             </main>
-        </>
+        </div>
     );
 }

--- a/packages/browser-wallet/src/popup/page-layouts/MainLayout/MainLayout.tsx
+++ b/packages/browser-wallet/src/popup/page-layouts/MainLayout/MainLayout.tsx
@@ -5,6 +5,7 @@ import { useAtom, useAtomValue } from 'jotai';
 
 import { absoluteRoutes } from '@popup/constants/routes';
 import { selectedAccountAtom, accountsAtom } from '@popup/store/account';
+import Header from './Header';
 
 export default function MainLayout() {
     const { t } = useTranslation('mainLayout');
@@ -18,9 +19,7 @@ export default function MainLayout() {
 
     return (
         <>
-            <header>
-                <h3>{t('title')}</h3>
-            </header>
+            <Header />
             <nav className="main-layout__nav">
                 <NavLink to={absoluteRoutes.home.path}>{t('nav.home')}</NavLink> |{' '}
                 <NavLink to={absoluteRoutes.setup.path}>{t('nav.setup')}</NavLink>

--- a/packages/browser-wallet/src/popup/page-layouts/MainLayout/MainLayout.tsx
+++ b/packages/browser-wallet/src/popup/page-layouts/MainLayout/MainLayout.tsx
@@ -1,16 +1,13 @@
 import React from 'react';
-import { NavLink, Outlet, Navigate } from 'react-router-dom';
-import { useTranslation } from 'react-i18next';
-import { useAtom, useAtomValue } from 'jotai';
+import { Outlet, Navigate } from 'react-router-dom';
+import { useAtomValue } from 'jotai';
 
 import { absoluteRoutes } from '@popup/constants/routes';
-import { selectedAccountAtom, accountsAtom } from '@popup/store/account';
+import { accountsAtom } from '@popup/store/account';
 import Header from './Header';
 
 export default function MainLayout() {
-    const { t } = useTranslation('mainLayout');
     const accounts = useAtomValue(accountsAtom);
-    const [selectedAccount, setSelectedAccount] = useAtom(selectedAccountAtom);
 
     if (accounts.length === 0) {
         // Force user to go through setup
@@ -21,24 +18,7 @@ export default function MainLayout() {
         <div className="main-layout">
             <Header />
             <main className="main-layout__main">
-                <nav className="m-b-10">
-                    <NavLink to={absoluteRoutes.home.path}>{t('nav.home')}</NavLink> |{' '}
-                    <NavLink to={absoluteRoutes.setup.path}>{t('nav.setup')}</NavLink>
-                </nav>
-                <select
-                    className="main-layout__select-account"
-                    value={selectedAccount}
-                    onChange={(e) => setSelectedAccount(e.target.value)}
-                >
-                    {accounts.map((a) => (
-                        <option key={a} value={a}>
-                            {a}
-                        </option>
-                    ))}
-                </select>
-                <div className="m-t-10">
-                    <Outlet />
-                </div>
+                <Outlet />
             </main>
         </div>
     );

--- a/packages/browser-wallet/src/popup/page-layouts/MainLayout/i18n/da.ts
+++ b/packages/browser-wallet/src/popup/page-layouts/MainLayout/i18n/da.ts
@@ -6,6 +6,11 @@ const t: typeof en = {
         home: 'Hjem',
         setup: 'Indstillinger',
     },
+    header: {
+        accounts: 'Konti',
+        ids: 'ID kort',
+        settings: 'Wallet indstillinger',
+    },
 };
 
 export default t;

--- a/packages/browser-wallet/src/popup/page-layouts/MainLayout/i18n/en.ts
+++ b/packages/browser-wallet/src/popup/page-layouts/MainLayout/i18n/en.ts
@@ -4,6 +4,11 @@ const t = {
         home: 'Home',
         setup: 'Settings',
     },
+    header: {
+        accounts: 'Accounts',
+        ids: 'ID cards',
+        settings: 'Wallet settings',
+    },
 };
 
 export default t;

--- a/packages/browser-wallet/src/popup/pages/Account/Account.scss
+++ b/packages/browser-wallet/src/popup/pages/Account/Account.scss
@@ -1,3 +1,6 @@
-.account {
-    display: block;
+.account-page {
+    &__select-account {
+        display: block;
+        width: 100%;
+    }
 }

--- a/packages/browser-wallet/src/popup/pages/Account/Account.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/Account.tsx
@@ -1,12 +1,28 @@
-import { useAtomValue } from 'jotai';
+import { useAtom, useAtomValue } from 'jotai';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { selectedAccountAtom } from '@popup/store/account';
+import { accountsAtom, selectedAccountAtom } from '@popup/store/account';
 
 export default function Account() {
     const { t } = useTranslation('account');
-    const address = useAtomValue(selectedAccountAtom);
+    const accounts = useAtomValue(accountsAtom);
+    const [selectedAccount, setSelectedAccount] = useAtom(selectedAccountAtom);
 
-    return <div>{t('address', { address })}</div>;
+    return (
+        <>
+            <select
+                className="main-layout__select-account"
+                value={selectedAccount}
+                onChange={(e) => setSelectedAccount(e.target.value)}
+            >
+                {accounts.map((a) => (
+                    <option key={a} value={a}>
+                        {a}
+                    </option>
+                ))}
+            </select>
+            <div className="m-t-10">{t('address', { address: selectedAccount })}</div>
+        </>
+    );
 }

--- a/packages/browser-wallet/src/popup/pages/Account/Account.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/Account.tsx
@@ -12,7 +12,7 @@ export default function Account() {
     return (
         <>
             <select
-                className="main-layout__select-account"
+                className="account-page__select-account"
                 value={selectedAccount}
                 onChange={(e) => setSelectedAccount(e.target.value)}
             >

--- a/packages/browser-wallet/src/popup/pages/Setup/Setup.tsx
+++ b/packages/browser-wallet/src/popup/pages/Setup/Setup.tsx
@@ -10,6 +10,7 @@ import FormInput from '@popup/shared/Form/Input';
 import Submit from '@popup/shared/Form/Submit';
 import { jsonRpcUrlAtom, credentialsAtom } from '@popup/store/settings';
 import { WalletCredential } from '@shared/storage/types';
+import PageHeader from '@popup/shared/PageHeader';
 import ThemeSwitch from './ThemeSwitch';
 
 type FormValues = {
@@ -72,10 +73,8 @@ export default function Setup() {
 
     return (
         <>
-            <header>
-                <h3>{t('title')}</h3>
-            </header>
-            <Form onSubmit={handleSubmit} defaultValues={values}>
+            <PageHeader>{t('title')}</PageHeader>
+            <Form onSubmit={handleSubmit} defaultValues={values} className="p-10">
                 {({ register }) => (
                     <>
                         <ThemeSwitch />

--- a/packages/browser-wallet/src/popup/shared/Form/Form.scss
+++ b/packages/browser-wallet/src/popup/shared/Form/Form.scss
@@ -21,7 +21,7 @@
         height: rem(32px);
         border: rem(1px) solid $color-grey;
         border-radius: rem(5px);
-        padding: rem(10px) rem(5px) rem(5px);
+        padding: rem(12px) rem(5px) rem(5px);
         width: 100%;
         outline: none;
         transition: border-color $transition-timing $transition-easing;

--- a/packages/browser-wallet/src/popup/shared/IdCard/IdCard.stories.tsx
+++ b/packages/browser-wallet/src/popup/shared/IdCard/IdCard.stories.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable react/destructuring-assignment */
-/* eslint-disable react/function-component-definition, import/no-extraneous-dependencies */
+/* eslint-disable react/function-component-definition, import/no-extraneous-dependencies, react/destructuring-assignment */
 import React, { useEffect, useState } from 'react';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 import IdCard from './IdCard';

--- a/packages/browser-wallet/src/popup/shared/NavList/NavList.scss
+++ b/packages/browser-wallet/src/popup/shared/NavList/NavList.scss
@@ -1,0 +1,7 @@
+.nav-list {
+    padding: 0 rem(10px);
+
+    & > *:not(:last-child) {
+        border-bottom: 1px dotted $color-grey;
+    }
+}

--- a/packages/browser-wallet/src/popup/shared/NavList/NavList.stories.tsx
+++ b/packages/browser-wallet/src/popup/shared/NavList/NavList.stories.tsx
@@ -1,0 +1,22 @@
+/* eslint-disable react/function-component-definition, import/no-extraneous-dependencies, react/destructuring-assignment */
+import React from 'react';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import NavList from './NavList';
+
+export default {
+    title: 'Shared/NavList',
+    component: NavList,
+} as ComponentMeta<typeof NavList>;
+
+export const Primary: ComponentStory<typeof NavList> = () => {
+    return (
+        <div style={{ width: 300 }}>
+            <NavList>
+                <div>First</div>
+                <div>Second</div>
+                <div>Third</div>
+                <div>Fourth</div>
+            </NavList>
+        </div>
+    );
+};

--- a/packages/browser-wallet/src/popup/shared/NavList/NavList.tsx
+++ b/packages/browser-wallet/src/popup/shared/NavList/NavList.tsx
@@ -1,0 +1,9 @@
+import { ClassName } from '@shared/utils/types';
+import clsx from 'clsx';
+import React, { PropsWithChildren } from 'react';
+
+type Props = PropsWithChildren<ClassName>;
+
+export default function NavList({ className, children }: Props) {
+    return <div className={clsx('nav-list', className)}>{children}</div>;
+}

--- a/packages/browser-wallet/src/popup/shared/NavList/index.ts
+++ b/packages/browser-wallet/src/popup/shared/NavList/index.ts
@@ -1,0 +1,1 @@
+export { default } from './NavList';

--- a/packages/browser-wallet/src/popup/shared/PageHeader/PageHeader.scss
+++ b/packages/browser-wallet/src/popup/shared/PageHeader/PageHeader.scss
@@ -1,26 +1,26 @@
 .page-header {
     display: flex;
-    height: rem(35px);
+    align-items: center;
+    height: rem(40px);
     width: 100%;
+    padding-bottom: rem(1px);
 
     &__icon {
         position: relative;
-        flex: 0 0 rem(50px);
+        flex: 0;
         height: 100%;
         display: flex;
         justify-content: center;
         align-items: center;
+        margin-left: rem(10px);
         margin-right: rem(14px);
-
-        path {
-            fill: $color-text;
-        }
+        padding-right: rem(14px);
 
         &::after {
             display: block;
             content: '';
             width: rem(2px);
-            height: 100%;
+            height: 80%;
             background: radial-gradient(50% 50% at 50% 50%, #000 0%, rgb(196 196 196 / 0%) 100%);
             position: absolute;
             right: 0;
@@ -32,12 +32,20 @@
         }
     }
 
+    &__logo,
     &__back-icon {
-        height: rem(16px);
+        path {
+            fill: $color-text;
+        }
     }
 
     &__logo {
-        width: rem(25px);
+        width: rem(23px);
+    }
+
+    &__back-icon {
+        margin: 0 rem(7px); // center compared to &__logo
+        width: rem(9px);
     }
 
     &__title {

--- a/packages/browser-wallet/src/popup/shared/PageHeader/PageHeader.stories.tsx
+++ b/packages/browser-wallet/src/popup/shared/PageHeader/PageHeader.stories.tsx
@@ -21,25 +21,25 @@ const Template: ComponentStory<typeof PageHeader> = (args) => {
 
 export const Primary = Template.bind({});
 Primary.args = {
-    title: 'Title',
+    children: 'Title',
 };
 
 export const Back = Template.bind({});
 Back.args = {
-    title: 'Title',
+    children: 'Title',
     canGoBack: true,
 };
 
 export const Steps = Template.bind({});
 Steps.args = {
-    title: 'Title',
+    children: 'Title',
     steps: 5,
     activeStep: 0,
 };
 
 export const CompletedSteps = Template.bind({});
 CompletedSteps.args = {
-    title: 'Title',
+    children: 'Title',
     canGoBack: true,
     steps: 5,
     activeStep: 3,

--- a/packages/browser-wallet/src/popup/shared/PageHeader/PageHeader.tsx
+++ b/packages/browser-wallet/src/popup/shared/PageHeader/PageHeader.tsx
@@ -52,7 +52,7 @@ export default function PageHeader(props: Props | FlowProps) {
                     <Logo className="page-header__logo" />
                 )}
             </div>
-            <div className="flexColumn justifyCenter flexChildFill">
+            <div className="flex-column justify-center flex-child-fill">
                 <h1 className="page-header__title">{title}</h1>
                 {isFlow(props) && <FlowProgress {...props} />}
             </div>

--- a/packages/browser-wallet/src/popup/shared/PageHeader/PageHeader.tsx
+++ b/packages/browser-wallet/src/popup/shared/PageHeader/PageHeader.tsx
@@ -4,16 +4,17 @@ import { useNavigate } from 'react-router-dom';
 
 import BackIcon from '@assets/svg/back-arrow.svg';
 import Logo from '@assets/svg/concordium.svg';
+import { ClassName } from '@shared/utils/types';
 import Button from '../Button';
 
-type Props = {
+type BaseProps = ClassName & {
     // eslint-disable-next-line react/no-unused-prop-types
-    title: string;
+    children: string;
     // eslint-disable-next-line react/no-unused-prop-types
     canGoBack?: boolean;
 };
 
-type FlowProps = Props & {
+type FlowProps = BaseProps & {
     steps: number;
     activeStep: number;
 };
@@ -35,14 +36,16 @@ function FlowProgress({ steps, activeStep }: FlowProps) {
     );
 }
 
-const isFlow = (props: Props | FlowProps): props is FlowProps => (props as FlowProps).steps !== undefined;
+type Props = BaseProps | FlowProps;
 
-export default function PageHeader(props: Props | FlowProps) {
-    const { title, canGoBack } = props;
+const isFlow = (props: Props): props is FlowProps => (props as FlowProps).steps !== undefined;
+
+export default function PageHeader(props: Props) {
+    const { children, canGoBack, className } = props;
     const navigate = useNavigate();
 
     return (
-        <header className="page-header">
+        <header className={clsx('page-header', className)}>
             <div className="page-header__icon">
                 {canGoBack ? (
                     <Button className="flex" clear onClick={() => navigate(-1)}>
@@ -53,7 +56,7 @@ export default function PageHeader(props: Props | FlowProps) {
                 )}
             </div>
             <div className="flex-column justify-center flex-child-fill">
-                <h1 className="page-header__title">{title}</h1>
+                <h1 className="page-header__title">{children}</h1>
                 {isFlow(props) && <FlowProgress {...props} />}
             </div>
         </header>

--- a/packages/browser-wallet/src/popup/shell/Routes.tsx
+++ b/packages/browser-wallet/src/popup/shell/Routes.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react';
-import { Route, Routes as ReactRoutes, useLocation, useNavigate } from 'react-router-dom';
+import { Navigate, Route, Routes as ReactRoutes, useLocation, useNavigate } from 'react-router-dom';
 import { InternalMessageType, MessageType, createMessageTypeFilter } from '@concordium/browser-wallet-message-hub';
 import { AccountTransactionSignature } from '@concordium/web-sdk';
 
@@ -62,7 +62,10 @@ export default function Routes() {
             <Route path={relativeRoutes.home.path} element={<MainLayout />}>
                 <Route index element={<Account />} />
                 <Route element={<div>No content yet...</div>} path={relativeRoutes.home.identities.path} />
-                <Route element={<div>No content yet...</div>} path={relativeRoutes.home.settings.path} />
+                <Route
+                    element={<Navigate replace to={absoluteRoutes.setup.path} />}
+                    path={relativeRoutes.home.settings.path}
+                />
             </Route>
             <Route path={relativeRoutes.prompt.path} element={<FullscreenPromptLayout />}>
                 <Route

--- a/packages/browser-wallet/src/popup/shell/Routes.tsx
+++ b/packages/browser-wallet/src/popup/shell/Routes.tsx
@@ -61,6 +61,8 @@ export default function Routes() {
         <ReactRoutes>
             <Route path={relativeRoutes.home.path} element={<MainLayout />}>
                 <Route index element={<Account />} />
+                <Route element={<div>No content yet...</div>} path={relativeRoutes.home.identities.path} />
+                <Route element={<div>No content yet...</div>} path={relativeRoutes.home.settings.path} />
             </Route>
             <Route path={relativeRoutes.prompt.path} element={<FullscreenPromptLayout />}>
                 <Route

--- a/packages/browser-wallet/src/popup/styles/_components.scss
+++ b/packages/browser-wallet/src/popup/styles/_components.scss
@@ -4,6 +4,7 @@
 @import '../shared/ButtonGroup/ButtonGroup';
 @import '../shared/IdCard/IdCard';
 @import '../shared/PageHeader/PageHeader';
+@import '../shared/NavList/NavList';
 
 // Pages
 @import '../pages/Account/Account';

--- a/packages/browser-wallet/src/popup/styles/_components.scss
+++ b/packages/browser-wallet/src/popup/styles/_components.scss
@@ -15,4 +15,5 @@
 
 // Layouts
 @import '../page-layouts/MainLayout/MainLayout';
+@import '../page-layouts/MainLayout/Header/Header';
 @import '../page-layouts/FullscreenPromptLayout/FullscreenPromptLayout';

--- a/packages/browser-wallet/src/popup/styles/config/_bundle.scss
+++ b/packages/browser-wallet/src/popup/styles/config/_bundle.scss
@@ -1,5 +1,6 @@
 @import 'variables';
 @import 'colors';
 @import 'transition';
+@import 'mixins';
 @import 'functions';
 @import 'typography';

--- a/packages/browser-wallet/src/popup/styles/config/_colors.scss
+++ b/packages/browser-wallet/src/popup/styles/config/_colors.scss
@@ -10,6 +10,7 @@ $color-green: #4ac29e;
 $color-dark-green: #308274;
 $color-blue: #4486ab;
 $color-salmon: #ff8a8a;
+$color-petroleum: #325d76;
 
 // Derived
 $color-text-faded: $color-grey;

--- a/packages/browser-wallet/src/popup/styles/config/_mixins.scss
+++ b/packages/browser-wallet/src/popup/styles/config/_mixins.scss
@@ -1,0 +1,9 @@
+@mixin with-first-last-mods() {
+    &,
+    &\:not-first:not(:first-child),
+    &\:not-last:not(:last-child),
+    &\:first:first-child,
+    &\:last:last-child {
+        @content;
+    }
+}

--- a/packages/browser-wallet/src/popup/styles/elements/_base.scss
+++ b/packages/browser-wallet/src/popup/styles/elements/_base.scss
@@ -17,7 +17,6 @@ body {
     width: 100%;
     height: 100%;
     margin: 0;
-    padding: 10px;
     background-color: $color-bg;
     color: $color-text;
     font-size: 100%;
@@ -35,7 +34,7 @@ body {
     &:not(.dark) .bg {
         background-image: url('../assets/images/bg-light.jpg');
         background-size: cover;
-        background-position-x: -80px;
+        background-position-x: rem(-80px);
         opacity: 0.85;
     }
 
@@ -45,7 +44,7 @@ body {
 
         .bg {
             background-image: url('../assets/images/bg-dark.jpg');
-            background-position: -119px center;
+            background-position: rem(-119px) center;
             background-size: cover;
             opacity: 0.3;
         }

--- a/packages/browser-wallet/src/popup/styles/elements/_base.scss
+++ b/packages/browser-wallet/src/popup/styles/elements/_base.scss
@@ -58,3 +58,7 @@ body {
 * {
     box-sizing: border-box;
 }
+
+#root {
+    height: 100%;
+}

--- a/packages/browser-wallet/src/popup/styles/util/_bundle.scss
+++ b/packages/browser-wallet/src/popup/styles/util/_bundle.scss
@@ -1,2 +1,3 @@
 @import 'flex';
 @import 'position';
+@import 'spacing';

--- a/packages/browser-wallet/src/popup/styles/util/_bundle.scss
+++ b/packages/browser-wallet/src/popup/styles/util/_bundle.scss
@@ -1,1 +1,2 @@
 @import 'flex';
+@import 'position';

--- a/packages/browser-wallet/src/popup/styles/util/_flex.scss
+++ b/packages/browser-wallet/src/popup/styles/util/_flex.scss
@@ -2,36 +2,36 @@
     display: flex;
 }
 
-.flexWrap {
+.flex-wrap {
     flex-wrap: wrap;
 }
 
-.inlineFlex {
+.inline-flex {
     display: inline-flex;
 }
 
-.inlineFlexColumn {
+.inline-flex-column {
     display: inline-flex;
     flex-direction: column;
 }
 
-.flexColumn {
+.flex-column {
     display: flex;
     flex-direction: column;
 }
 
-.justifyCenter {
+.justify-center {
     justify-content: center;
 }
 
-.justifySpaceBetween {
+.justify-space-between {
     justify-content: space-between;
 }
 
-.alignCenter {
+.align-center {
     align-items: center;
 }
 
-.flexChildFill {
+.flex-child-fill {
     flex: 1;
 }

--- a/packages/browser-wallet/src/popup/styles/util/_position.scss
+++ b/packages/browser-wallet/src/popup/styles/util/_position.scss
@@ -21,17 +21,13 @@ $sides: (top, bottom, left, right);
 Generates spacing utility classes based on tuples above:
 
 r-0 = right: 0;
-
-b-10 = bottom: rem(10px);
+b-10 = bottom: 1rem;
+l-neg-20 = left: -2rem;
 */
 @each $space in $spacings {
     @each $side in $sides {
         .#{str-slice($side, 0, 1)}-#{$space} {
-            @if $space == 0 {
-                #{$side}: 0;
-            } @else {
-                #{$side}: rem($space);
-            }
+            #{$side}: rem($space);
         }
         .#{str-slice($side, 0, 1)}-neg-#{$space} {
             #{$side}: -#{rem($space)};

--- a/packages/browser-wallet/src/popup/styles/util/_position.scss
+++ b/packages/browser-wallet/src/popup/styles/util/_position.scss
@@ -1,0 +1,40 @@
+.relative {
+    position: relative;
+}
+
+.absolute {
+    position: absolute;
+}
+
+.w-full {
+    width: 100%;
+}
+
+.h-full {
+    height: 100%;
+}
+
+$spacings: (0, 5, 10, 20);
+$sides: (top, bottom, left, right);
+
+/*
+Generates spacing utility classes based on tuples above:
+
+r-0 = right: 0;
+
+b-10 = bottom: rem(10px);
+*/
+@each $space in $spacings {
+    @each $side in $sides {
+        .#{str-slice($side, 0, 1)}-#{$space} {
+            @if $space == 0 {
+                #{$side}: 0;
+            } @else {
+                #{$side}: rem($space);
+            }
+        }
+        .#{str-slice($side, 0, 1)}-neg-#{$space} {
+            #{$side}: -#{rem($space)};
+        }
+    }
+}

--- a/packages/browser-wallet/src/popup/styles/util/_spacing.scss
+++ b/packages/browser-wallet/src/popup/styles/util/_spacing.scss
@@ -1,0 +1,62 @@
+$spacings: (0, 5, 10, 20, 30, 40, 50);
+$sides: (top, bottom, left, right);
+
+/*
+Generates spacing utility classes based on tuples above:
+
+m-0 = margin: 0;
+p-0 = padding: 0;
+
+m-b-10 = margin-bottom: 1rem;
+p-t-10 = padding-top: 1rem;
+
+m-v-30 = margin-top: 3rem; margin-bottom: 3rem;
+p-h-50 = padding-left: 5rem; padding-right: 5rem;
+*/
+@each $space in $spacings {
+    .m-#{$space} {
+        margin: #{rem($space)};
+    }
+    .p-#{$space} {
+        padding: #{rem($space)};
+    }
+}
+
+@each $space in $spacings {
+    .m-v-#{$space} {
+        margin-top: #{rem($space)};
+        margin-bottom: #{rem($space)};
+    }
+    .p-v-#{$space} {
+        padding-top: #{rem($space)};
+        padding-bottom: #{rem($space)};
+    }
+    .m-h-#{$space} {
+        margin-left: #{rem($space)};
+        margin-right: #{rem($space)};
+    }
+    .p-h-#{$space} {
+        padding-left: #{rem($space)};
+        padding-right: #{rem($space)};
+    }
+}
+
+@each $space in $spacings {
+    @each $side in $sides {
+        .m-#{str-slice($side, 0, 1)}-#{$space} {
+            @include with-first-last-mods {
+                margin-#{$side}: #{rem($space)};
+            }
+        }
+        .p-#{str-slice($side, 0, 1)}-#{$space} {
+            @include with-first-last-mods {
+                padding-#{$side}: #{rem($space)};
+            }
+        }
+    }
+}
+
+.margin-center {
+    margin-left: auto;
+    margin-right: auto;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1690,6 +1690,7 @@ __metadata:
     cross-env: ^7.0.3
     css-loader: ^6.7.1
     esbuild: ^0.14.31
+    esbuild-plugin-svgr: ^1.0.1
     esbuild-sass-plugin: ^2.2.6
     i18next: ^21.6.16
     i18next-browser-languagedetector: ^6.1.4


### PR DESCRIPTION
## Purpose

Adds header to pages residing under the main layout, which provides navigation to different top level sections of the wallet.

## Changes

- `NavList` component to be used for lists of navigation items
- `Header` component for `MainLayout`

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
