### PR TITLE
Reject when locked

### DIFF
--- a/packages/browser-wallet-api-helpers/README.md
+++ b/packages/browser-wallet-api-helpers/README.md
@@ -51,7 +51,7 @@ declare global {
 
 ### connect
 
-To request a connection to the wallet from the user, the `connect` method has to be invoked. The method returns a `Promise` resolving with information related to the most recently selected account, which has whitelisted the dApp, or rejecting if the request is rejected in the wallet.
+To request a connection to the wallet from the user, the `connect` method has to be invoked. The method returns a `Promise` resolving with information related to the most recently selected account, which has whitelisted the dApp, or rejecting if the request is rejected in the wallet. If the wallet is locked, then this call prompts the user to first unlock the wallet before accepting or rejecting the connection request.
 
 ```typescript
 const provider = await detectConcordiumProvider();
@@ -62,7 +62,7 @@ N.B. In the current version, if the dApp is already whitelisted, but not by the 
 
 ### getMostRecentlySelectedAccount
 
-To get the most recently selected account, or to check whether the wallet is connected without using connect, the `getMostRecentlySelectedAccount` can be invoked. The method returns a `Promise` resolving with the address of the most recently selected account in the wallet, or with undefined if there are no connected accounts in the wallet.
+To get the most recently selected account, or to check whether the wallet is connected without using connect, the `getMostRecentlySelectedAccount` can be invoked. The method returns a `Promise` resolving with the address of the most recently selected account in the wallet, or with undefined if the wallet is locked or there are no connected accounts in the wallet.
 
 ```typescript
 const provider = await detectConcordiumProvider();
@@ -80,7 +80,7 @@ N.B. In the current version, if the currently selected account has not whitelist
 
 To send a transaction, three arguments need to be provided: The account address for the account in the wallet that should sign the transaction, a transaction type and a corresponding payload. Invoking `sendTransaction` returns a `Promise`, which resolves with the transaction hash for the submitted transaction.
 
-If you have not connected with the wallet (or previously been whitelisted) or if the user rejects signing the transaction, the `Promise` will reject.
+If the wallet is locked, or you have not connected with the wallet (or previously been whitelisted) or if the user rejects signing the transaction, the `Promise` will reject.
 
 The following exemplifies how to create a simple transfer of funds from one account to another. Please note that [@concordium/web-sdk](https://github.com/Concordium/concordium-node-sdk-js/tree/main/packages/web) is used to provide the correct formats and types for the transaction payload.
 
@@ -124,7 +124,7 @@ const txHash = await provider.sendTransaction(
 
 It is possible to sign arbitrary messages using the keys for an account stored in the wallet, by invoking the `signMessage` method. The first parameter is the account to be used for signing the message. This method returns a `Promise` resolving with a signature of the message.
 
-If you have not connected with the wallet (or previously been whitelisted) or if the user rejects signing the meesage, the `Promise` will reject.
+If the wallet is locked, or you have not connected with the wallet (or previously been whitelisted) or if the user rejects signing the meesage, the `Promise` will reject.
 
 The following exemplifies requesting a signature of a message:
 

--- a/packages/browser-wallet/src/popup/pages/ConnectionRequest/ConnectionRequest.tsx
+++ b/packages/browser-wallet/src/popup/pages/ConnectionRequest/ConnectionRequest.tsx
@@ -1,9 +1,11 @@
 import { fullscreenPromptContext } from '@popup/page-layouts/FullscreenPromptLayout';
 import { selectedAccountAtom, storedConnectedSitesAtom } from '@popup/store/account';
+import { sessionPasscodeAtom } from '@popup/store/settings';
 import { useAtom, useAtomValue } from 'jotai';
 import React, { useContext, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
+import Login from '../Login/Login';
 
 type Props = {
     onAllow(): void;
@@ -17,11 +19,17 @@ export default function ConnectionRequest({ onAllow, onReject }: Props) {
     const selectedAccount = useAtomValue(selectedAccountAtom);
     const [connectedSitesLoading, setConnectedSites] = useAtom(storedConnectedSitesAtom);
     const connectedSites = connectedSitesLoading.value;
+    const passcode = useAtomValue(sessionPasscodeAtom);
 
     useEffect(() => onClose(onReject), [onClose, onReject]);
 
-    if (!selectedAccount || connectedSitesLoading.loading) {
+    if (!selectedAccount || connectedSitesLoading.loading || passcode.loading) {
         return null;
+    }
+
+    // The wallet is locked, so prompt the user to unlock the wallet before connecting.
+    if (!passcode.value) {
+        return <Login />;
     }
 
     function connectAccount(account: string, url: string) {

--- a/packages/browser-wallet/src/popup/pages/Login/Login.tsx
+++ b/packages/browser-wallet/src/popup/pages/Login/Login.tsx
@@ -6,7 +6,6 @@ import Form from '@popup/shared/Form';
 import Submit from '@popup/shared/Form/Submit';
 import FormPassword from '@popup/shared/Form/Password';
 import { useTranslation } from 'react-i18next';
-import { absoluteRoutes } from '@popup/constants/routes';
 import { useNavigate } from 'react-router-dom';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { decrypt } from '@popup/shared/crypto';
@@ -18,7 +17,7 @@ type FormValues = {
     passcode: string;
 };
 
-export default function Login() {
+export default function Login({ navigateTo }: { navigateTo?: string }) {
     const navigate = useNavigate();
     const setPasscodeInSession = useSetAtom(sessionPasscodeAtom);
     const encryptedSeedPhrase = useAtomValue(encryptedSeedPhraseAtom);
@@ -38,7 +37,9 @@ export default function Login() {
                 // TODO Replace this with an authenticated encryption scheme (AES-GCM). This is a dirty way of validating the decryption.
                 if (validateMnemonic(decryptedSeedPhrase, wordlist)) {
                     setPasscodeInSession(vs.passcode);
-                    navigate(absoluteRoutes.home.account.path);
+                    if (navigateTo) {
+                        navigate(navigateTo);
+                    }
                 } else {
                     form.setError('passcode', { message: t('incorrectPasscode') });
                 }

--- a/packages/browser-wallet/src/popup/shell/Routes.tsx
+++ b/packages/browser-wallet/src/popup/shell/Routes.tsx
@@ -107,7 +107,7 @@ export default function Routes() {
                 />
             </Route>
             <Route path={`${relativeRoutes.setup.path}/*`} element={<Setup />} />
-            <Route path={relativeRoutes.login.path} element={<Login />} />
+            <Route path={relativeRoutes.login.path} element={<Login navigateTo={absoluteRoutes.home.account.path} />} />
             <Route path={relativeRoutes.home.path} element={<MainLayout />}>
                 <Route
                     element={<IdentityIssuanceStart />}


### PR DESCRIPTION
## Purpose
Ensure that the wallet API is locked down if the wallet is locked.

## Changes
- A connect request to a locked wallet prompts the user to unlock, and then to connect.
- The JSON-RPC interface will reject if the wallet is locked.
- Sign transaction and sign message will reject if the wallet is locked. An improvement we can do later is to specifically return the reason, right now it's not possible to see if it was the user rejecting or the wallet was locked.

## Checklist
- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.