### PR TITLE
Refactored chrome storage atoms to not use promises

### DIFF
--- a/packages/browser-wallet/src/popup/page-layouts/MainLayout/MainLayout.tsx
+++ b/packages/browser-wallet/src/popup/page-layouts/MainLayout/MainLayout.tsx
@@ -4,12 +4,16 @@ import { useAtomValue } from 'jotai';
 import clsx from 'clsx';
 
 import { absoluteRoutes } from '@popup/constants/routes';
-import { jsonRpcUrlAtom } from '@popup/store/settings';
+import { jsonRpcUrlAtomLoading } from '@popup/store/settings';
 import Header from './Header';
 
 export default function MainLayout() {
-    const jsonRpcUrl = useAtomValue(jsonRpcUrlAtom);
+    const { loading, value: jsonRpcUrl } = useAtomValue(jsonRpcUrlAtomLoading);
     const [headerOpen, setHeaderOpen] = useState(false);
+
+    if (loading) {
+        return null; // This will be near instant, as we're just waiting for the chrome async store
+    }
 
     if (!jsonRpcUrl) {
         // Force user to go through setup

--- a/packages/browser-wallet/src/popup/shared/i18n/da.ts
+++ b/packages/browser-wallet/src/popup/shared/i18n/da.ts
@@ -1,9 +1,6 @@
 import type en from './en';
 
 const t: typeof en = {
-    root: {
-        loading: 'Henter brugerindstillinger...',
-    },
     form: {
         password: {
             tooWeak: 'Meget svagt',

--- a/packages/browser-wallet/src/popup/shared/i18n/en.ts
+++ b/packages/browser-wallet/src/popup/shared/i18n/en.ts
@@ -1,7 +1,4 @@
 const t = {
-    root: {
-        loading: 'Loading user settings...',
-    },
     form: {
         password: {
             tooWeak: 'Very weak',

--- a/packages/browser-wallet/src/popup/shell/Root.tsx
+++ b/packages/browser-wallet/src/popup/shell/Root.tsx
@@ -1,6 +1,5 @@
 import { Provider, useAtomValue } from 'jotai';
-import React, { ReactElement, Suspense, useEffect } from 'react';
-import { useTranslation } from 'react-i18next';
+import React, { ReactElement, useEffect } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { InternalMessageType } from '@concordium/browser-wallet-message-hub';
 import { noOp } from 'wallet-common-helpers';
@@ -63,18 +62,14 @@ function Theme({ children }: { children: ReactElement }) {
 }
 
 export default function Root() {
-    const { t } = useTranslation();
     useScaling();
 
     return (
         <Provider>
             <MemoryRouter>
-                {/* The Suspense is needed here due to async atoms loading stuff from storage */}
-                <Suspense fallback={t('root.loading')}>
-                    <Theme>
-                        <Routes />
-                    </Theme>
-                </Suspense>
+                <Theme>
+                    <Routes />
+                </Theme>
             </MemoryRouter>
         </Provider>
     );

--- a/packages/browser-wallet/src/popup/store/settings.ts
+++ b/packages/browser-wallet/src/popup/store/settings.ts
@@ -2,17 +2,23 @@ import { ChromeStorageKey, Theme, WalletCredential } from '@shared/storage/types
 import { atom } from 'jotai';
 import { EventType } from '@concordium/browser-wallet-api-helpers';
 import { popupMessageHandler } from '@popup/shared/message-handler';
-import { atomWithChromeStorage } from './utils';
+import { atomWithChromeStorage, AsyncWrapper } from './utils';
 
 export const credentialsAtom = atomWithChromeStorage<WalletCredential[]>(ChromeStorageKey.Credentials, []);
 export const themeAtom = atomWithChromeStorage<Theme>(ChromeStorageKey.Theme, Theme.Light);
 export const urlWhitelistAtom = atomWithChromeStorage<string[]>(ChromeStorageKey.UrlWhitelist, []);
 
-const storedJsonRpcUrlAtom = atomWithChromeStorage<string | undefined>(ChromeStorageKey.JsonRpcUrl, undefined);
-export const jsonRpcUrlAtom = atom<string | undefined, string | undefined>(
+const storedJsonRpcUrlAtom = atomWithChromeStorage<string | undefined>(ChromeStorageKey.JsonRpcUrl, undefined, true);
+export const jsonRpcUrlAtomLoading = atom<AsyncWrapper<string | undefined>, string | undefined>(
     (get) => get(storedJsonRpcUrlAtom),
     (_, set, jsonRpcUrl) => {
         set(storedJsonRpcUrlAtom, jsonRpcUrl);
         popupMessageHandler.broadcast(EventType.ChainChanged, jsonRpcUrl);
+    }
+);
+export const jsonRpcUrlAtom = atom<string | undefined, string | undefined>(
+    (get) => get(jsonRpcUrlAtomLoading).value,
+    (_, set, jsonRpcUrl) => {
+        set(jsonRpcUrlAtomLoading, jsonRpcUrl);
     }
 );


### PR DESCRIPTION
## Purpose

Window was blinking due to the suspense in the `Root` component being triggered every time storage atoms were being updated. This fixes the issue by moving away from promise based storage atoms.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
