### PR TITLE
Add the about page

### DIFF
--- a/packages/browser-wallet/src/popup/pages/About/About.scss
+++ b/packages/browser-wallet/src/popup/pages/About/About.scss
@@ -1,0 +1,23 @@
+.about-page {
+    height: 100%;
+    background-color: $color-bg;
+    padding: 0 rem(10px);
+
+    h3 {
+        margin-bottom: rem(5px);
+        margin-top: 0;
+        padding-top: rem(10px);
+    }
+
+    &__support {
+        a {
+            display: block;
+            margin-top: rem(5px);
+        }
+    }
+
+    &__item {
+        display: block;
+        padding: rem(10px) 0;
+    }
+}

--- a/packages/browser-wallet/src/popup/pages/About/About.tsx
+++ b/packages/browser-wallet/src/popup/pages/About/About.tsx
@@ -1,0 +1,51 @@
+import NavList from '@popup/shared/NavList';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import packageJson from '../../../../package.json';
+
+function ExternalLink({ path, label }: { path: string; label: string }) {
+    return (
+        <a href={`${path}`} target="_blank" rel="noreferrer">
+            {label}
+        </a>
+    );
+}
+
+export default function About() {
+    const { t } = useTranslation('about');
+
+    return (
+        <div className="about-page">
+            <div>
+                <h3>{t('version')}</h3>
+                {packageJson.version}
+            </div>
+
+            <div className="about-page__support">
+                <h3>Support</h3>
+                If you encountered a problem, or need help with something, you can reach out to us via
+                <a href="mailto:support@concordium.software">support@concordium.software</a>
+            </div>
+
+            <div>
+                <h3>Links</h3>
+                <NavList>
+                    <div className="about-page__item">
+                        <ExternalLink
+                            path="https://developer.concordium.software/en/mainnet/index.html"
+                            label={t('documentation')}
+                        />
+                    </div>
+                    <div className="about-page__item">
+                        <ExternalLink path="https://support.concordium.software" label={t('support')} />
+                    </div>
+                    <div className="about-page__item">
+                        <ExternalLink path="https://www.concordium.com" label={t('website')} />
+                    </div>
+                    <div className="about-page__item">Terms and conditions</div>
+                    <div className="about-page__item">License notices</div>
+                </NavList>
+            </div>
+        </div>
+    );
+}

--- a/packages/browser-wallet/src/popup/pages/About/i18n/da.ts
+++ b/packages/browser-wallet/src/popup/pages/About/i18n/da.ts
@@ -1,0 +1,10 @@
+import type en from './en';
+
+const t: typeof en = {
+    version: 'Version',
+    documentation: 'Concordium dokumentation',
+    support: 'Concordium support forum',
+    website: "Besøg Concordium's hjemmeside",
+};
+
+export default t;

--- a/packages/browser-wallet/src/popup/pages/About/i18n/en.ts
+++ b/packages/browser-wallet/src/popup/pages/About/i18n/en.ts
@@ -1,0 +1,8 @@
+const t = {
+    version: 'Version',
+    documentation: 'Concordium documentation',
+    support: 'Concordium support forum',
+    website: 'Visit the Concordium website',
+};
+
+export default t;

--- a/packages/browser-wallet/src/popup/pages/About/index.ts
+++ b/packages/browser-wallet/src/popup/pages/About/index.ts
@@ -1,0 +1,1 @@
+export { default } from './About';

--- a/packages/browser-wallet/src/popup/pages/Settings/Settings.scss
+++ b/packages/browser-wallet/src/popup/pages/Settings/Settings.scss
@@ -1,4 +1,6 @@
 .settings-page {
+    height: 100%;
+    background-color: $color-bg;
     padding: 0 rem(10px);
 
     &__link {

--- a/packages/browser-wallet/src/popup/shell/Routes.tsx
+++ b/packages/browser-wallet/src/popup/shell/Routes.tsx
@@ -17,6 +17,7 @@ import Settings from '@popup/pages/Settings';
 import NetworkSettings from '@popup/pages/NetworkSettings';
 import VisualSettings from '@popup/pages/VisualSettings';
 import AddAccount from '@popup/pages/AddAccount';
+import About from '@popup/pages/About';
 
 type PromptKey = keyof Omit<typeof absoluteRoutes['prompt'], 'path'>;
 
@@ -105,7 +106,7 @@ export default function Routes() {
                     <Route element={<NoContent />} path={relativeRoutes.home.settings.passcode.path} />
                     <Route element={<NetworkSettings />} path={relativeRoutes.home.settings.network.path} />
                     <Route element={<VisualSettings />} path={relativeRoutes.home.settings.visual.path} />
-                    <Route element={<NoContent />} path={relativeRoutes.home.settings.about.path} />
+                    <Route element={<About />} path={relativeRoutes.home.settings.about.path} />
                 </Route>
                 <Route
                     element={<AddAccount />}

--- a/packages/browser-wallet/src/popup/shell/i18n/locales/da.ts
+++ b/packages/browser-wallet/src/popup/shell/i18n/locales/da.ts
@@ -8,6 +8,7 @@ import connectionRequest from '@popup/pages/ConnectionRequest/i18n/da';
 import settings from '@popup/pages/Settings/i18n/da';
 import networkSettings from '@popup/pages/NetworkSettings/i18n/da';
 import visualSettings from '@popup/pages/VisualSettings/i18n/da';
+import about from '@popup/pages/About/i18n/da';
 import addAccount from '@popup/pages/AddAccount/i18n/da';
 
 import type en from './en';
@@ -24,6 +25,7 @@ const t: typeof en = {
     networkSettings,
     visualSettings,
     addAccount,
+    about,
 };
 
 export default t;

--- a/packages/browser-wallet/src/popup/shell/i18n/locales/en.ts
+++ b/packages/browser-wallet/src/popup/shell/i18n/locales/en.ts
@@ -8,6 +8,7 @@ import connectionRequest from '@popup/pages/ConnectionRequest/i18n/en';
 import settings from '@popup/pages/Settings/i18n/en';
 import networkSettings from '@popup/pages/NetworkSettings/i18n/en';
 import visualSettings from '@popup/pages/VisualSettings/i18n/en';
+import about from '@popup/pages/About/i18n/en';
 import addAccount from '@popup/pages/AddAccount/i18n/en';
 
 const t = {
@@ -22,6 +23,7 @@ const t = {
     networkSettings,
     visualSettings,
     addAccount,
+    about,
 };
 
 export default t;

--- a/packages/browser-wallet/src/popup/styles/_components.scss
+++ b/packages/browser-wallet/src/popup/styles/_components.scss
@@ -19,6 +19,7 @@
 @import '../pages/Setup/Setup';
 @import '../pages/ConnectionRequest/ConnectionRequest';
 @import '../pages/Settings/Settings';
+@import '../pages/About/About';
 
 // Layouts
 @import '../page-layouts/MainLayout';


### PR DESCRIPTION
## Purpose
Add the about page. Note that the terms and conditions and license notices are not linked yet, as they are separate tasks.

## Changes
- Updated the CSS for the Settings page to have a background color instead of the background image.
- Updated the about page to contain the version, the support email and relevant links to documentation, the support forum and the main Concordium website.

## Checklist
- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.