### PR TITLE
Add button to reset connections

### DIFF
--- a/packages/browser-wallet/src/popup/pages/Account/Account.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/Account.tsx
@@ -6,13 +6,14 @@ import { useNavigate } from 'react-router-dom';
 import { accountsAtom, selectedAccountAtom } from '@popup/store/account';
 import { absoluteRoutes } from '@popup/constants/routes';
 import Button from '@popup/shared/Button';
-import { credentialsAtom } from '@popup/store/settings';
+import { credentialsAtom, urlWhitelistAtom } from '@popup/store/settings';
 
 export default function Account() {
     const { t } = useTranslation('account');
     const accounts = useAtomValue(accountsAtom);
     const [selectedAccount, setSelectedAccount] = useAtom(selectedAccountAtom);
     const [creds, setCreds] = useAtom(credentialsAtom);
+    const [whitelist, setWhitelist] = useAtom(urlWhitelistAtom);
     const nav = useNavigate();
 
     const removeAccount = useCallback(() => {
@@ -21,6 +22,10 @@ export default function Account() {
 
         setSelectedAccount(next[0]?.address);
     }, [creds, selectedAccount]);
+
+    const removeConnections = useCallback(() => {
+        setWhitelist([]);
+    }, []);
 
     return (
         <div className="flex-column justify-center align-center">
@@ -52,6 +57,9 @@ export default function Account() {
                     </Button>
                 </>
             )}
+            <Button disabled={!whitelist.length} danger className="m-t-20" onClick={removeConnections}>
+                {t('resetConnections')}
+            </Button>
         </div>
     );
 }

--- a/packages/browser-wallet/src/popup/pages/Account/i18n/da.ts
+++ b/packages/browser-wallet/src/popup/pages/Account/i18n/da.ts
@@ -4,6 +4,7 @@ const t: typeof en = {
     address: 'Adresse: {{address}}',
     noAccounts: 'Ingen konti i wallet',
     removeAccount: 'Fjern konto (kun lokalt)',
+    resetConnections: 'Fjern forbindelser',
 };
 
 export default t;

--- a/packages/browser-wallet/src/popup/pages/Account/i18n/en.ts
+++ b/packages/browser-wallet/src/popup/pages/Account/i18n/en.ts
@@ -2,6 +2,7 @@ const t = {
     address: 'Address: {{address}}',
     noAccounts: 'No accounts in wallet',
     removeAccount: 'Remove account (local only)',
+    resetConnections: 'Reset connections',
 };
 
 export default t;

--- a/packages/browser-wallet/src/popup/store/settings.ts
+++ b/packages/browser-wallet/src/popup/store/settings.ts
@@ -4,3 +4,4 @@ import { atomWithChromeStorage } from './utils';
 export const credentialsAtom = atomWithChromeStorage<WalletCredential[]>(ChromeStorageKey.Credentials, []);
 export const jsonRpcUrlAtom = atomWithChromeStorage<string | undefined>(ChromeStorageKey.JsonRpcUrl, undefined);
 export const themeAtom = atomWithChromeStorage<Theme>(ChromeStorageKey.Theme, Theme.Light);
+export const urlWhitelistAtom = atomWithChromeStorage<string[]>(ChromeStorageKey.UrlWhitelist, []);


### PR DESCRIPTION
## Purpose

It is annoying that you can't reset connections without reinstalling the wallet, so I added a temporary button to do it :upside_down_face: 

## Changes

Added the button
