### PR TITLE
getSelectedAccount

### DIFF
--- a/examples/piggybank/src/Root.tsx
+++ b/examples/piggybank/src/Root.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import React, { useEffect, useState, useMemo } from 'react';
+import React, { useEffect, useState, useMemo, useCallback } from 'react';
 
 import { detectConcordiumProvider } from '@concordium/browser-wallet-api-helpers';
 import PiggyBankV0 from './Version0';
@@ -15,34 +15,33 @@ export default function Root() {
     const [isVersion0, setIsVersion0] = useState<boolean>(false);
     const [jsonRpcUrl, setJsonRpcUrl] = useState<string>();
 
+    const handleGetAccount = useCallback((accountAddress: string | undefined) => {
+        setAccount(accountAddress);
+        setIsConnected(Boolean(accountAddress));
+    }, []);
+
+    const handleOnClick = useCallback(
+        () =>
+            detectConcordiumProvider()
+                .then((provider) => provider.connect())
+                .then(handleGetAccount),
+        []
+    );
+
     useEffect(() => {
         detectConcordiumProvider()
             .then((provider) => {
                 // Listen for relevant events from the wallet.
                 provider.on('accountChanged', setAccount);
-                provider.on('accountDisconnected', () => {
-                    setAccount(undefined);
-                    setIsConnected(false);
-                    provider.connect().then((accountAddress) => {
-                        setAccount(accountAddress);
-                        setIsConnected(true);
-                    });
-                });
+                provider.on('accountDisconnected', () => provider.getSelectedAccount().then(handleGetAccount));
                 provider.on('chainChanged', setJsonRpcUrl);
-
-                provider
-                    .connect()
-                    .then((acc) => {
-                        // Connection accepted, set the application state parameters.
-                        setAccount(acc);
-                        setIsConnected(true);
-                    })
-                    .catch(() => setIsConnected(false));
+                // Check if you are already connected
+                provider.getSelectedAccount().then(handleGetAccount);
             })
             .catch(() => setIsConnected(false));
     }, []);
 
-    const stateValue: State = useMemo(() => ({ isConnected, account, jsonRpcUrl }), [isConnected, account, jsonRpcUrl]);
+    const stateValue: State = useMemo(() => ({ isConnected, account }), [isConnected, account]);
 
     return (
         // Setup a globally accessible state with data from the wallet.
@@ -50,8 +49,23 @@ export default function Root() {
             <button type="button" onClick={() => setIsVersion0((v) => !v)}>
                 Switch to {isVersion0 ? 'V1' : 'V0'}
             </button>
-            {isVersion0 && <PiggyBankV0 />}
-            {!isVersion0 && <PiggyBankV1 />}
+            <main className="piggybank">
+                <div className={`connection-banner ${isConnected ? 'connected' : ''}`}>
+                    {isConnected && `Connected: ${account}`}
+                    {!isConnected && (
+                        <>
+                            <p>No wallet connection</p>
+                            <button type="button" onClick={handleOnClick}>
+                                Connect
+                            </button>
+                        </>
+                    )}
+                </div>
+                <div>{jsonRpcUrl ? `JSON-RPC Url: ${jsonRpcUrl}` : 'No JSON-RPC Url yet'}</div>
+                <br />
+                {isVersion0 && <PiggyBankV0 />}
+                {!isVersion0 && <PiggyBankV1 />}
+            </main>
         </state.Provider>
     );
 }

--- a/examples/piggybank/src/Root.tsx
+++ b/examples/piggybank/src/Root.tsx
@@ -33,10 +33,12 @@ export default function Root() {
             .then((provider) => {
                 // Listen for relevant events from the wallet.
                 provider.on('accountChanged', setAccount);
-                provider.on('accountDisconnected', () => provider.getSelectedAccount().then(handleGetAccount));
+                provider.on('accountDisconnected', () =>
+                    provider.getMostRecentlySelectedAccount().then(handleGetAccount)
+                );
                 provider.on('chainChanged', setJsonRpcUrl);
                 // Check if you are already connected
-                provider.getSelectedAccount().then(handleGetAccount);
+                provider.getMostRecentlySelectedAccount().then(handleGetAccount);
             })
             .catch(() => setIsConnected(false));
     }, []);

