### PR TITLE
Connection setup

### DIFF
--- a/examples/two-step-transfer/index.html
+++ b/examples/two-step-transfer/index.html
@@ -6,15 +6,20 @@
         <script src="../../packages/browser-wallet-api-helpers/lib/concordiumHelpers.min.js"></script>
         <meta charset="utf-8" />
         <script>
+            let currentAccountAddress = '';
+
             async function setupPage() {
                 const provider = await concordiumHelpers.detectConcordiumProvider();
 
-                document
-                    .getElementById('connect')
-                    .addEventListener('click', () => provider.connect().then(alert).catch(alert));
+                document.getElementById('connect').addEventListener('click', () => {
+                    provider.connect().then((accountAddress) => {
+                        currentAccountAddress = accountAddress;
+                        document.getElementById('accountAddress').innerHTML = accountAddress;
+                    });
+                });
                 document.getElementById('sendTransfer').addEventListener('click', () =>
                     provider
-                        .sendTransaction(concordiumSDK.AccountTransactionType.SimpleTransfer, {
+                        .sendTransaction(currentAccountAddress, concordiumSDK.AccountTransactionType.SimpleTransfer, {
                             amount: new concordiumSDK.GtuAmount(1n),
                             toAddress: new concordiumSDK.AccountAddress(
                                 '39bKAuC7sXCZQfo7DmVQTMbiUuBMQJ5bCfsS7sva1HvDnUXp13'
@@ -25,27 +30,32 @@
                 );
                 document.getElementById('signMessage').addEventListener('click', () =>
                     provider
-                        .signMessage(message.value)
+                        .signMessage(currentAccountAddress, message.value)
                         .then((sig) => alert(JSON.stringify(sig)))
                         .catch(alert)
                 );
                 document.getElementById('sendDeposit').addEventListener('click', () =>
                     provider
-                        .sendTransaction(concordiumSDK.AccountTransactionType.UpdateSmartContractInstance, {
-                            amount: new concordiumSDK.GtuAmount(1n),
-                            contractAddress: {
-                                index: 98n,
-                                subindex: 0n,
-                            },
-                            receiveName: 'two-step-transfer.deposit',
-                            maxContractExecutionEnergy: 30000n,
-                        })
+                        .sendTransaction(
+                            currentAccountAddress,
+                            concordiumSDK.AccountTransactionType.UpdateSmartContractInstance,
+                            {
+                                amount: new concordiumSDK.GtuAmount(1n),
+                                contractAddress: {
+                                    index: 98n,
+                                    subindex: 0n,
+                                },
+                                receiveName: 'two-step-transfer.deposit',
+                                maxContractExecutionEnergy: 30000n,
+                            }
+                        )
                         .then(alert)
                         .catch(alert)
                 );
                 document.getElementById('sendReceive').addEventListener('click', () =>
                     provider
                         .sendTransaction(
+                            currentAccountAddress,
                             concordiumSDK.AccountTransactionType.UpdateSmartContractInstance,
                             {
                                 amount: new concordiumSDK.GtuAmount(1n),
@@ -67,6 +77,7 @@
                 document.getElementById('sendInit').addEventListener('click', () =>
                     provider
                         .sendTransaction(
+                            currentAccountAddress,
                             concordiumSDK.AccountTransactionType.InitializeSmartContractInstance,
                             {
                                 amount: new concordiumSDK.GtuAmount(1n),
@@ -90,7 +101,7 @@
                         .catch(alert)
                 );
 
-                provider.on('accountChanged', (accountAddres) => alert(accountAddres));
+                provider.on('accountChanged', (accountAddress) => (currentAccountAddress = accountAddress));
                 provider.on('chainChanged', (chain) => alert(chain));
             }
 
@@ -99,6 +110,9 @@
     </head>
 
     <body>
+        <div>
+            <h3 id="accountAddress">Account address:</h3>
+        </div>
         <button id="connect">Connect</button>
         <button id="sendInit">Initiate two step transfer contract</button>
         <button id="sendTransfer">Send transfer</button>

--- a/packages/browser-wallet-api-helpers/CHANGELOG.md
+++ b/packages/browser-wallet-api-helpers/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.0
+
+-   Updated API of sendTransaction and signMessage to require the account address.
+
 ## 0.1.0
 
 -   Initialized from the old browser-wallet-api-types package.

--- a/packages/browser-wallet-api-helpers/README.md
+++ b/packages/browser-wallet-api-helpers/README.md
@@ -60,16 +60,20 @@ const accountAddress = await provider.connect();
 
 ### sendTransaction
 
-To send a transaction, two arguments need to be provided: A transaction type and a corresponding payload. Invoking `sendTransaction` returns a `Promise`, which resolves with the transaction hash for the submitted transaction.
+To send a transaction, three arguments need to be provided: The account address for the account in the wallet that should sign the transaction, a transaction type and a corresponding payload. Invoking `sendTransaction` returns a `Promise`, which resolves with the transaction hash for the submitted transaction.
 
-The following exemplifies how to create a simple transfer of funds from one account (selected account in the wallet) to another. Please note that [@concordium/web-sdk](https://github.com/Concordium/concordium-node-sdk-js/tree/main/packages/web) is used to provide the correct formats and types for the transaction payload.
+The following exemplifies how to create a simple transfer of funds from one account to another. Please note that [@concordium/web-sdk](https://github.com/Concordium/concordium-node-sdk-js/tree/main/packages/web) is used to provide the correct formats and types for the transaction payload.
 
 ```typescript
 const provider = await detectConcordiumProvider();
-const txHash = await provider.sendTransaction(concordiumSDK.AccountTransactionType.SimpleTransfer, {
-    amount: new concordiumSDK.GtuAmount(1n),
-    toAddress: new concordiumSDK.AccountAddress('39bKAuC7sXCZQfo7DmVQTMbiUuBMQJ5bCfsS7sva1HvDnUXp13'),
-});
+const txHash = await provider.sendTransaction(
+    '4MyVHYbRkAU6fqQsoSDzni6mrVz1KEvhDJoMVmDmrCgPBD8b7S',
+    concordiumSDK.AccountTransactionType.SimpleTransfer,
+    {
+        amount: new concordiumSDK.GtuAmount(1n),
+        toAddress: new concordiumSDK.AccountAddress('39bKAuC7sXCZQfo7DmVQTMbiUuBMQJ5bCfsS7sva1HvDnUXp13'),
+    }
+);
 ```
 
 In the case of a smart contract init/update, parameters for the specific function and a corresponding schema for serializing the parameters can be defined.
@@ -77,6 +81,7 @@ In the case of a smart contract init/update, parameters for the specific functio
 ```typescript
 const provider = await detectConcordiumProvider();
 const txHash = await provider.sendTransaction(
+    '4MyVHYbRkAU6fqQsoSDzni6mrVz1KEvhDJoMVmDmrCgPBD8b7S',
     concordiumSDK.AccountTransactionType.UpdateSmartContractInstance,
     {
         amount: new concordiumSDK.GtuAmount(1n),
@@ -96,18 +101,21 @@ const txHash = await provider.sendTransaction(
 
 ### signMessage
 
-It is possible to sign arbitrary messages using the keys for an account stored in the wallet, by invoking the `signMessage` method. This method returns a `Promise` resolving with a signature of the message.
+It is possible to sign arbitrary messages using the keys for an account stored in the wallet, by invoking the `signMessage` method. The first parameter is the account to be used for signing the message. This method returns a `Promise` resolving with a signature of the message.
 
 The following exemplifies requesting a signature of a message:
 
 ```typescript
 const provider = await detectConcordiumProvider();
-const signature = await provider.signMessage('This is a message to be signed');
+const signature = await provider.signMessage(
+    '4MyVHYbRkAU6fqQsoSDzni6mrVz1KEvhDJoMVmDmrCgPBD8b7S',
+    'This is a message to be signed'
+);
 ```
 
 ### addChangeAccountListener
 
-To react when the selected account in the wallet changes, a handler function can be assigned through `addChangeAccountListener`. This does **not** return the currently selected account when the handler is initially assigned. This can be obtained by invoking the `connect` method.
+To react when the selected account in the wallet changes, a handler function can be assigned through `addChangeAccountListener`. This does **not** return the currently selected account when the handler is initially assigned. This can be obtained by invoking the `connect` method. Note that the event will not be received if the user changes to an account in the wallet that is not connected to your dApp.
 
 ```typescript
 const provider = await detectConcordiumProvider();

--- a/packages/browser-wallet-api-helpers/package.json
+++ b/packages/browser-wallet-api-helpers/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/browser-wallet-api-helpers",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "license": "Apache-2.0",
     "packageManager": "yarn@3.2.0",
     "main": "lib/index.js",

--- a/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
+++ b/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
@@ -36,6 +36,7 @@ interface MainWalletApi {
      * @param schema schema used for the initContract and updateContract transactions to serialize the parameters. Should be base64 encoded.
      */
     sendTransaction(
+        accountAddress: string,
         type:
             | AccountTransactionType.UpdateSmartContractInstance
             | AccountTransactionType.InitializeSmartContractInstance,
@@ -49,13 +50,17 @@ interface MainWalletApi {
      * @param type the type of transaction that is to be signed and sent.
      * @param payload the payload of the transaction to be signed and sent.
      */
-    sendTransaction(type: AccountTransactionType, payload: AccountTransactionPayload): Promise<string>;
+    sendTransaction(
+        accountAddress: string,
+        type: AccountTransactionType,
+        payload: AccountTransactionPayload
+    ): Promise<string>;
     /**
      * Sends a message to the Concordium Wallet and awaits the users action. If the user signs the message, this will resolve to the signature.
      * Note that if the user rejects signing the message, this will throw an error.
      * @param message message to be signed. Note that the wallet will prepend some bytes to ensure the message cannot be a transaction
      */
-    signMessage(message: string): Promise<AccountTransactionSignature>;
+    signMessage(accountAddress: string, message: string): Promise<AccountTransactionSignature>;
     /**
      * Requests a connection to the Concordium wallet, prompting the user to either accept or reject the request.
      * If a connection has already been accepted for the url once the returned promise will resolve without prompting the user.

--- a/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
+++ b/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
@@ -30,6 +30,7 @@ interface MainWalletApi {
     /**
      * Sends a transaction to the Concordium Wallet and awaits the users action. Note that a header is not sent, and will be constructed by the wallet itself.
      * Note that if the user rejects signing the transaction, this will throw an error.
+     * @param accountAddress the address of the account that should sign the transaction
      * @param type the type of transaction that is to be signed and sent.
      * @param payload the payload of the transaction to be signed and sent.
      * @param parameters parameters for the initContract and updateContract transactions in JSON-like format.
@@ -47,6 +48,7 @@ interface MainWalletApi {
     /**
      * Sends a transaction to the Concordium Wallet and awaits the users action. Note that a header is not sent, and will be constructed by the wallet itself.
      * Note that if the user rejects signing the transaction, this will throw an error.
+     * @param accountAddress the address of the account that should sign the transaction
      * @param type the type of transaction that is to be signed and sent.
      * @param payload the payload of the transaction to be signed and sent.
      */
@@ -58,6 +60,7 @@ interface MainWalletApi {
     /**
      * Sends a message to the Concordium Wallet and awaits the users action. If the user signs the message, this will resolve to the signature.
      * Note that if the user rejects signing the message, this will throw an error.
+     * @param accountAddress the address of the account that should sign the message
      * @param message message to be signed. Note that the wallet will prepend some bytes to ensure the message cannot be a transaction
      */
     signMessage(accountAddress: string, message: string): Promise<AccountTransactionSignature>;

--- a/packages/browser-wallet-api/src/wallet-api.ts
+++ b/packages/browser-wallet-api/src/wallet-api.ts
@@ -38,7 +38,8 @@ class WalletApi extends EventEmitter implements IWalletApi {
     public async connect(): Promise<string | undefined> {
         const response = await this.messageHandler.sendMessage<string | undefined | false>(MessageType.Connect);
 
-        if (response === false) {
+        // TODO Response becomes === null when we would expect it to be undefined. Catching it here is a temporary quick-fix.
+        if (response === false || response === null) {
             throw new Error('Connection rejected');
         }
 

--- a/packages/browser-wallet-api/src/wallet-api.ts
+++ b/packages/browser-wallet-api/src/wallet-api.ts
@@ -19,8 +19,9 @@ class WalletApi extends EventEmitter implements IWalletApi {
     /**
      * Sends a sign request to the Concordium Wallet and awaits the users action
      */
-    public async signMessage(message: string): Promise<AccountTransactionSignature> {
+    public async signMessage(accountAddress: string, message: string): Promise<AccountTransactionSignature> {
         const response = await this.sendMessage<AccountTransactionSignature | undefined>(MessageType.SignMessage, {
+            accountAddress,
             message,
         });
 
@@ -50,12 +51,14 @@ class WalletApi extends EventEmitter implements IWalletApi {
      * Sends a transaction to the Concordium Wallet and awaits the users action
      */
     public async sendTransaction(
+        accountAddress: string,
         type: AccountTransactionType,
         payload: AccountTransactionPayload,
         parameters?: Record<string, unknown>,
         schema?: string
     ): Promise<string> {
         const response = await this.sendMessage<string | undefined>(MessageType.SendTransaction, {
+            accountAddress,
             type,
             payload: stringify(payload),
             parameters,

--- a/packages/browser-wallet-message-hub/src/handlers.ts
+++ b/packages/browser-wallet-message-hub/src/handlers.ts
@@ -251,7 +251,7 @@ export class ExtensionsMessageHandler extends BaseMessageHandler<WalletMessage> 
 
         let whitelistedUrls: string[] = [];
         if (selectedAccount && connectedSites) {
-            whitelistedUrls = connectedSites[selectedAccount];
+            whitelistedUrls = connectedSites[selectedAccount] ?? [];
         }
 
         return tabs.filter(({ url }) => url !== undefined && whitelistedUrls?.includes(url));

--- a/packages/browser-wallet-message-hub/src/handlers.ts
+++ b/packages/browser-wallet-message-hub/src/handlers.ts
@@ -176,7 +176,10 @@ export class ContentMessageHandler {
 }
 
 export class ExtensionsMessageHandler extends BaseMessageHandler<WalletMessage> {
-    constructor(private whitelistedUrls: { get(): Promise<string[] | undefined> }) {
+    constructor(
+        private connectedSites: { get(): Promise<Record<string, string[]> | undefined> },
+        private selectedAccount: { get(): Promise<string | undefined> }
+    ) {
         super();
     }
 
@@ -243,7 +246,14 @@ export class ExtensionsMessageHandler extends BaseMessageHandler<WalletMessage> 
     }
 
     private async getWhitelistedTabs(tabs: chrome.tabs.Tab[]): Promise<chrome.tabs.Tab[]> {
-        const whitelistedUrls = await this.whitelistedUrls.get();
+        const connectedSites = await this.connectedSites.get();
+        const selectedAccount = await this.selectedAccount.get();
+
+        let whitelistedUrls: string[] = [];
+        if (selectedAccount && connectedSites) {
+            whitelistedUrls = connectedSites[selectedAccount];
+        }
+
         return tabs.filter(({ url }) => url !== undefined && whitelistedUrls?.includes(url));
     }
 

--- a/packages/browser-wallet/src/background/index.ts
+++ b/packages/browser-wallet/src/background/index.ts
@@ -90,7 +90,7 @@ async function findPrioritizedAccountConnectedToSite(url: string): Promise<strin
  * account in the wallet is connected to the sender URL.
  *
  * 1. If no selected account exists (the wallet is empty), then do not run and return undefined.
- * 1. Else if the selected account is connected to the sender URL, then do not run and return the select account address.
+ * 1. Else if the selected account is connected to the sender URL, then do not run and return the selected account address.
  * 1. Else if any other account is connected to the sender URL, then do not run and return that account's address.
  * 1. Else run the handler.
  */

--- a/packages/browser-wallet/src/background/message-handler.ts
+++ b/packages/browser-wallet/src/background/message-handler.ts
@@ -4,9 +4,9 @@ import {
     InternalMessageType,
     Payload,
 } from '@concordium/browser-wallet-message-hub';
-import { storedUrlWhitelist } from '@shared/storage/access';
+import { storedSelectedAccount, storedConnectedSites } from '@shared/storage/access';
 
-const bgMessageHandler = new ExtensionsMessageHandler(storedUrlWhitelist);
+const bgMessageHandler = new ExtensionsMessageHandler(storedConnectedSites, storedSelectedAccount);
 
 export default bgMessageHandler;
 

--- a/packages/browser-wallet/src/popup/pages/Account/Account.scss
+++ b/packages/browser-wallet/src/popup/pages/Account/Account.scss
@@ -32,14 +32,6 @@ $account-page-details-height: var(--details-height, $account-page-details-height
         position: relative;
         overflow: overlay;
         @include transition(height);
-
-        > div {
-            // TODO remove - only here to make temp content prettier.
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            height: 100%;
-        }
     }
 
     &__close {

--- a/packages/browser-wallet/src/popup/pages/Account/Account.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/Account.tsx
@@ -1,61 +1,20 @@
-import { useAtom, useAtomValue } from 'jotai';
-import React, { useCallback, useState } from 'react';
+import { useAtomValue } from 'jotai';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Outlet, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
-
+import { Outlet, Route, Routes } from 'react-router-dom';
 import { accountsAtom, selectedAccountAtom } from '@popup/store/account';
-import Button from '@popup/shared/Button';
-import { credentialsAtom, urlWhitelistAtom } from '@popup/store/settings';
-import CloseButton from '@popup/shared/CloseButton';
-import { absoluteRoutes } from '@popup/constants/routes';
 import MenuButton from '@popup/shared/MenuButton';
 import { accountRoutes } from './routes';
 import AccountActions from './AccountActions';
 import DisplayAddress from './DisplayAddress';
 import AccountDetails from './AccountDetails';
-
-function AccountSettings() {
-    const { t } = useTranslation('account');
-    const [creds, setCreds] = useAtom(credentialsAtom);
-    const [selectedAccount, setSelectedAccount] = useAtom(selectedAccountAtom);
-    const [whitelist, setWhitelist] = useAtom(urlWhitelistAtom);
-
-    const removeAccount = useCallback(() => {
-        const next = creds.filter((c) => c.address !== selectedAccount);
-        setCreds(next);
-
-        setSelectedAccount(next[0]?.address);
-    }, [creds, selectedAccount]);
-
-    const removeConnections = useCallback(() => {
-        setWhitelist([]);
-    }, []);
-
-    if (selectedAccount === undefined) {
-        return null;
-    }
-
-    return (
-        <div className="flex-column">
-            <Button danger onClick={removeAccount}>
-                {t('removeAccount')}
-            </Button>
-            <Button disabled={!whitelist.length} danger className="m-t-20" onClick={removeConnections}>
-                {t('resetConnections')}
-            </Button>
-        </div>
-    );
-}
+import AccountSettings from './AccountSettings';
 
 function Account() {
     const { t } = useTranslation('account');
     const accounts = useAtomValue(accountsAtom);
     const selectedAccount = useAtomValue(selectedAccountAtom);
-    const { pathname } = useLocation();
-    const nav = useNavigate();
     const [detailsExpanded, setDetailsExpanded] = useState(true);
-
-    const canClose = pathname !== absoluteRoutes.home.account.path;
 
     return (
         <div className="flex-column justify-space-between align-center h-full relative">
@@ -73,17 +32,11 @@ function Account() {
                         </div>
                         <div className="account-page__routes">
                             <Outlet />
-                            {canClose && (
-                                <CloseButton
-                                    className="account-page__close"
-                                    onClick={() => nav(absoluteRoutes.home.account.path)}
-                                />
-                            )}
                         </div>
                     </>
                 )}
             </div>
-            <AccountActions className="account-page__actions" />
+            <AccountActions className="account-page__actions" setDetailsExpanded={setDetailsExpanded} />
         </div>
     );
 }
@@ -95,7 +48,7 @@ export default function AccountRoutes() {
                 <Route index element={<div>Transaction log</div>} />
                 <Route path={accountRoutes.send} element={<div>Send CCD</div>} />
                 <Route path={accountRoutes.receive} element={<DisplayAddress />} />
-                <Route path={accountRoutes.settings} element={<AccountSettings />} />
+                <Route path={`${accountRoutes.settings}/*`} element={<AccountSettings />} />
             </Route>
         </Routes>
     );

--- a/packages/browser-wallet/src/popup/pages/Account/AccountActions/AccountActions.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/AccountActions/AccountActions.tsx
@@ -9,7 +9,6 @@ import SendIcon from '@assets/svg/paperplane.svg';
 import ReceiveIcon from '@assets/svg/qr.svg';
 import SettingsIcon from '@assets/svg/cog.svg';
 
-import { ClassName } from 'wallet-common-helpers';
 import clsx from 'clsx';
 import { accountRoutes } from '../routes';
 
@@ -51,9 +50,12 @@ function ActionLinks({ children }: ActionLinksProps) {
     );
 }
 
-type Props = ClassName;
+interface Props {
+    className: string;
+    setDetailsExpanded: React.Dispatch<React.SetStateAction<boolean>>;
+}
 
-export default function AccountActions({ className }: Props) {
+export default function AccountActions({ className, setDetailsExpanded }: Props) {
     const { t } = useTranslation('account', { keyPrefix: 'actions' });
 
     return (
@@ -68,7 +70,12 @@ export default function AccountActions({ className }: Props) {
                 <NavLink className="account-page-actions__link" to={accountRoutes.receive} title={t('receive')}>
                     <ReceiveIcon className="account-page-actions__receive-icon" />
                 </NavLink>
-                <NavLink className="account-page-actions__link" to={accountRoutes.settings} title={t('settings')}>
+                <NavLink
+                    className="account-page-actions__link"
+                    to={accountRoutes.settings}
+                    title={t('settings')}
+                    onClick={() => setDetailsExpanded(false)}
+                >
                     <SettingsIcon className="account-page-actions__settings-icon" />
                 </NavLink>
             </ActionLinks>

--- a/packages/browser-wallet/src/popup/pages/Account/AccountSettings/AccountSettings.scss
+++ b/packages/browser-wallet/src/popup/pages/Account/AccountSettings/AccountSettings.scss
@@ -23,6 +23,11 @@
         justify-content: space-between;
         padding-top: rem(10px);
         padding-bottom: rem(10px);
+
+        &__disconnect {
+            cursor: pointer;
+            color: $color-blue;
+        }
     }
 
     & > *:not(:last-child) {

--- a/packages/browser-wallet/src/popup/pages/Account/AccountSettings/AccountSettings.scss
+++ b/packages/browser-wallet/src/popup/pages/Account/AccountSettings/AccountSettings.scss
@@ -1,0 +1,31 @@
+.account-settings-page {
+    height: 100%;
+    width: 100%;
+    background-color: $color-bg;
+    padding: 0 rem(10px);
+    display: block;
+
+    &__link {
+        display: block;
+        padding: rem(10px) 0;
+    }
+}
+
+.connected-sites-list {
+    width: 100%;
+    padding-left: rem(14px);
+    padding-right: rem(14px);
+    background-color: $color-bg;
+
+    &__element {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        padding-top: rem(10px);
+        padding-bottom: rem(10px);
+    }
+
+    & > *:not(:last-child) {
+        border-bottom: rem(1px) solid $color-petroleum;
+    }
+}

--- a/packages/browser-wallet/src/popup/pages/Account/AccountSettings/AccountSettings.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/AccountSettings/AccountSettings.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import NavList from '@popup/shared/NavList';
 import { Link, Route, Routes } from 'react-router-dom';
+import { useAtom, useAtomValue } from 'jotai';
+import { selectedAccountAtom, storedConnectedSitesAtom } from '@popup/store/account';
+import Button from '@popup/shared/Button';
 import { accountSettingsRoutes } from './routes';
 
 export function AccountSettings() {
@@ -17,16 +20,49 @@ export function AccountSettings() {
 }
 
 function ConnectedSites() {
+    const selectedAccount = useAtomValue(selectedAccountAtom);
+    const [connectedSites, setConnectedSites] = useAtom(storedConnectedSitesAtom);
+    const localSites = selectedAccount ? connectedSites[selectedAccount] : undefined;
+
+    if (localSites === undefined || selectedAccount === undefined) {
+        return (
+            <div className="connected-sites-list">
+                <div className="connected-sites-list__element">The selected account is not connected to any sites.</div>
+            </div>
+        );
+    }
+
+    function updateSites(site: string, account?: string) {
+        if (!account) {
+            throw new Error('This never happens');
+        }
+
+        const currentValue = connectedSites[account] ? connectedSites[account] : [];
+        const updatedValue = currentValue.filter((v) => v !== site);
+
+        const newValue = {
+            ...connectedSites,
+        };
+        newValue[account] = updatedValue;
+        setConnectedSites(newValue);
+    }
+
     return (
         <div className="connected-sites-list">
-            <div className="connected-sites-list__element">
-                <div>app.bridge.org</div>
-                <div>Disconnect</div>
-            </div>
-            <div className="connected-sites-list__element">
-                <div>app.bridge.org</div>
-                <div>Disconnect</div>
-            </div>
+            {localSites.map((site) => {
+                return (
+                    <div className="connected-sites-list__element" key={site}>
+                        <div>{site}</div>
+                        <Button
+                            clear
+                            className="connected-sites-list__element__disconnect"
+                            onClick={() => updateSites(site, selectedAccount)}
+                        >
+                            Disconnect
+                        </Button>
+                    </div>
+                );
+            })}
         </div>
     );
 }

--- a/packages/browser-wallet/src/popup/pages/Account/AccountSettings/AccountSettings.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/AccountSettings/AccountSettings.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import NavList from '@popup/shared/NavList';
 import { Link, Route, Routes } from 'react-router-dom';
-import { useAtom, useAtomValue } from 'jotai';
-import { selectedAccountAtom, storedConnectedSitesAtom } from '@popup/store/account';
-import Button from '@popup/shared/Button';
 import { accountSettingsRoutes } from './routes';
+import ConnectedSites from './ConnectedSites';
 
 export function AccountSettings() {
     return (
@@ -16,54 +14,6 @@ export function AccountSettings() {
                 Export private key
             </Link>
         </NavList>
-    );
-}
-
-function ConnectedSites() {
-    const selectedAccount = useAtomValue(selectedAccountAtom);
-    const [connectedSites, setConnectedSites] = useAtom(storedConnectedSitesAtom);
-    const localSites = selectedAccount ? connectedSites[selectedAccount] : undefined;
-
-    if (localSites === undefined || selectedAccount === undefined) {
-        return (
-            <div className="connected-sites-list">
-                <div className="connected-sites-list__element">The selected account is not connected to any sites.</div>
-            </div>
-        );
-    }
-
-    function updateSites(site: string, account?: string) {
-        if (!account) {
-            throw new Error('This never happens');
-        }
-
-        const currentValue = connectedSites[account] ? connectedSites[account] : [];
-        const updatedValue = currentValue.filter((v) => v !== site);
-
-        const newValue = {
-            ...connectedSites,
-        };
-        newValue[account] = updatedValue;
-        setConnectedSites(newValue);
-    }
-
-    return (
-        <div className="connected-sites-list">
-            {localSites.map((site) => {
-                return (
-                    <div className="connected-sites-list__element" key={site}>
-                        <div>{site}</div>
-                        <Button
-                            clear
-                            className="connected-sites-list__element__disconnect"
-                            onClick={() => updateSites(site, selectedAccount)}
-                        >
-                            Disconnect
-                        </Button>
-                    </div>
-                );
-            })}
-        </div>
     );
 }
 

--- a/packages/browser-wallet/src/popup/pages/Account/AccountSettings/AccountSettings.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/AccountSettings/AccountSettings.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import NavList from '@popup/shared/NavList';
+import { Link, Route, Routes } from 'react-router-dom';
+import { accountSettingsRoutes } from './routes';
+
+export function AccountSettings() {
+    return (
+        <NavList className="account-settings-page">
+            <Link className="account-settings-page__link" to={accountSettingsRoutes.connectedSites}>
+                Connected sites
+            </Link>
+            <Link className="account-settings-page__link" to={accountSettingsRoutes.exportPrivateKey}>
+                Export private key
+            </Link>
+        </NavList>
+    );
+}
+
+function ConnectedSites() {
+    return (
+        <div className="connected-sites-list">
+            <div className="connected-sites-list__element">
+                <div>app.bridge.org</div>
+                <div>Disconnect</div>
+            </div>
+            <div className="connected-sites-list__element">
+                <div>app.bridge.org</div>
+                <div>Disconnect</div>
+            </div>
+        </div>
+    );
+}
+
+export default function AccountSettingRoutes() {
+    return (
+        <Routes>
+            <Route index element={<AccountSettings />} />
+            <Route path={accountSettingsRoutes.connectedSites} element={<ConnectedSites />} />
+            <Route path={accountSettingsRoutes.exportPrivateKey} element={<div>Export private key</div>} />
+        </Routes>
+    );
+}

--- a/packages/browser-wallet/src/popup/pages/Account/AccountSettings/AccountSettings.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/AccountSettings/AccountSettings.tsx
@@ -1,17 +1,21 @@
 import React from 'react';
 import NavList from '@popup/shared/NavList';
 import { Link, Route, Routes } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { accountSettingsRoutes } from './routes';
 import ConnectedSites from './ConnectedSites';
 
 export function AccountSettings() {
+    const { t: tc } = useTranslation('account', { keyPrefix: 'settings.connectedSites' });
+    const { t } = useTranslation('account', { keyPrefix: 'settings' });
+
     return (
         <NavList className="account-settings-page">
             <Link className="account-settings-page__link" to={accountSettingsRoutes.connectedSites}>
-                Connected sites
+                {tc('title')}
             </Link>
             <Link className="account-settings-page__link" to={accountSettingsRoutes.exportPrivateKey}>
-                Export private key
+                {t('exportPrivateKey')}
             </Link>
         </NavList>
     );

--- a/packages/browser-wallet/src/popup/pages/Account/AccountSettings/ConnectedSites.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/AccountSettings/ConnectedSites.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { useAtom, useAtomValue } from 'jotai';
+import { selectedAccountAtom, storedConnectedSitesAtom } from '@popup/store/account';
+import Button from '@popup/shared/Button';
+
+export default function ConnectedSites() {
+    const selectedAccount = useAtomValue(selectedAccountAtom);
+    const [connectedSites, setConnectedSites] = useAtom(storedConnectedSitesAtom);
+
+    if (!selectedAccount) {
+        return null;
+    }
+
+    const localSites = connectedSites[selectedAccount];
+    if (!localSites || localSites.length === 0) {
+        return (
+            <div className="connected-sites-list">
+                <div className="connected-sites-list__element">The selected account is not connected to any sites.</div>
+            </div>
+        );
+    }
+
+    function removeConnectedSite(site: string, account: string) {
+        const currentConnectedSitesForAccount = connectedSites[account] ?? [];
+        const updatedConnectedSitesForAccount = currentConnectedSitesForAccount.filter((v) => v !== site);
+
+        const connectedSitesWithSiteRemoved = {
+            ...connectedSites,
+        };
+
+        connectedSitesWithSiteRemoved[account] = updatedConnectedSitesForAccount;
+        setConnectedSites(connectedSitesWithSiteRemoved);
+    }
+
+    return (
+        <div className="connected-sites-list">
+            {localSites.map((site) => {
+                return (
+                    <div className="connected-sites-list__element" key={site}>
+                        <div>{site}</div>
+                        <Button
+                            clear
+                            className="connected-sites-list__element__disconnect"
+                            onClick={() => removeConnectedSite(site, selectedAccount)}
+                        >
+                            Disconnect
+                        </Button>
+                    </div>
+                );
+            })}
+        </div>
+    );
+}

--- a/packages/browser-wallet/src/popup/pages/Account/AccountSettings/ConnectedSites.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/AccountSettings/ConnectedSites.tsx
@@ -2,20 +2,23 @@ import React from 'react';
 import { useAtom, useAtomValue } from 'jotai';
 import { selectedAccountAtom, storedConnectedSitesAtom } from '@popup/store/account';
 import Button from '@popup/shared/Button';
+import { useTranslation } from 'react-i18next';
 
 export default function ConnectedSites() {
+    const { t } = useTranslation('account', { keyPrefix: 'settings.connectedSites' });
     const selectedAccount = useAtomValue(selectedAccountAtom);
-    const [connectedSites, setConnectedSites] = useAtom(storedConnectedSitesAtom);
+    const [connectedSitesLoading, setConnectedSites] = useAtom(storedConnectedSitesAtom);
+    const connectedSites = connectedSitesLoading.value;
 
     if (!selectedAccount) {
         return null;
     }
 
-    const localSites = connectedSites[selectedAccount];
-    if (!localSites || localSites.length === 0) {
+    const localSites = connectedSites[selectedAccount] ?? [];
+    if (!connectedSitesLoading.loading && localSites.length === 0) {
         return (
             <div className="connected-sites-list">
-                <div className="connected-sites-list__element">The selected account is not connected to any sites.</div>
+                <div className="connected-sites-list__element">{t('noConnected')}</div>
             </div>
         );
     }
@@ -43,7 +46,7 @@ export default function ConnectedSites() {
                             className="connected-sites-list__element__disconnect"
                             onClick={() => removeConnectedSite(site, selectedAccount)}
                         >
-                            Disconnect
+                            {t('disconnect')}
                         </Button>
                     </div>
                 );

--- a/packages/browser-wallet/src/popup/pages/Account/AccountSettings/index.ts
+++ b/packages/browser-wallet/src/popup/pages/Account/AccountSettings/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AccountSettings';

--- a/packages/browser-wallet/src/popup/pages/Account/AccountSettings/routes.ts
+++ b/packages/browser-wallet/src/popup/pages/Account/AccountSettings/routes.ts
@@ -1,0 +1,4 @@
+export const accountSettingsRoutes = {
+    connectedSites: 'connected-sites',
+    exportPrivateKey: 'export-private-key',
+};

--- a/packages/browser-wallet/src/popup/pages/Account/i18n/da.ts
+++ b/packages/browser-wallet/src/popup/pages/Account/i18n/da.ts
@@ -16,6 +16,14 @@ const t: typeof en = {
         atDisposal: 'Offentligt til rådighed',
         stakeAmount: 'Stake',
     },
+    settings: {
+        connectedSites: {
+            title: 'Forbundne hjemmesider',
+            noConnected: 'Den valgte konto er ikke forbundet til nogen hjemmeside.',
+            disconnect: 'Fjern',
+        },
+        exportPrivateKey: 'Eksportér privat nøgle',
+    },
 };
 
 export default t;

--- a/packages/browser-wallet/src/popup/pages/Account/i18n/en.ts
+++ b/packages/browser-wallet/src/popup/pages/Account/i18n/en.ts
@@ -14,6 +14,14 @@ const t = {
         atDisposal: 'Public amount at disposal',
         stakeAmount: 'Stake / delegation amount',
     },
+    settings: {
+        connectedSites: {
+            title: 'Connected sites',
+            noConnected: 'The selected account is not connected to any sites.',
+            disconnect: 'Disconnect',
+        },
+        exportPrivateKey: 'Export private key',
+    },
 };
 
 export default t;

--- a/packages/browser-wallet/src/popup/pages/Account/index.scss
+++ b/packages/browser-wallet/src/popup/pages/Account/index.scss
@@ -2,3 +2,4 @@
 @import './AccountActions/AccountActions';
 @import './DisplayAddress/DisplayAddress';
 @import './AccountDetails/AccountDetails';
+@import './AccountSettings/AccountSettings';

--- a/packages/browser-wallet/src/popup/pages/ConnectionRequest/ConnectionRequest.scss
+++ b/packages/browser-wallet/src/popup/pages/ConnectionRequest/ConnectionRequest.scss
@@ -13,21 +13,8 @@
         white-space: pre-wrap;
         word-break: break-all;
     }
-}
 
-.account-list {
-    width: 100%;
-    padding-left: rem(14px);
-    padding-right: rem(14px);
-    background-color: $color-bg;
-    margin-top: 5px;
-
-    &__element {
-        padding-top: rem(10px);
-        padding-bottom: rem(10px);
-    }
-
-    & > *:not(:last-child) {
-        border-bottom: rem(1px) solid $color-petroleum;
+    &__address {
+        word-break: break-all;
     }
 }

--- a/packages/browser-wallet/src/popup/pages/ConnectionRequest/ConnectionRequest.scss
+++ b/packages/browser-wallet/src/popup/pages/ConnectionRequest/ConnectionRequest.scss
@@ -1,4 +1,5 @@
 .connection-request {
+    background-color: $color-bg;
     display: block;
 
     &__actions {
@@ -11,5 +12,22 @@
     &__url {
         white-space: pre-wrap;
         word-break: break-all;
+    }
+}
+
+.account-list {
+    width: 100%;
+    padding-left: rem(14px);
+    padding-right: rem(14px);
+    background-color: $color-bg;
+    margin-top: 5px;
+
+    &__element {
+        padding-top: rem(10px);
+        padding-bottom: rem(10px);
+    }
+
+    & > *:not(:last-child) {
+        border-bottom: rem(1px) solid $color-petroleum;
     }
 }

--- a/packages/browser-wallet/src/popup/pages/ConnectionRequest/ConnectionRequest.tsx
+++ b/packages/browser-wallet/src/popup/pages/ConnectionRequest/ConnectionRequest.tsx
@@ -1,5 +1,5 @@
 import { fullscreenPromptContext } from '@popup/page-layouts/FullscreenPromptLayout';
-import { accountsAtom, storedConnectedSitesAtom } from '@popup/store/account';
+import { selectedAccountAtom, storedConnectedSitesAtom } from '@popup/store/account';
 import { useAtom, useAtomValue } from 'jotai';
 import React, { useContext, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -14,57 +14,43 @@ export default function ConnectionRequest({ onAllow, onReject }: Props) {
     const { state } = useLocation();
     const { t } = useTranslation('connectionRequest');
     const { onClose, withClose } = useContext(fullscreenPromptContext);
-    const accounts = useAtomValue(accountsAtom);
+    const selectedAccount = useAtomValue(selectedAccountAtom);
     const [connectedSites, setConnectedSites] = useAtom(storedConnectedSitesAtom);
+
+    if (!selectedAccount) {
+        return null;
+    }
 
     useEffect(() => onClose(onReject), [onClose, onReject]);
 
-    function connectAccounts(accountAddresses: string[], url: string) {
-        const updatedRecord: Record<string, string[]> = connectedSites;
+    function connectAccount(account: string, url: string) {
+        const updatedConnectedSites = {
+            ...connectedSites,
+        };
 
-        for (const accountAddress of accountAddresses) {
-            const currentConnectedSites = connectedSites[accountAddress];
-            const updatedConnectedSites = [];
-            if (currentConnectedSites && !currentConnectedSites.includes(url)) {
-                updatedConnectedSites.push(...currentConnectedSites, url);
-            } else {
-                updatedConnectedSites.push(url);
-            }
-            updatedRecord[accountAddress] = updatedConnectedSites;
-        }
+        const connectedSitesForAccount = connectedSites[account] ?? [];
+        connectedSitesForAccount.push(url);
+        updatedConnectedSites[account] = connectedSitesForAccount;
 
-        setConnectedSites(updatedRecord);
+        setConnectedSites(updatedConnectedSites);
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { title, url } = (state as any).payload;
 
-    // TODO The user must select the accounts to connect to instead of connecting to all.
     return (
         <>
             <header>
                 <h3>{t('title')}</h3>
             </header>
-            <div>{t('description', { title })}</div>
+            <pre className="connection-request__url">{title}</pre>
             <pre className="connection-request__url">{url}</pre>
-
-            <div>The following accounts will be connected to the site</div>
-            <div className="account-list">
-                {accounts.length > 0 &&
-                    accounts.map((account) => {
-                        return (
-                            <div className="account-list__element" key={account}>
-                                {account.substring(0, 10)}
-                            </div>
-                        );
-                    })}
-            </div>
-
+            <div>{t('description', { selectedAccount })}</div>
             <div className="connection-request__actions">
                 <button
                     type="button"
                     onClick={withClose(() => {
-                        connectAccounts(accounts, url);
+                        connectAccount(selectedAccount, url);
                         onAllow();
                     })}
                 >

--- a/packages/browser-wallet/src/popup/pages/ConnectionRequest/ConnectionRequest.tsx
+++ b/packages/browser-wallet/src/popup/pages/ConnectionRequest/ConnectionRequest.tsx
@@ -1,4 +1,6 @@
 import { fullscreenPromptContext } from '@popup/page-layouts/FullscreenPromptLayout';
+import { accountsAtom, storedConnectedSitesAtom } from '@popup/store/account';
+import { useAtom, useAtomValue } from 'jotai';
 import React, { useContext, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
@@ -12,12 +14,32 @@ export default function ConnectionRequest({ onAllow, onReject }: Props) {
     const { state } = useLocation();
     const { t } = useTranslation('connectionRequest');
     const { onClose, withClose } = useContext(fullscreenPromptContext);
+    const accounts = useAtomValue(accountsAtom);
+    const [connectedSites, setConnectedSites] = useAtom(storedConnectedSitesAtom);
 
     useEffect(() => onClose(onReject), [onClose, onReject]);
+
+    function connectAccounts(accountAddresses: string[], url: string) {
+        const updatedRecord: Record<string, string[]> = connectedSites;
+
+        for (const accountAddress of accountAddresses) {
+            const currentConnectedSites = connectedSites[accountAddress];
+            const updatedConnectedSites = [];
+            if (currentConnectedSites && !currentConnectedSites.includes(url)) {
+                updatedConnectedSites.push(...currentConnectedSites, url);
+            } else {
+                updatedConnectedSites.push(url);
+            }
+            updatedRecord[accountAddress] = updatedConnectedSites;
+        }
+
+        setConnectedSites(updatedRecord);
+    }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { title, url } = (state as any).payload;
 
+    // TODO The user must select the accounts to connect to instead of connecting to all.
     return (
         <>
             <header>
@@ -25,8 +47,27 @@ export default function ConnectionRequest({ onAllow, onReject }: Props) {
             </header>
             <div>{t('description', { title })}</div>
             <pre className="connection-request__url">{url}</pre>
+
+            <div>The following accounts will be connected to the site</div>
+            <div className="account-list">
+                {accounts.length > 0 &&
+                    accounts.map((account) => {
+                        return (
+                            <div className="account-list__element" key={account}>
+                                {account.substring(0, 10)}
+                            </div>
+                        );
+                    })}
+            </div>
+
             <div className="connection-request__actions">
-                <button type="button" onClick={withClose(onAllow)}>
+                <button
+                    type="button"
+                    onClick={withClose(() => {
+                        connectAccounts(accounts, url);
+                        onAllow();
+                    })}
+                >
                     {t('actions.allow')}
                 </button>
                 <button type="button" onClick={withClose(onReject)}>

--- a/packages/browser-wallet/src/popup/pages/ConnectionRequest/ConnectionRequest.tsx
+++ b/packages/browser-wallet/src/popup/pages/ConnectionRequest/ConnectionRequest.tsx
@@ -15,13 +15,14 @@ export default function ConnectionRequest({ onAllow, onReject }: Props) {
     const { t } = useTranslation('connectionRequest');
     const { onClose, withClose } = useContext(fullscreenPromptContext);
     const selectedAccount = useAtomValue(selectedAccountAtom);
-    const [connectedSites, setConnectedSites] = useAtom(storedConnectedSitesAtom);
-
-    if (!selectedAccount) {
-        return null;
-    }
+    const [connectedSitesLoading, setConnectedSites] = useAtom(storedConnectedSitesAtom);
+    const connectedSites = connectedSitesLoading.value;
 
     useEffect(() => onClose(onReject), [onClose, onReject]);
+
+    if (!selectedAccount || connectedSitesLoading.loading) {
+        return null;
+    }
 
     function connectAccount(account: string, url: string) {
         const updatedConnectedSites = {
@@ -45,7 +46,7 @@ export default function ConnectionRequest({ onAllow, onReject }: Props) {
             </header>
             <pre className="connection-request__url">{title}</pre>
             <pre className="connection-request__url">{url}</pre>
-            <div>{t('description', { selectedAccount })}</div>
+            <div className="connection-request__address">{t('description', { selectedAccount })}</div>
             <div className="connection-request__actions">
                 <button
                     type="button"

--- a/packages/browser-wallet/src/popup/pages/ConnectionRequest/i18n/da.ts
+++ b/packages/browser-wallet/src/popup/pages/ConnectionRequest/i18n/da.ts
@@ -2,7 +2,7 @@ import type en from './en';
 
 const t: typeof en = {
     title: 'Forbindelsesforespørgsel',
-    description: 'Tillad forbindelse fra "{{title}}"',
+    description: 'Tillad denne hjemmeside at forbinde til kontoen {{selectedAccount}}',
     actions: {
         allow: 'Tillad',
         reject: 'Afvis',

--- a/packages/browser-wallet/src/popup/pages/ConnectionRequest/i18n/en.ts
+++ b/packages/browser-wallet/src/popup/pages/ConnectionRequest/i18n/en.ts
@@ -1,6 +1,6 @@
 const t = {
     title: 'Connection request',
-    description: 'Allow connection from "{{title}}"',
+    description: 'Allow this site to connect to account {{selectedAccount}}',
     actions: {
         allow: 'Allow',
         reject: 'Reject',

--- a/packages/browser-wallet/src/popup/pages/SendTransaction/SendTransaction.tsx
+++ b/packages/browser-wallet/src/popup/pages/SendTransaction/SendTransaction.tsx
@@ -13,7 +13,6 @@ import {
     TransactionExpiry,
     getAccountTransactionHash,
 } from '@concordium/web-sdk';
-import { selectedAccountAtom } from '@popup/store/account';
 import { jsonRpcUrlAtom, credentialsAtom } from '@popup/store/settings';
 import DisplayUpdateContract from './displayTransaction/DisplayUpdateContract';
 import DisplayInitContract from './displayTransaction/DisplayInitContract';
@@ -23,6 +22,7 @@ import { parsePayload } from './util';
 interface Location {
     state: {
         payload: {
+            accountAddress: string;
             type: AccountTransactionType;
             payload: string;
             parameters?: Record<string, unknown>;
@@ -40,11 +40,11 @@ export default function SendTransaction({ onSubmit, onReject }: Props) {
     const { state } = useLocation() as Location;
     const { t } = useTranslation('sendTransaction');
     const [error, setError] = useState<string>();
-    const address = useAtomValue(selectedAccountAtom);
     const creds = useAtomValue(credentialsAtom);
     const url = useAtomValue(jsonRpcUrlAtom);
     const { withClose, onClose } = useContext(fullscreenPromptContext);
 
+    const { accountAddress } = state.payload;
     const { type: transactionType, payload } = useMemo(
         () => parsePayload(state.payload.type, state.payload.payload, state.payload.parameters, state.payload.schema),
         [JSON.stringify(state.payload)]
@@ -53,17 +53,17 @@ export default function SendTransaction({ onSubmit, onReject }: Props) {
     useEffect(() => onClose(onReject), [onClose, onReject]);
 
     const sendTransaction = useCallback(async () => {
-        if (!url || !address) {
+        if (!url || !accountAddress) {
             throw new Error('Missing url for JsonRpc or account address');
         }
-        const key = creds.find((c) => c.address === address)?.key;
+        const key = creds.find((c) => c.address === accountAddress)?.key;
         if (!key) {
             throw new Error('Missing key for the chosen address');
         }
 
         // TODO: Maybe we should not create the client for each transaction sent
         const client = new JsonRpcClient(new HttpProvider(url));
-        const sender = new AccountAddress(address);
+        const sender = new AccountAddress(accountAddress);
         const nonce = await client.getNextAccountNonce(sender);
 
         if (!nonce) {
@@ -92,7 +92,7 @@ export default function SendTransaction({ onSubmit, onReject }: Props) {
         <>
             <div>{t('description')}</div>
             <h5>{t('sender')}:</h5>
-            <p className="send-transaction__address">{address}</p>
+            <p className="send-transaction__address">{accountAddress}</p>
             {transactionType === AccountTransactionType.SimpleTransfer && <DisplaySimpleTransfer payload={payload} />}
             {transactionType === AccountTransactionType.UpdateSmartContractInstance && (
                 <DisplayUpdateContract payload={payload} parameters={state.payload.parameters} />

--- a/packages/browser-wallet/src/popup/pages/SignMessage/SignMessage.tsx
+++ b/packages/browser-wallet/src/popup/pages/SignMessage/SignMessage.tsx
@@ -3,7 +3,6 @@ import React, { useContext, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 import { useAtomValue } from 'jotai';
-import { selectedAccountAtom } from '@popup/store/account';
 import { credentialsAtom } from '@popup/store/settings';
 import { signMessage, buildBasicAccountSigner, AccountTransactionSignature } from '@concordium/web-sdk';
 
@@ -15,6 +14,7 @@ type Props = {
 interface Location {
     state: {
         payload: {
+            accountAddress: string;
             message: string;
         };
     };
@@ -24,9 +24,9 @@ export default function SignMessage({ onSubmit, onReject }: Props) {
     const { state } = useLocation() as Location;
     const [error, setError] = useState();
     const { t } = useTranslation('signMessage');
-    const address = useAtomValue(selectedAccountAtom);
     const creds = useAtomValue(credentialsAtom);
     const { withClose } = useContext(fullscreenPromptContext);
+    const address = state.payload.accountAddress;
 
     const onClick = useCallback(async () => {
         if (!address) {
@@ -37,11 +37,11 @@ export default function SignMessage({ onSubmit, onReject }: Props) {
             throw new Error('Missing key for the chosen address');
         }
         return signMessage(state.payload.message, buildBasicAccountSigner(key));
-    }, [state.payload.message]);
+    }, [state.payload.message, state.payload.accountAddress]);
 
     return (
         <>
-            <div>{t('description')}</div>
+            <div>{t('description', { address })}</div>
             <p>{state.payload.message}</p>
             <button
                 type="button"

--- a/packages/browser-wallet/src/popup/pages/SignMessage/i18n/da.ts
+++ b/packages/browser-wallet/src/popup/pages/SignMessage/i18n/da.ts
@@ -1,7 +1,7 @@
 import type en from './en';
 
 const t: typeof en = {
-    description: 'Signér besked',
+    description: 'Signér besked med konto {{address}}',
     sign: 'Signér',
     deny: 'Afvis',
     error: 'Fejl',

--- a/packages/browser-wallet/src/popup/pages/SignMessage/i18n/en.ts
+++ b/packages/browser-wallet/src/popup/pages/SignMessage/i18n/en.ts
@@ -1,5 +1,5 @@
 const t = {
-    description: 'Sign message',
+    description: 'Sign message with account {{address}}',
     sign: 'Sign',
     deny: 'Deny',
     error: 'Error',

--- a/packages/browser-wallet/src/popup/shared/message-handler.ts
+++ b/packages/browser-wallet/src/popup/shared/message-handler.ts
@@ -1,4 +1,4 @@
 import { ExtensionsMessageHandler } from '@concordium/browser-wallet-message-hub';
-import { storedUrlWhitelist } from '@shared/storage/access';
+import { storedConnectedSites, storedSelectedAccount } from '@shared/storage/access';
 
-export const popupMessageHandler = new ExtensionsMessageHandler(storedUrlWhitelist);
+export const popupMessageHandler = new ExtensionsMessageHandler(storedConnectedSites, storedSelectedAccount);

--- a/packages/browser-wallet/src/popup/store/account.ts
+++ b/packages/browser-wallet/src/popup/store/account.ts
@@ -9,7 +9,8 @@ import { atomWithChromeStorage } from './utils';
 
 export const storedConnectedSitesAtom = atomWithChromeStorage<Record<string, string[]>>(
     ChromeStorageKey.ConnectedSites,
-    {}
+    {},
+    true
 );
 
 const storedAccountAtom = atomWithChromeStorage<string | undefined>(ChromeStorageKey.SelectedAccount, undefined);

--- a/packages/browser-wallet/src/popup/store/account.ts
+++ b/packages/browser-wallet/src/popup/store/account.ts
@@ -7,6 +7,11 @@ import { EventType } from '@concordium/browser-wallet-api-helpers';
 import { credentialsAtom } from './settings';
 import { atomWithChromeStorage } from './utils';
 
+export const storedConnectedSitesAtom = atomWithChromeStorage<Record<string, string[]>>(
+    ChromeStorageKey.ConnectedSites,
+    {}
+);
+
 const storedAccountAtom = atomWithChromeStorage<string | undefined>(ChromeStorageKey.SelectedAccount, undefined);
 export const selectedAccountAtom = atom<string | undefined, string | undefined>(
     (get) => get(storedAccountAtom),

--- a/packages/browser-wallet/src/popup/store/settings.ts
+++ b/packages/browser-wallet/src/popup/store/settings.ts
@@ -6,7 +6,6 @@ import { atomWithChromeStorage, AsyncWrapper } from './utils';
 
 export const credentialsAtom = atomWithChromeStorage<WalletCredential[]>(ChromeStorageKey.Credentials, []);
 export const themeAtom = atomWithChromeStorage<Theme>(ChromeStorageKey.Theme, Theme.Light);
-export const urlWhitelistAtom = atomWithChromeStorage<string[]>(ChromeStorageKey.UrlWhitelist, []);
 
 const storedJsonRpcUrlAtom = atomWithChromeStorage<string>(ChromeStorageKey.JsonRpcUrl, '', true);
 export const jsonRpcUrlAtomLoading = atom<AsyncWrapper<string>, string>(

--- a/packages/browser-wallet/src/popup/store/utils.ts
+++ b/packages/browser-wallet/src/popup/store/utils.ts
@@ -5,7 +5,6 @@ import {
     storedJsonRpcUrl,
     storedSelectedAccount,
     storedTheme,
-    storedUrlWhitelist,
 } from '@shared/storage/access';
 import { ChromeStorageKey } from '@shared/storage/types';
 import { atom, WritableAtom } from 'jotai';
@@ -15,7 +14,6 @@ const accessorMap = {
     [ChromeStorageKey.Credentials]: storedCredentials,
     [ChromeStorageKey.SelectedAccount]: storedSelectedAccount,
     [ChromeStorageKey.JsonRpcUrl]: storedJsonRpcUrl,
-    [ChromeStorageKey.UrlWhitelist]: storedUrlWhitelist,
     [ChromeStorageKey.Theme]: storedTheme,
 };
 

--- a/packages/browser-wallet/src/popup/store/utils.ts
+++ b/packages/browser-wallet/src/popup/store/utils.ts
@@ -1,5 +1,6 @@
 import {
     StorageAccessor,
+    storedConnectedSites,
     storedCredentials,
     storedJsonRpcUrl,
     storedSelectedAccount,
@@ -10,6 +11,7 @@ import { ChromeStorageKey } from '@shared/storage/types';
 import { atom, WritableAtom } from 'jotai';
 
 const accessorMap = {
+    [ChromeStorageKey.ConnectedSites]: storedConnectedSites,
     [ChromeStorageKey.Credentials]: storedCredentials,
     [ChromeStorageKey.SelectedAccount]: storedSelectedAccount,
     [ChromeStorageKey.JsonRpcUrl]: storedJsonRpcUrl,

--- a/packages/browser-wallet/src/shared/storage/access.ts
+++ b/packages/browser-wallet/src/shared/storage/access.ts
@@ -37,5 +37,4 @@ export const storedConnectedSites = makeStorageAccessor<Record<string, string[]>
 export const storedCredentials = makeStorageAccessor<WalletCredential[]>('local', ChromeStorageKey.Credentials);
 export const storedJsonRpcUrl = makeStorageAccessor<string>('local', ChromeStorageKey.JsonRpcUrl);
 export const storedSelectedAccount = makeStorageAccessor<string>('local', ChromeStorageKey.SelectedAccount);
-export const storedUrlWhitelist = makeStorageAccessor<string[]>('local', ChromeStorageKey.UrlWhitelist);
 export const storedTheme = makeStorageAccessor<Theme>('local', ChromeStorageKey.Theme);

--- a/packages/browser-wallet/src/shared/storage/access.ts
+++ b/packages/browser-wallet/src/shared/storage/access.ts
@@ -30,6 +30,10 @@ const makeStorageAccessor = <V>(area: chrome.storage.AreaName, key: ChromeStorag
     };
 };
 
+export const storedConnectedSites = makeStorageAccessor<Record<string, string[]>>(
+    'local',
+    ChromeStorageKey.ConnectedSites
+);
 export const storedCredentials = makeStorageAccessor<WalletCredential[]>('local', ChromeStorageKey.Credentials);
 export const storedJsonRpcUrl = makeStorageAccessor<string>('local', ChromeStorageKey.JsonRpcUrl);
 export const storedSelectedAccount = makeStorageAccessor<string>('local', ChromeStorageKey.SelectedAccount);

--- a/packages/browser-wallet/src/shared/storage/types.ts
+++ b/packages/browser-wallet/src/shared/storage/types.ts
@@ -1,4 +1,5 @@
 export enum ChromeStorageKey {
+    ConnectedSites = 'connectedSites',
     Credentials = 'credentials',
     JsonRpcUrl = 'jsonRpcUrl',
     SelectedAccount = 'selectedAccont',

--- a/packages/browser-wallet/src/shared/storage/types.ts
+++ b/packages/browser-wallet/src/shared/storage/types.ts
@@ -3,7 +3,6 @@ export enum ChromeStorageKey {
     Credentials = 'credentials',
     JsonRpcUrl = 'jsonRpcUrl',
     SelectedAccount = 'selectedAccont',
-    UrlWhitelist = 'urlWhitelist',
     Theme = 'theme',
 }
 


### PR DESCRIPTION
## Purpose
Make whitelisting of dApps a per-account setting instead of a global setting.

## Changes
- Added an account settings page.
- Added a connected sites page for handling the dApps that an account is connected to. Currently it only allows for disconnecting from a site.
- When a dApp connects we connect the currently selected account. Later this should/could be expanded to provide a list of accounts to connect to.
- signMessage and signTransaction now require dApps to provide the account that should perform the action, as it no longer defaults to the selected account.
- the connect() API will return an address of a connected account if any is present, not only if the selected account is connected. The selected account is still prioritized as the first value to return if connected.
- Removed url whitelist storage as it has been replaced by the connected sites.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.