### PR TITLE
Add toast component for background errors

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -8,6 +8,7 @@
 -   Change passcode settings page.
 -   Transaction details view when clicking a transaction in the transaction list.
 -   Theme toggle button to the settings page.
+-   Toasts for showing errors when failing to retrieve account balance or transaction history.
 
 ### Changed
 

--- a/packages/browser-wallet/src/popup/page-layouts/MainLayout/AccountList/AccountList.tsx
+++ b/packages/browser-wallet/src/popup/page-layouts/MainLayout/AccountList/AccountList.tsx
@@ -2,7 +2,7 @@ import React, { forwardRef, useEffect, useState } from 'react';
 import clsx from 'clsx';
 import { useAtomValue, useAtom } from 'jotai';
 import { useNavigate } from 'react-router-dom';
-import { ClassName, displayAsCcd } from 'wallet-common-helpers';
+import { ClassName, displayAsCcd, noOp } from 'wallet-common-helpers';
 
 import CopyButton from '@popup/shared/CopyButton';
 import CheckmarkIcon from '@assets/svg/checkmark-blue.svg';
@@ -65,10 +65,12 @@ const AccountList = forwardRef<HTMLDivElement, Props>(({ className, onSelect }, 
 
     useEffect(() => {
         const emitter = new AccountInfoEmitter(jsonRpcUrl);
-        emitter.listen(accounts.map((account) => account.address));
         emitter.on('totalchanged', (accountInfo: AccountInfo, address: string) => {
             setTotalBalanceMap(new Map(totalBalanceMap.set(address, accountInfo.accountAmount)));
         });
+        // TODO Log the error instead of gobbling it.
+        emitter.on('error', noOp);
+        emitter.listen(accounts.map((account) => account.address));
         return () => {
             emitter.removeAllListeners('totalchanged');
             emitter.stop();

--- a/packages/browser-wallet/src/popup/page-layouts/MainLayout/MainLayout.tsx
+++ b/packages/browser-wallet/src/popup/page-layouts/MainLayout/MainLayout.tsx
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 
 import { absoluteRoutes } from '@popup/constants/routes';
 import { encryptedSeedPhraseAtom, sessionPasscodeAtom } from '@popup/store/settings';
+import Toast from '@popup/shared/Toast/Toast';
 import Header from './Header';
 
 export default function MainLayout() {
@@ -32,6 +33,7 @@ export default function MainLayout() {
             <main className={clsx('main-layout__main', headerOpen && 'main-layout__main--blur')}>
                 <Outlet />
             </main>
+            <Toast />
         </div>
     );
 }

--- a/packages/browser-wallet/src/popup/pages/Account/AccountDetails/AccountDetails.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/AccountDetails/AccountDetails.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx';
 import React, { useEffect, useState } from 'react';
 import { displayAsCcd, getPublicAccountAmounts, PublicAccountAmounts } from 'wallet-common-helpers';
 import { useTranslation } from 'react-i18next';
-import { useAtomValue } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
 import { identityNamesAtom } from '@popup/store/identity';
 import { networkConfigurationAtom } from '@popup/store/settings';
 
@@ -11,6 +11,7 @@ import VerifiedIcon from '@assets/svg/verified-stamp.svg';
 import { AccountInfo } from '@concordium/web-sdk';
 import { AccountInfoEmitter } from '@popup/shared/account-info-emitter';
 import { CreationStatus, WalletCredential } from '@shared/storage/types';
+import { toastAtom } from '@popup/state';
 
 type AmountProps = {
     label: string;
@@ -43,15 +44,19 @@ export default function AccountDetails({ expanded, account, className }: Props) 
     const { jsonRpcUrl } = useAtomValue(networkConfigurationAtom);
     const [balances, setBalances] = useState<Omit<PublicAccountAmounts, 'scheduled'>>(zeroBalance);
     const identityNames = useAtomValue(identityNamesAtom);
+    const setToast = useSetAtom(toastAtom);
 
     useEffect(() => {
         setBalances(zeroBalance);
         if (account.status === CreationStatus.Confirmed) {
             const emitter = new AccountInfoEmitter(jsonRpcUrl);
-            emitter.listen([account.address]);
             emitter.on('totalchanged', (accountInfo: AccountInfo) => {
                 setBalances(getPublicAccountAmounts(accountInfo));
             });
+            emitter.on('error', () => {
+                setToast(t('error'));
+            });
+            emitter.listen([account.address]);
             return () => {
                 emitter.removeAllListeners('totalchanged');
                 emitter.stop();

--- a/packages/browser-wallet/src/popup/pages/Account/TransactionLog/TransactionList.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/TransactionLog/TransactionList.tsx
@@ -4,9 +4,11 @@ import InfiniteLoader from 'react-window-infinite-loader';
 import { VariableSizeList as List } from 'react-window';
 import { noOp, PropsOf } from 'wallet-common-helpers';
 import AutoSizer from 'react-virtualized-auto-sizer';
-import { useAtomValue } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
 import { selectedAccountAtom } from '@popup/store/account';
 import { BrowserWalletTransaction } from '@popup/shared/utils/transaction-history-types';
+import { useTranslation } from 'react-i18next';
+import { toastAtom } from '@popup/state';
 import TransactionElement, { transactionElementHeight } from './TransactionElement';
 import useTransactionGroups, { TransactionsByDateTuple } from './useTransactionGroups';
 
@@ -145,10 +147,12 @@ export interface TransactionListProps {
  * Displays a list of transactions from an account's transaction history.
  */
 export default function TransactionList({ onTransactionClick }: TransactionListProps) {
+    const { t } = useTranslation('transactionLog');
     const accountAddress = useAtomValue(selectedAccountAtom);
     const [transactions, setTransactions] = useState<BrowserWalletTransaction[]>([]);
     const [isNextPageLoading, setIsNextPageLoading] = useState<boolean>(false);
     const [hasNextPage, setHasNextPage] = useState<boolean>(true);
+    const setToast = useSetAtom(toastAtom);
 
     if (!accountAddress) {
         return null;
@@ -165,10 +169,9 @@ export default function TransactionList({ onTransactionClick }: TransactionListP
                 setTransactions(updatedTransactions);
                 setIsNextPageLoading(false);
             })
-            .catch((e) => {
-                // TODO Handle exception when trying to get transactions.
+            .catch(() => {
+                setToast(t('error'));
                 setIsNextPageLoading(false);
-                throw Error(e);
             });
     }
 

--- a/packages/browser-wallet/src/popup/pages/Account/TransactionLog/i18n/da.ts
+++ b/packages/browser-wallet/src/popup/pages/Account/TransactionLog/i18n/da.ts
@@ -8,6 +8,7 @@ const t: typeof en = {
     blockHash: 'Blok hash ',
     events: 'Hændelser',
     rejectReason: 'Afvisningsårsag',
+    error: 'Fejl ved hentning af transaktionshistorik',
 };
 
 export default t;

--- a/packages/browser-wallet/src/popup/pages/Account/TransactionLog/i18n/en.ts
+++ b/packages/browser-wallet/src/popup/pages/Account/TransactionLog/i18n/en.ts
@@ -6,6 +6,7 @@ const t = {
     blockHash: 'Block hash',
     events: 'Events',
     rejectReason: 'Reject reason',
+    error: 'Unable to retrieve transaction history',
 };
 
 export default t;

--- a/packages/browser-wallet/src/popup/pages/Account/i18n/da.ts
+++ b/packages/browser-wallet/src/popup/pages/Account/i18n/da.ts
@@ -17,6 +17,7 @@ const t: typeof en = {
         total: 'Offentligt total',
         atDisposal: 'Offentligt til rådighed',
         stakeAmount: 'Stake',
+        error: 'Fejl ved hentning af kontoens balance',
     },
     settings: {
         connectedSites: {

--- a/packages/browser-wallet/src/popup/pages/Account/i18n/en.ts
+++ b/packages/browser-wallet/src/popup/pages/Account/i18n/en.ts
@@ -15,6 +15,7 @@ const t = {
         total: 'Public balance total',
         atDisposal: 'Public amount at disposal',
         stakeAmount: 'Stake / delegation amount',
+        error: 'Unable to retrieve account balance',
     },
     settings: {
         connectedSites: {

--- a/packages/browser-wallet/src/popup/shared/Toast/Toast.scss
+++ b/packages/browser-wallet/src/popup/shared/Toast/Toast.scss
@@ -1,0 +1,49 @@
+.toast {
+    visibility: hidden;
+    width: rem(220px);
+    left: 0;
+    right: 0;
+    margin: 0 auto;
+    background-color: $color-darker-grey;
+    color: $color-off-white;
+    text-align: center;
+    border-radius: rem(30px);
+    padding: rem(10px) rem(15px);
+    position: fixed;
+    z-index: 2;
+    bottom: rem(55px);
+
+    &__show {
+        visibility: visible;
+        animation: fadein 0.5s;
+    }
+
+    &__fadeout {
+        visibility: visible;
+        animation: fadeout 0.5s;
+    }
+
+    @keyframes fadein {
+        from {
+            bottom: 0;
+            opacity: 0;
+        }
+
+        to {
+            bottom: rem(55px);
+            opacity: 1;
+        }
+    }
+
+    @keyframes fadeout {
+        from {
+            bottom: rem(55px);
+            opacity: 1;
+        }
+
+        to {
+            bottom: rem(55px);
+            opacity: 0;
+        }
+    }
+}

--- a/packages/browser-wallet/src/popup/shared/Toast/Toast.tsx
+++ b/packages/browser-wallet/src/popup/shared/Toast/Toast.tsx
@@ -1,0 +1,48 @@
+import { toastsAtom } from '@popup/state';
+import clsx from 'clsx';
+import { useAtom } from 'jotai';
+import React, { useEffect, useState } from 'react';
+
+// The timeouts have to be aligned with the animations in the corresponding CSS.
+const toastTimeoutMs = 5400;
+const fadeoutTimeoutMs = 400;
+
+export default function Toast() {
+    const [toasts, setToasts] = useAtom(toastsAtom);
+    const [toastText, setToastText] = useState<string>();
+    const [fadeout, setFadeout] = useState<boolean>(false);
+
+    useEffect(() => {
+        if (!toastText && toasts.length > 0) {
+            const [nextToast, ...remainderToasts] = toasts;
+            setToastText(nextToast);
+            setToasts(remainderToasts);
+        }
+    }, [toasts, toastText]);
+
+    useEffect(() => {
+        let timeout: NodeJS.Timeout | undefined;
+        let fadeoutTimer: NodeJS.Timeout | undefined;
+
+        if (toastText) {
+            fadeoutTimer = setTimeout(() => {
+                setFadeout(true);
+                setTimeout(() => setFadeout(false), fadeoutTimeoutMs);
+            }, toastTimeoutMs - fadeoutTimeoutMs);
+
+            timeout = setTimeout(() => {
+                setToastText(undefined);
+            }, toastTimeoutMs);
+        }
+        return () => {
+            if (timeout) {
+                clearTimeout(timeout);
+            }
+            if (fadeoutTimer) {
+                clearTimeout(fadeoutTimer);
+            }
+        };
+    }, [toastText]);
+
+    return <div className={clsx('toast', toastText && 'toast__show', fadeout && 'toast__fadeout')}>{toastText}</div>;
+}

--- a/packages/browser-wallet/src/popup/shared/Toast/index.tsx
+++ b/packages/browser-wallet/src/popup/shared/Toast/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './Toast';

--- a/packages/browser-wallet/src/popup/shared/account-info-emitter.ts
+++ b/packages/browser-wallet/src/popup/shared/account-info-emitter.ts
@@ -54,9 +54,8 @@ export class AccountInfoEmitter extends EventEmitter {
                     this.emit('totalchanged', accountInfo, accountAddress);
                 }
             }
-        } catch {
-            // TODO Determine how we want to handle connection issues. I expect that we will emit
-            // on an error topic that the UI can handle.
+        } catch (e) {
+            this.emit('error', e);
         }
 
         this.interval = setInterval(async () => {
@@ -72,9 +71,8 @@ export class AccountInfoEmitter extends EventEmitter {
                         }
                     }
                 }
-            } catch {
-                // TODO Determine how we want to handle connection issues. I expect that we will emit
-                // on an error topic that the UI can handle.
+            } catch (e) {
+                this.emit('error', e);
             }
         }, accountInfoRetrievalIntervalMs);
     }

--- a/packages/browser-wallet/src/popup/state/index.ts
+++ b/packages/browser-wallet/src/popup/state/index.ts
@@ -2,3 +2,13 @@ import { atom } from 'jotai';
 
 export const passcodeAtom = atom<string | undefined>(undefined);
 export const seedPhraseAtom = atom<string | undefined>(undefined);
+
+export const toastsAtom = atom<string[]>([]);
+export const toastAtom = atom<string[], string>(
+    (get) => get(toastsAtom),
+    (get, set, newToast) => {
+        const currentToasts = get(toastsAtom);
+        const updatedToasts = [...currentToasts, newToast];
+        set(toastsAtom, updatedToasts);
+    }
+);

--- a/packages/browser-wallet/src/popup/styles/_components.scss
+++ b/packages/browser-wallet/src/popup/styles/_components.scss
@@ -13,6 +13,7 @@
 @import '../shared/Modal/Modal';
 @import '../shared/IdentityProviderIcon/IdentityProviderIcon';
 @import '../shared/SidedRow/SidedRow';
+@import '../shared/Toast/Toast';
 
 // Pages
 @import '../pages/Account';

--- a/packages/browser-wallet/src/popup/styles/config/_colors.scss
+++ b/packages/browser-wallet/src/popup/styles/config/_colors.scss
@@ -3,6 +3,7 @@ $color-white: #fff;
 $color-off-white: #fbfbf9;
 $color-black: #000;
 $color-off-black: #181817;
+$color-darker-grey: #727272;
 $color-grey: #979797;
 $color-red: #ff4d4d;
 $color-green: #4ac29e;
@@ -65,9 +66,6 @@ $color-transaction-group-header-text: var(
 $color-main-header: var(--color-main-header, $color-main-header-light);
 $color-input-bg: var(--color-input-bg, $color-input-bg-light);
 $color-text-inverted: $color-bg;
-$color-highlight-mainnet: var(--color-highlight-mainnet, $color-highlight-mainnet-light);
-$color-highlight-testnet: var(--color-highlight-testnet, $color-highlight-testnet-light);
-$color-highlight: var(--color-highlight, $color-highlight-testnet);
 $color-highlight-mainnet: var(--color-highlight-mainnet, $color-highlight-mainnet-light);
 $color-highlight-testnet: var(--color-highlight-testnet, $color-highlight-testnet-light);
 $color-highlight: var(--color-highlight, $color-highlight-testnet);


### PR DESCRIPTION
## Purpose
Showing error messages for background activity, e.g. fetching account balances and transaction history which do not require user input.

## Changes
- Added a Toast component that holds a "queue" of messages that will be shown.
- Show toast error message when fetching account balance fetching or transaction history fails.
- Cleaned up duplicate definitions in CSS>

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.