--- a/examples/piggybank/src/Version0.tsx
+++ b/examples/piggybank/src/Version0.tsx
@@ -21,7 +21,7 @@ const isPiggybankSmashed = (piggyState: PiggyBankState): piggyState is PiggyBank
     (piggyState as PiggyBankStateSmashed).Smashed !== undefined;
 
 export default function PiggyBankV0() {
-    const { account, isConnected, jsonRpcUrl } = useContext(state);
+    const { account, isConnected } = useContext(state);
     const [piggybank, setPiggyBank] = useState<InstanceInfoV0>();
     const input = useRef<HTMLInputElement>(null);
 
@@ -58,12 +58,7 @@ export default function PiggyBankV0() {
     const canUse = isConnected && piggyBankState !== undefined && !isPiggybankSmashed(piggyBankState);
 
     return (
-        <main className="piggybank">
-            <div className={`connection-banner ${isConnected ? 'connected' : ''}`}>
-                {isConnected ? `Connected: ${account}` : 'No wallet connection'}
-            </div>
-            <div>{jsonRpcUrl ? `JSON-RPC Url: ${jsonRpcUrl}` : 'No JSON-RPC Url yet'}</div>
-            <br />
+        <>
             {piggybank === undefined ? (
                 <div>Loading piggy bank...</div>
             ) : (
@@ -105,6 +100,6 @@ export default function PiggyBankV0() {
             >
                 <HammerIcon width="40" />
             </button>
-        </main>
+        </>
     );
 }

--- a/examples/piggybank/src/Version1.tsx
+++ b/examples/piggybank/src/Version1.tsx
@@ -31,7 +31,7 @@ async function updateState(setSmashed: (x: boolean) => void, setAmount: (x: bigi
 }
 
 export default function PiggyBank() {
-    const { account, isConnected, jsonRpcUrl } = useContext(state);
+    const { account, isConnected } = useContext(state);
     const [owner, setOwner] = useState<string>();
     const [smashed, setSmashed] = useState<boolean>();
     const [amount, setAmount] = useState<bigint>(0n);
@@ -66,12 +66,7 @@ export default function PiggyBank() {
     const canUse = isConnected && smashed !== undefined && !smashed;
 
     return (
-        <main className="piggybank">
-            <div className={`connection-banner ${isConnected ? 'connected' : ''}`}>
-                {isConnected ? `Connected: ${account}` : 'No wallet connection'}
-            </div>
-            <div>{jsonRpcUrl ? `JSON-RPC Url: ${jsonRpcUrl}` : 'No JSON-RPC Url yet'}</div>
-            <br />
+        <>
             {owner === undefined ? (
                 <div>Loading piggy bank...</div>
             ) : (
@@ -116,6 +111,6 @@ export default function PiggyBank() {
             >
                 <HammerIcon width="40" />
             </button>
-        </main>
+        </>
     );
 }

--- a/examples/piggybank/src/utils.ts
+++ b/examples/piggybank/src/utils.ts
@@ -68,7 +68,6 @@ export const smash = (account: string, index: bigint, subindex = 0n) => {
 export type State = {
     isConnected: boolean;
     account: string | undefined;
-    jsonRpcUrl: string | undefined;
 };
 
-export const state = createContext<State>({ isConnected: false, account: undefined, jsonRpcUrl: undefined });
+export const state = createContext<State>({ isConnected: false, account: undefined });

--- a/packages/browser-wallet-api-helpers/CHANGELOG.md
+++ b/packages/browser-wallet-api-helpers/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 -   Expose a JSON-RPC client, using the wallet's current JSON-RPC server.
--   `getSelectedAccount` method, which allows dApps to get the current account with using `connect`.
+-   `getMostRecentlySelectedAccount` method. This method allows dApps to get the most prioritized account without using `connect`.
 
 ### (Breaking) Changed
 

--- a/packages/browser-wallet-api-helpers/CHANGELOG.md
+++ b/packages/browser-wallet-api-helpers/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 -   Expose a JSON-RPC client, using the wallet's current JSON-RPC server.
--   `getMostRecentlySelectedAccount` method. This method allows dApps to get the most prioritized account without using `connect`.
+-   `getMostRecentlySelectedAccount` method. This method allows dApps to get the most prioritized account without using `connect`. In a future release it will be updated to actually return the most recently selected account.
 
 ### (Breaking) Changed
 

--- a/packages/browser-wallet-api-helpers/CHANGELOG.md
+++ b/packages/browser-wallet-api-helpers/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 -   Expose a JSON-RPC client, using the wallet's current JSON-RPC server.
+-   `getSelectedAccount` method, which allows dApps to get the current account with using `connect`.
 
 ### (Breaking) Changed
 

--- a/packages/browser-wallet-api-helpers/README.md
+++ b/packages/browser-wallet-api-helpers/README.md
@@ -58,6 +58,20 @@ const provider = await detectConcordiumProvider();
 const accountAddress = await provider.connect();
 ```
 
+### getSelectedAccount
+
+To get the currently selected account, or to check whether the wallet is connected without using connect, the `getSelectedAccount` can be invoked. The method returns a `Promise` resolving with the address of the currently selected account in the wallet, or with undefined if there are no connected accounts in the wallet.
+
+```typescript
+const provider = await detectConcordiumProvider();
+const accountAddress = await provider.getSelectedAccount();
+if (accountAddress) {
+    // We are connected to the wallet
+} else {
+    // We are not connected to the wallet
+}
+```
+
 ### sendTransaction
 
 To send a transaction, three arguments need to be provided: The account address for the account in the wallet that should sign the transaction, a transaction type and a corresponding payload. Invoking `sendTransaction` returns a `Promise`, which resolves with the transaction hash for the submitted transaction.

--- a/packages/browser-wallet-api-helpers/README.md
+++ b/packages/browser-wallet-api-helpers/README.md
@@ -51,20 +51,25 @@ declare global {
 
 ### connect
 
-To request a connection to the wallet from the user, the `connect` method has to be invoked. The method returns a `Promise` resolving with information related to the currently selected account in the wallet, or rejecting if the request is rejected in the wallet. If this is not called, it will be called as part of any other request (f.x. `sendTransaction` or `signMessage`) made by the API.
+To request a connection to the wallet from the user, the `connect` method has to be invoked. The method returns a `Promise` resolving with information related to the most recently selected account, which has whitelisted the dApp, or rejecting if the request is rejected in the wallet. If this is not called, it will be called as part of any other request (f.x. `sendTransaction` or `signMessage`) made by the API.
+
+N.B. In the current version, if the dApp is already whitelisted, but not by the currently selected account, the returned account will not actually be the most recently selected account, but instead the oldest account that has whitelasted the dApp.
+q
 
 ```typescript
 const provider = await detectConcordiumProvider();
 const accountAddress = await provider.connect();
 ```
 
-### getSelectedAccount
+### getMostRecentlySelectedAccount
 
-To get the currently selected account, or to check whether the wallet is connected without using connect, the `getSelectedAccount` can be invoked. The method returns a `Promise` resolving with the address of the currently selected account in the wallet, or with undefined if there are no connected accounts in the wallet.
+To get the most recently selected account, or to check whether the wallet is connected without using connect, the `getMostRecentlySelectedAccount` can be invoked. The method returns a `Promise` resolving with the address of the most recently selected account in the wallet, or with undefined if there are no connected accounts in the wallet.
+
+N.B. In the current version, if the currently selected account has not whitelisted the dApp, the returned account will not actually be the most recently selected account, but instead the oldest account that has whitelasted the dApp.
 
 ```typescript
 const provider = await detectConcordiumProvider();
-const accountAddress = await provider.getSelectedAccount();
+const accountAddress = await provider.getMostRecentlySelectedAccount();
 if (accountAddress) {
     // We are connected to the wallet
 } else {

--- a/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
+++ b/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
@@ -76,6 +76,11 @@ interface MainWalletApi {
      */
     connect(): Promise<string | undefined>;
 
+    /**
+     * Returns some connected account, prioritizing the one currently selected. Resolves with account address or undefined if there are no connected account.
+     */
+    getSelectedAccount(): Promise<string | undefined>;
+
     removeAllListeners(event?: EventType | string | undefined): this;
 
     getJsonRpcClient(): JsonRpcClient;

--- a/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
+++ b/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
@@ -77,9 +77,9 @@ interface MainWalletApi {
     connect(): Promise<string | undefined>;
 
     /**
-     * Returns some connected account, prioritizing the one currently selected. Resolves with account address or undefined if there are no connected account.
+     * Returns some connected account, prioritizing the most recently selected. Resolves with account address or undefined if there are no connected account.
      */
-    getSelectedAccount(): Promise<string | undefined>;
+    getMostRecentlySelectedAccount(): Promise<string | undefined>;
 
     removeAllListeners(event?: EventType | string | undefined): this;
 

--- a/packages/browser-wallet-api/src/wallet-api.ts
+++ b/packages/browser-wallet-api/src/wallet-api.ts
@@ -71,9 +71,9 @@ class WalletApi extends EventEmitter implements IWalletApi {
     }
 
     /**
-     * Returns some connected account, prioritizing the one currently selected. Resolves with account address or undefined if there are no connected account.
+     * Returns some connected account, prioritizing the most recently selected. Resolves with account address or undefined if there are no connected account.
      */
-    public async getSelectedAccount(): Promise<string | undefined> {
+    public async getMostRecentlySelectedAccount(): Promise<string | undefined> {
         const response = await this.messageHandler.sendMessage<string | null>(MessageType.GetSelectedAccount);
 
         // TODO Response becomes === null when we would expect it to be undefined. Catching it here is a temporary quick-fix.

--- a/packages/browser-wallet-api/src/wallet-api.ts
+++ b/packages/browser-wallet-api/src/wallet-api.ts
@@ -71,6 +71,19 @@ class WalletApi extends EventEmitter implements IWalletApi {
     }
 
     /**
+     * Returns some connected account, prioritizing the one currently selected. Resolves with account address or undefined if there are no connected account.
+     */
+    public async getSelectedAccount(): Promise<string | undefined> {
+        const response = await this.messageHandler.sendMessage<string | null>(MessageType.GetSelectedAccount);
+
+        // TODO Response becomes === null when we would expect it to be undefined. Catching it here is a temporary quick-fix.
+        if (response === null) {
+            return undefined;
+        }
+        return response;
+    }
+
+    /**
      * Sends a transaction to the Concordium Wallet and awaits the users action
      */
     public async sendTransaction(

--- a/packages/browser-wallet-message-hub/src/message.ts
+++ b/packages/browser-wallet-message-hub/src/message.ts
@@ -9,6 +9,7 @@ export enum MessageType {
     SendTransaction = 'M_SendTransaction',
     SignMessage = 'M_SignMessage',
     GetAccounts = 'M_GetAccounts',
+    GetSelectedAccount = 'M_GetSelectedAccount',
     Connect = 'M_Connect',
     JsonRpcRequest = 'M_JsonRpcRequest',
 }

--- a/packages/browser-wallet/src/background/index.ts
+++ b/packages/browser-wallet/src/background/index.ts
@@ -187,6 +187,19 @@ const handleConnectionResponse: HandleResponse<string | undefined | false> = asy
     return response;
 };
 
+/**
+ * Callback method which returns the prioritized account's address.
+ */
+const getSelectedAccountHandler: ExtensionMessageHandler = (_msg, sender, respond) => {
+    if (!sender.url) {
+        throw new Error('Expected URL to be available for sender.');
+    }
+    findPrioritizedAccountConnectedToSite(sender.url).then(respond);
+    return true;
+};
+
+bgMessageHandler.handleMessage(createMessageTypeFilter(MessageType.GetSelectedAccount), getSelectedAccountHandler);
+
 forwardToPopup(
     MessageType.Connect,
     InternalMessageType.Connect,

--- a/packages/browser-wallet/src/background/index.ts
+++ b/packages/browser-wallet/src/background/index.ts
@@ -105,6 +105,7 @@ const runIfWhitelisted: RunCondition<false> = async (msg, sender) => {
     return { run: false, response: false };
 };
 
+// TODO change this to find most recently selected account
 /**
  * Finds the most prioritized account that is connected to the provided site.
  * The priority is defined as:
@@ -190,7 +191,7 @@ const handleConnectionResponse: HandleResponse<string | undefined | false> = asy
 /**
  * Callback method which returns the prioritized account's address.
  */
-const getSelectedAccountHandler: ExtensionMessageHandler = (_msg, sender, respond) => {
+const getMostRecentlySelectedAccountHandler: ExtensionMessageHandler = (_msg, sender, respond) => {
     if (!sender.url) {
         throw new Error('Expected URL to be available for sender.');
     }
@@ -198,7 +199,10 @@ const getSelectedAccountHandler: ExtensionMessageHandler = (_msg, sender, respon
     return true;
 };
 
-bgMessageHandler.handleMessage(createMessageTypeFilter(MessageType.GetSelectedAccount), getSelectedAccountHandler);
+bgMessageHandler.handleMessage(
+    createMessageTypeFilter(MessageType.GetSelectedAccount),
+    getMostRecentlySelectedAccountHandler
+);
 
 forwardToPopup(
     MessageType.Connect,


### PR DESCRIPTION
## Purpose

Add `getSelectedAccount` to the wallet-api, and make the piggybank example use it.

## Changes

Added `getSelectedAccount` to the wallet api + handling it in the background script.
Refactor piggyBank, and use `getSelectedAccount` instead of doing unprompted connects.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.


