### PR TITLE
Add site connected status box to account page

### DIFF
--- a/packages/browser-wallet/src/popup/pages/Account/Account.scss
+++ b/packages/browser-wallet/src/popup/pages/Account/Account.scss
@@ -43,4 +43,22 @@ $account-page-details-height: var(--details-height, $account-page-details-height
     &__actions {
         height: $account-page-actions-height;
     }
+
+    &__connection-box {
+        position: absolute;
+        right: 0;
+        top: 0;
+        margin-right: rem(8px);
+        margin-top: rem(5px);
+        border: 1px solid $color-green;
+        border-radius: rem(15px);
+        font-family: $font-family-mono;
+        font-size: rem(8px);
+        padding: rem(2px) rem(5px) rem(2px) rem(5px);
+    }
+
+    &__not-connected {
+        color: $color-grey;
+        border-color: $color-grey;
+    }
 }

--- a/packages/browser-wallet/src/popup/pages/Account/Account.scss
+++ b/packages/browser-wallet/src/popup/pages/Account/Account.scss
@@ -50,15 +50,15 @@ $account-page-details-height: var(--details-height, $account-page-details-height
         top: 0;
         margin-right: rem(8px);
         margin-top: rem(5px);
-        border: 1px solid $color-green;
+        border: rem(1px) solid $color-success;
         border-radius: rem(15px);
         font-family: $font-family-mono;
         font-size: rem(8px);
-        padding: rem(2px) rem(5px) rem(2px) rem(5px);
+        padding: rem(2px) rem(5px);
     }
 
     &__not-connected {
-        color: $color-grey;
-        border-color: $color-grey;
+        color: $color-text-faded;
+        border-color: $color-passive;
     }
 }

--- a/packages/browser-wallet/src/popup/pages/Account/Account.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/Account.tsx
@@ -1,14 +1,45 @@
 import { useAtomValue } from 'jotai';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Outlet, Route, Routes } from 'react-router-dom';
-import { accountsAtom, selectedAccountAtom } from '@popup/store/account';
+import { Link, Outlet, Route, Routes } from 'react-router-dom';
+import { accountsAtom, selectedAccountAtom, storedConnectedSitesAtom } from '@popup/store/account';
 import MenuButton from '@popup/shared/MenuButton';
+import { getCurrentOpenTabUrl } from '@popup/shared/utils/tabs';
+import clsx from 'clsx';
 import { accountRoutes } from './routes';
+import { accountSettingsRoutes } from './AccountSettings/routes';
 import AccountActions from './AccountActions';
 import DisplayAddress from './DisplayAddress';
 import AccountDetails from './AccountDetails';
 import AccountSettings from './AccountSettings';
