### PR TITLE
Re-lock export of private key on account change

### DIFF
--- a/packages/browser-wallet/src/popup/pages/Account/AccountSettings/ExportPrivateKey.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/AccountSettings/ExportPrivateKey.tsx
@@ -8,7 +8,7 @@ import { usePrivateKey } from '@popup/shared/utils/account-helpers';
 import { selectedAccountAtom } from '@popup/store/account';
 import { sessionPasscodeAtom } from '@popup/store/settings';
 import { useAtomValue } from 'jotai';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Validate } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
@@ -31,6 +31,10 @@ export default function ExportPrivateKey() {
     if (!privateKey) {
         return null;
     }
+
+    useEffect(() => {
+        setShowPrivateKey(false);
+    }, [selectedAccountAddress]);
 
     const handleSubmit = () => {
         setShowPrivateKey(true);


### PR DESCRIPTION
## Purpose
Ensure that the user has to re-enter the password for the wallet if switching account while exporting private keys.

## Changes
- Stop showing the private key if the selected account address changes.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.