### PR TITLE
Add ability to manually add connection to a site

### DIFF
--- a/examples/piggybank/src/Root.tsx
+++ b/examples/piggybank/src/Root.tsx
@@ -209,16 +209,24 @@ export default function Root() {
     useEffect(() => {
         detectConcordiumProvider()
             .then((provider) => {
+                // Listen for relevant events from the wallet.
+                provider.on('accountChanged', setAccount);
+                provider.on('accountDisconnected', () => {
+                    setAccount(undefined);
+                    setIsConnected(false);
+                    provider.connect().then((accountAddress) => {
+                        setAccount(accountAddress);
+                        setIsConnected(true);
+                    });
+                });
+                provider.on('chainChanged', setJsonRpcUrl);
+
                 provider
                     .connect()
                     .then((acc) => {
                         // Connection accepted, set the application state parameters.
                         setAccount(acc);
                         setIsConnected(true);
-
-                        // Listen for relevant events from the wallet.
-                        provider.on('accountChanged', setAccount);
-                        provider.on('chainChanged', setJsonRpcUrl);
                     })
                     .catch(() => setIsConnected(false));
             })

--- a/examples/two-step-transfer/index.html
+++ b/examples/two-step-transfer/index.html
@@ -101,6 +101,7 @@
                         .catch(alert)
                 );
 
+                provider.on('accountDisconnected', (accountAddress) => (currentAccountAddress = undefined));
                 provider.on('accountChanged', (accountAddress) => (currentAccountAddress = accountAddress));
                 provider.on('chainChanged', (chain) => alert(chain));
             }

--- a/packages/browser-wallet-api-helpers/CHANGELOG.md
+++ b/packages/browser-wallet-api-helpers/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.2.0
 
 -   Updated API of sendTransaction and signMessage to require the account address.
+-   Updated API to include an 'accountDisconnected' event.
 
 ## 0.1.0
 

--- a/packages/browser-wallet-api-helpers/README.md
+++ b/packages/browser-wallet-api-helpers/README.md
@@ -113,7 +113,9 @@ const signature = await provider.signMessage(
 );
 ```
 
-### Account changed listener
+## Events
+
+### Account changed
 
 An event is emitted when the selected account in the wallet is changed. An event is not emitted by the wallet when initially opening, only when the user
 explicitly switches between accounts. The `connect` method should be used to obtain the currently selected account when starting an interaction with the wallet.
@@ -125,7 +127,7 @@ let selectedAccountAddress: string | undefined = undefined;
 provider.on('accountChanged', (accountAddress) => (selectedAccountAddress = accountAddress);
 ```
 
-### Account disconnected listener
+### Account disconnected
 
 An event is emitted when dApp connection is disconnected by the user in the wallet. The disconnect
 event is only emitted to the relevant dApp being disconnected. To either reconnect or get another

--- a/packages/browser-wallet-api-helpers/README.md
+++ b/packages/browser-wallet-api-helpers/README.md
@@ -113,12 +113,34 @@ const signature = await provider.signMessage(
 );
 ```
 
-### addChangeAccountListener
+### Account changed listener
 
-To react when the selected account in the wallet changes, a handler function can be assigned through `addChangeAccountListener`. This does **not** return the currently selected account when the handler is initially assigned. This can be obtained by invoking the `connect` method. Note that the event will not be received if the user changes to an account in the wallet that is not connected to your dApp.
+An event is emitted when the selected account in the wallet is changed. An event is not emitted by the wallet when initially opening, only when the user
+explicitly switches between accounts. The `connect` method should be used to obtain the currently selected account when starting an interaction with the wallet.
+Note that the event will not be received if the user changes to an account in the wallet that is not connected to your dApp.
 
 ```typescript
 const provider = await detectConcordiumProvider();
 let selectedAccountAddress: string | undefined = undefined;
-provider.addChangeAccountListener((address) => (selectedAccountAddress = address));
+provider.on('accountChanged', (accountAddress) => (selectedAccountAddress = accountAddress);
+```
+
+### Account disconnected listener
+
+An event is emitted when dApp connection is disconnected by the user in the wallet. The disconnect
+event is only emitted to the relevant dApp being disconnected. To either reconnect or get another
+connected account a dApp should use the `connect` method. This can be done either by having the user of the dApp manually press a connect button, or it can be done automatically based on the received disconnect event.
+
+```typescript
+const provider = await detectConcordiumProvider();
+let selectedAccountAddress: string | undefined = undefined;
+provider.on('accountDisconnected', (accountAddress) => {
+    selectedAccountAddress = undefined;
+
+    // To immediately connect to an account in the wallet again.
+    // provider.connect().then((accountAddress) => (selectedAccountAddress = accountAddress));
+});
+
+// Connect to an account in the wallet again triggered elsewhere in the dApp.
+provider.connect().then((accountAddress) => (selectedAccountAddress = accountAddress));
 ```

--- a/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
+++ b/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
@@ -9,6 +9,7 @@ import type {
  */
 export enum EventType {
     AccountChanged = 'accountChanged',
+    AccountDisconnected = 'accountDisconnected',
     ChainChanged = 'chainChanged',
 }
 
@@ -24,7 +25,8 @@ interface Listeners<T extends EventType, Args extends any[]> {
 }
 
 type EventListeners = Listeners<EventType.AccountChanged, [accountAddress: string]> &
-    Listeners<EventType.ChainChanged, [chain: string]>;
+    Listeners<EventType.ChainChanged, [chain: string]> &
+    Listeners<EventType.AccountDisconnected, [accountAddress: string]>;
 
 interface MainWalletApi {
     /**

--- a/packages/browser-wallet-message-hub/src/handlers.ts
+++ b/packages/browser-wallet-message-hub/src/handlers.ts
@@ -199,7 +199,8 @@ export class ExtensionsMessageHandler extends BaseMessageHandler<WalletMessage> 
     }
 
     /**
-     * Send event of specific type with optional payload
+     * Broadcast an event of a specific type, with an optional payload, to all currently
+     * open and whitelisted (connected to the selected account) tabs.
      *
      * @example
      * handler.broadcast(EventType.ChangeAccount, "1234");
@@ -215,6 +216,18 @@ export class ExtensionsMessageHandler extends BaseMessageHandler<WalletMessage> 
                     .filter(({ id }) => id !== undefined)
                     .forEach((t) => this.sendEventToTab(t.id as number, new WalletEvent(type, payload)))
             );
+    }
+
+    /**
+     * Broadcast event of a specific type with an optional payload to open tabs with the provided URL.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    public async broadcastToUrl(type: EventType, tabUrl: string, payload?: any): Promise<void[]> {
+        const tabsRestrictedToUrl = await chrome.tabs.query({ url: `${tabUrl}/*` });
+        const sendToTabsPromises = tabsRestrictedToUrl
+            .filter((tab) => tab.id !== undefined)
+            .map((t) => this.sendEventToTab(t.id as number, new WalletEvent(type, payload)));
+        return Promise.all(sendToTabsPromises);
     }
 
     public override handleMessage(filter: MessageFilter<WalletMessage>, handler: ExtensionMessageHandler): Unsubscribe {
@@ -254,7 +267,7 @@ export class ExtensionsMessageHandler extends BaseMessageHandler<WalletMessage> 
             whitelistedUrls = connectedSites[selectedAccount] ?? [];
         }
 
-        return tabs.filter(({ url }) => url !== undefined && whitelistedUrls?.includes(url));
+        return tabs.filter(({ url }) => url !== undefined && whitelistedUrls?.includes(new URL(url).origin));
     }
 
     private async sendEventToTab(tabId: number, event: WalletEvent) {

--- a/packages/browser-wallet/src/background/index.ts
+++ b/packages/browser-wallet/src/background/index.ts
@@ -48,7 +48,7 @@ const runIfWhitelisted: RunCondition<false> = async (msg, sender) => {
     }
 
     const accountConnectedSites = connectedSites[accountAddress] ?? [];
-    if (sender.url !== undefined && accountConnectedSites.includes(sender.url)) {
+    if (sender.url !== undefined && accountConnectedSites.includes(new URL(sender.url).origin)) {
         return { run: true };
     }
 
@@ -65,6 +65,7 @@ const runIfWhitelisted: RunCondition<false> = async (msg, sender) => {
  * @returns the highest priority account address that is connected to the site with the provided URL.
  */
 async function findPrioritizedAccountConnectedToSite(url: string): Promise<string | undefined> {
+    const urlOrigin = new URL(url).origin;
     const selectedAccount = await storedSelectedAccount.get();
     const connectedSites = await storedConnectedSites.get();
 
@@ -73,11 +74,11 @@ async function findPrioritizedAccountConnectedToSite(url: string): Promise<strin
     }
 
     const selectedAccountConnectedSites = connectedSites[selectedAccount] ?? [];
-    if (selectedAccountConnectedSites.includes(url)) {
+    if (selectedAccountConnectedSites.includes(urlOrigin)) {
         return selectedAccount;
     }
 
-    const connectedAccount = Object.entries(connectedSites).find((item) => item[1] && item[1].includes(url));
+    const connectedAccount = Object.entries(connectedSites).find((item) => item[1] && item[1].includes(urlOrigin));
     if (connectedAccount) {
         return connectedAccount[0];
     }

--- a/packages/browser-wallet/src/popup/pages/Account/AccountSettings/AccountSettings.scss
+++ b/packages/browser-wallet/src/popup/pages/Account/AccountSettings/AccountSettings.scss
@@ -24,6 +24,11 @@
         padding-top: rem(10px);
         padding-bottom: rem(10px);
 
+        &__connect {
+            cursor: pointer;
+            color: $color-dark-green;
+        }
+
         &__disconnect {
             cursor: pointer;
             color: $color-blue;

--- a/packages/browser-wallet/src/popup/pages/Account/AccountSettings/ConnectedSites.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/AccountSettings/ConnectedSites.tsx
@@ -1,21 +1,37 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useAtom, useAtomValue } from 'jotai';
 import { selectedAccountAtom, storedConnectedSitesAtom } from '@popup/store/account';
 import Button from '@popup/shared/Button';
 import { useTranslation } from 'react-i18next';
+import { popupMessageHandler } from '@popup/shared/message-handler';
+import { EventType } from '@concordium/browser-wallet-api-helpers';
 
 export default function ConnectedSites() {
     const { t } = useTranslation('account', { keyPrefix: 'settings.connectedSites' });
     const selectedAccount = useAtomValue(selectedAccountAtom);
     const [connectedSitesLoading, setConnectedSites] = useAtom(storedConnectedSitesAtom);
     const connectedSites = connectedSitesLoading.value;
+    const [openTabUrl, setOpenTabUrl] = useState<string>();
+
+    async function getCurrentOpenTabUrl() {
+        const tabs = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
+        const { url } = tabs[0];
+        if (!url) {
+            return undefined;
+        }
+        return new URL(url).origin;
+    }
+
+    useEffect(() => {
+        getCurrentOpenTabUrl().then(setOpenTabUrl);
+    }, []);
 
     if (!selectedAccount) {
         return null;
     }
 
     const localSites = connectedSites[selectedAccount] ?? [];
-    if (!connectedSitesLoading.loading && localSites.length === 0) {
+    if (!openTabUrl && !connectedSitesLoading.loading && localSites.length === 0) {
         return (
             <div className="connected-sites-list">
                 <div className="connected-sites-list__element">{t('noConnected')}</div>
@@ -23,24 +39,61 @@ export default function ConnectedSites() {
         );
     }
 
+    function updateConnectedSites(updatedConnectedSitesForAccount: string[], account: string) {
+        const connectedSitesWithSiteAdded = {
+            ...connectedSites,
+        };
+        connectedSitesWithSiteAdded[account] = updatedConnectedSitesForAccount;
+        setConnectedSites(connectedSitesWithSiteAdded);
+    }
+
+    function connectSite(site: string, account: string) {
+        const currentConnectedSitesForAccount = connectedSites[account] ?? [];
+        if (currentConnectedSitesForAccount.includes(site)) {
+            return;
+        }
+
+        const updatedConnectedSitesForAccount = [site];
+        updatedConnectedSitesForAccount.push(...currentConnectedSitesForAccount);
+        updateConnectedSites(updatedConnectedSitesForAccount, account);
+        popupMessageHandler.broadcastToUrl(EventType.AccountChanged, site, account);
+    }
+
     function removeConnectedSite(site: string, account: string) {
         const currentConnectedSitesForAccount = connectedSites[account] ?? [];
         const updatedConnectedSitesForAccount = currentConnectedSitesForAccount.filter((v) => v !== site);
+        updateConnectedSites(updatedConnectedSitesForAccount, account);
+        popupMessageHandler.broadcastToUrl(EventType.AccountDisconnected, site, account);
+    }
 
-        const connectedSitesWithSiteRemoved = {
-            ...connectedSites,
-        };
+    function displayUrl(url: string) {
+        const { hostname } = new URL(url);
 
-        connectedSitesWithSiteRemoved[account] = updatedConnectedSitesForAccount;
-        setConnectedSites(connectedSitesWithSiteRemoved);
+        if (hostname.length < 29) {
+            return hostname;
+        }
+
+        return `${hostname.substring(0, 29)}...`;
     }
 
     return (
         <div className="connected-sites-list">
+            {openTabUrl && !localSites.includes(openTabUrl) && (
+                <div className="connected-sites-list__element" key={openTabUrl}>
+                    <div title={openTabUrl}>{displayUrl(openTabUrl)}</div>
+                    <Button
+                        clear
+                        className="connected-sites-list__element__connect"
+                        onClick={() => connectSite(openTabUrl, selectedAccount)}
+                    >
+                        {t('connect')}
+                    </Button>
+                </div>
+            )}
             {localSites.map((site) => {
                 return (
                     <div className="connected-sites-list__element" key={site}>
-                        <div>{site}</div>
+                        <div title={site}>{displayUrl(site)}</div>
                         <Button
                             clear
                             className="connected-sites-list__element__disconnect"

--- a/packages/browser-wallet/src/popup/pages/Account/AccountSettings/ConnectedSites.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/AccountSettings/ConnectedSites.tsx
@@ -6,6 +6,16 @@ import { useTranslation } from 'react-i18next';
 import { popupMessageHandler } from '@popup/shared/message-handler';
 import { EventType } from '@concordium/browser-wallet-api-helpers';
 
+function displayUrl(url: string) {
+    const { hostname } = new URL(url);
+
+    if (hostname.length < 29) {
+        return hostname;
+    }
+
+    return `${hostname.substring(0, 29)}...`;
+}
+
 export default function ConnectedSites() {
     const { t } = useTranslation('account', { keyPrefix: 'settings.connectedSites' });
     const selectedAccount = useAtomValue(selectedAccountAtom);
@@ -64,16 +74,6 @@ export default function ConnectedSites() {
         const updatedConnectedSitesForAccount = currentConnectedSitesForAccount.filter((v) => v !== site);
         updateConnectedSites(updatedConnectedSitesForAccount, account);
         popupMessageHandler.broadcastToUrl(EventType.AccountDisconnected, site, account);
-    }
-
-    function displayUrl(url: string) {
-        const { hostname } = new URL(url);
-
-        if (hostname.length < 29) {
-            return hostname;
-        }
-
-        return `${hostname.substring(0, 29)}...`;
     }
 
     return (

--- a/packages/browser-wallet/src/popup/pages/Account/i18n/da.ts
+++ b/packages/browser-wallet/src/popup/pages/Account/i18n/da.ts
@@ -20,6 +20,7 @@ const t: typeof en = {
         connectedSites: {
             title: 'Forbundne hjemmesider',
             noConnected: 'Den valgte konto er ikke forbundet til nogen hjemmeside.',
+            connect: 'Forbind',
             disconnect: 'Fjern',
         },
         exportPrivateKey: 'Eksportér privat nøgle',

--- a/packages/browser-wallet/src/popup/pages/Account/i18n/en.ts
+++ b/packages/browser-wallet/src/popup/pages/Account/i18n/en.ts
@@ -18,6 +18,7 @@ const t = {
         connectedSites: {
             title: 'Connected sites',
             noConnected: 'The selected account is not connected to any sites.',
+            connect: 'Connect',
             disconnect: 'Disconnect',
         },
         exportPrivateKey: 'Export private key',

--- a/packages/browser-wallet/src/popup/pages/ConnectionRequest/ConnectionRequest.tsx
+++ b/packages/browser-wallet/src/popup/pages/ConnectionRequest/ConnectionRequest.tsx
@@ -38,6 +38,7 @@ export default function ConnectionRequest({ onAllow, onReject }: Props) {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { title, url } = (state as any).payload;
+    const urlOrigin = new URL(url).origin;
 
     return (
         <>
@@ -45,13 +46,13 @@ export default function ConnectionRequest({ onAllow, onReject }: Props) {
                 <h3>{t('title')}</h3>
             </header>
             <pre className="connection-request__url">{title}</pre>
-            <pre className="connection-request__url">{url}</pre>
+            <pre className="connection-request__url">{urlOrigin}</pre>
             <div className="connection-request__address">{t('description', { selectedAccount })}</div>
             <div className="connection-request__actions">
                 <button
                     type="button"
                     onClick={withClose(() => {
-                        connectAccount(selectedAccount, url);
+                        connectAccount(selectedAccount, urlOrigin);
                         onAllow();
                     })}
                 >


### PR DESCRIPTION
## Purpose
Allow users to manually connect to a site. Broadcast a disconnect event when removing a connection and an accountChanged event when adding a new connection, but only to the given site.

## Changes
- Added new disconnect event to WalletApi. Emitted to the disconnected tab.
- Added option to manually connect the currently open tab's website to the wallet.
- An accountChanged event is emitted when manually connecting to a site, but only to that site.
- Connected site whitelisting now uses the `origin` field on the URL instead of the full URL which was too restrictive.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.