+
+function ConnectedBox({ setDetailsExpanded }: { setDetailsExpanded: React.Dispatch<React.SetStateAction<boolean>> }) {
+    const { t } = useTranslation('account');
+    const connectedSites = useAtomValue(storedConnectedSitesAtom);
+    const selectedAccount = useAtomValue(selectedAccountAtom);
+    const [isConnectedToSite, setIsConnectedToSite] = useState<boolean>();
+
+    useMemo(() => {
+        if (selectedAccount && !connectedSites.loading) {
+            getCurrentOpenTabUrl().then((url) => {
+                if (url) {
+                    const connectedSitesForAccount = connectedSites.value[selectedAccount] ?? [];
+                    setIsConnectedToSite(connectedSitesForAccount.includes(url));
+                }
+            });
+        }
+    }, [selectedAccount, connectedSites]);
+
+    return (
+        <Link
+            className={clsx('account-page__connection-box', !isConnectedToSite && 'account-page__not-connected')}
+            to={`${accountRoutes.settings}/${accountSettingsRoutes.connectedSites}`}
+            onClick={() => setDetailsExpanded(false)}
+        >
+            {isConnectedToSite ? t('siteConnected') : t('siteNotConnected')}
+        </Link>
+    );
+}
 
 function Account() {
     const { t } = useTranslation('account');
@@ -29,6 +60,7 @@ function Account() {
                                 onClick={() => setDetailsExpanded((o) => !o)}
                             />
                             <AccountDetails expanded={detailsExpanded} account={selectedAccount} />
+                            <ConnectedBox setDetailsExpanded={setDetailsExpanded} />
                         </div>
                         <div className="account-page__routes">
                             <Outlet />

--- a/packages/browser-wallet/src/popup/pages/Account/AccountSettings/AccountSettings.scss
+++ b/packages/browser-wallet/src/popup/pages/Account/AccountSettings/AccountSettings.scss
@@ -16,6 +16,7 @@
     padding-left: rem(14px);
     padding-right: rem(14px);
     background-color: $color-bg;
+    overflow: overlay;
 
     &__element {
         display: flex;

--- a/packages/browser-wallet/src/popup/pages/Account/AccountSettings/ConnectedSites.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/AccountSettings/ConnectedSites.tsx
@@ -5,6 +5,7 @@ import Button from '@popup/shared/Button';
 import { useTranslation } from 'react-i18next';
 import { popupMessageHandler } from '@popup/shared/message-handler';
 import { EventType } from '@concordium/browser-wallet-api-helpers';
+import { getCurrentOpenTabUrl } from '@popup/shared/utils/tabs';
 
 export default function ConnectedSites() {
     const { t } = useTranslation('account', { keyPrefix: 'settings.connectedSites' });
@@ -13,20 +14,11 @@ export default function ConnectedSites() {
     const connectedSites = connectedSitesLoading.value;
     const [openTabUrl, setOpenTabUrl] = useState<string>();
 
-    async function getCurrentOpenTabUrl() {
-        const tabs = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
-        const { url } = tabs[0];
-        if (!url) {
-            return undefined;
-        }
-        return new URL(url).origin;
-    }
-
     useEffect(() => {
         getCurrentOpenTabUrl().then(setOpenTabUrl);
     }, []);
 
-    if (!selectedAccount) {
+    if (!selectedAccount || !openTabUrl) {
         return null;
     }
 

--- a/packages/browser-wallet/src/popup/pages/Account/i18n/da.ts
+++ b/packages/browser-wallet/src/popup/pages/Account/i18n/da.ts
@@ -5,6 +5,8 @@ const t: typeof en = {
     removeAccount: 'Fjern konto (kun lokalt)',
     resetConnections: 'Fjern forbindelser',
     accountAddress: 'Konto adresse',
+    siteConnected: 'Forbundet',
+    siteNotConnected: 'Ikke forbundet',
     actions: {
         log: 'transaktionslog',
         send: 'send ccd',

--- a/packages/browser-wallet/src/popup/pages/Account/i18n/en.ts
+++ b/packages/browser-wallet/src/popup/pages/Account/i18n/en.ts
@@ -3,6 +3,8 @@ const t = {
     removeAccount: 'Remove account (local only)',
     resetConnections: 'Reset connections',
     accountAddress: 'Account address',
+    siteConnected: 'Connected',
+    siteNotConnected: 'Not connected',
     actions: {
         log: 'transaction log',
         send: 'send ccd',

--- a/packages/browser-wallet/src/popup/shared/utils/tabs.ts
+++ b/packages/browser-wallet/src/popup/shared/utils/tabs.ts
@@ -1,0 +1,14 @@
+/**
+ * Retrieves the URL of the tab that is currently open.
+ * @returns the URL origin, as a string, of the tab that is currently open
+ */
+export async function getCurrentOpenTabUrl(): Promise<string> {
+    const tabs = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
+    const { url } = tabs[0];
+    if (!url) {
+        throw new Error(
+            'The URL was not available from the tab. This only happens if the manifest does not include the <tabs> permission.'
+        );
+    }
+    return new URL(url).origin;
+}


### PR DESCRIPTION
## Purpose
Add a status box to let the user know if the currently open tab is connected to the wallet.

## Changes
- Added a status box with connected / not connected information. Pressing the box navigates to the connected sites for the currently selected account.
- Fixed UI scrolling issue when user had many sites connected.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.