### PR TITLE
Only search address field when searching accounts

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+-   Account search now only searches on the account address field.
+
 ## 0.4.0
 
 ### Added

--- a/packages/browser-wallet/src/popup/page-layouts/MainLayout/AccountList/AccountList.tsx
+++ b/packages/browser-wallet/src/popup/page-layouts/MainLayout/AccountList/AccountList.tsx
@@ -89,6 +89,7 @@ const AccountList = forwardRef<HTMLDivElement, Props>(({ className, onSelect }, 
             getKey={(a) => a.address}
             newText={t('accountList.new')}
             ref={ref}
+            searchableKeys={['address']}
         >
             {(a, checked) => (
                 <AccountListItem


### PR DESCRIPTION
## Purpose
When a user searched for accounts it would give what looked like faulty results as it searched all fields on a credential. It is now restricted to only searching on the address. When we add naming to accounts that field should be searched.

## Changes
- Use searchable key when searching for accounts, set to the account address.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.