### PR TITLE
Listen for identity and account status onInstalled

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 -   Account search now only searches on the account address field.
+-   Identities and accounts statuses are now resolved correctly on first installation of the wallet, without requiring a restart.
 
 ## 0.4.0
 

--- a/packages/browser-wallet/src/background/index.ts
+++ b/packages/browser-wallet/src/background/index.ts
@@ -94,6 +94,7 @@ const injectScript: ExtensionMessageHandler = (_msg, sender, respond) => {
 };
 
 chrome.runtime.onStartup.addListener(startupHandler);
+chrome.runtime.onInstalled.addListener(startupHandler);
 
 bgMessageHandler.handleMessage(
     createMessageTypeFilter(InternalMessageType.SendCredentialDeployment),


### PR DESCRIPTION
## Purpose
Fix an issue where the wallet did not listen for the status of identities and accounts on installation.

## Changes
- Run startup listener on `onInstalled` event.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.