### PR TITLE
Update checks for creating identity and account in background script

### DIFF
--- a/packages/browser-wallet/src/background/credential-deployment.ts
+++ b/packages/browser-wallet/src/background/credential-deployment.ts
@@ -14,38 +14,42 @@ import { BackgroundResponseStatus, CredentialDeploymentBackgroundResponse } from
 import { addCredential } from './update';
 
 async function createAndSendCredential(credIn: CredentialInputV1): Promise<CredentialDeploymentBackgroundResponse> {
-    const network = await storedCurrentNetwork.get();
-    const url = network?.jsonRpcUrl;
-    if (!url) {
-        throw new Error('No JSON RPC url available');
+    let address: string;
+    try {
+        const network = await storedCurrentNetwork.get();
+        const url = network?.jsonRpcUrl;
+        if (!url) {
+            throw new Error('No JSON RPC url available');
+        }
+
+        const request = createCredentialV1(credIn);
+        const { credId } = request.cdi;
+        const deploymentHash = getSignedCredentialDeploymentTransactionHash(request);
+        address = getAccountAddress(credId).address;
+        const newCred: PendingWalletCredential = {
+            address,
+            identityIndex: credIn.identityIndex,
+            providerIndex: credIn.ipInfo.ipIdentity,
+            credId,
+            credNumber: credIn.credNumber,
+            status: CreationStatus.Pending,
+            deploymentHash,
+        };
+
+        // Send Request
+        const successful = await new JsonRpcClient(new HttpProvider(url, fetch)).sendCredentialDeployment(request);
+        if (!successful) {
+            throw new Error('Credential deployment was rejected');
+        }
+
+        // Add Pending
+        await addCredential(newCred);
+        // Set Selected to new account
+        await storedSelectedAccount.set(address);
+    } finally {
+        // Remove guard stopping another credential being created
+        await sessionCreatingCredential.set(false);
     }
-
-    const request = createCredentialV1(credIn);
-    const { credId } = request.cdi;
-    const deploymentHash = getSignedCredentialDeploymentTransactionHash(request);
-    const { address } = getAccountAddress(credId);
-    const newCred: PendingWalletCredential = {
-        address,
-        identityIndex: credIn.identityIndex,
-        providerIndex: credIn.ipInfo.ipIdentity,
-        credId,
-        credNumber: credIn.credNumber,
-        status: CreationStatus.Pending,
-        deploymentHash,
-    };
-
-    // Send Request
-    const successful = await new JsonRpcClient(new HttpProvider(url, fetch)).sendCredentialDeployment(request);
-    if (!successful) {
-        throw new Error('Credential deployment was rejected');
-    }
-
-    // Add Pending
-    await addCredential(newCred);
-    // Set Selected to new account
-    await storedSelectedAccount.set(address);
-    // Remove guard stopping another credential being created
-    await sessionCreatingCredential.set(false);
 
     return {
         status: BackgroundResponseStatus.Success,

--- a/packages/browser-wallet/src/background/credential-deployment.ts
+++ b/packages/browser-wallet/src/background/credential-deployment.ts
@@ -8,7 +8,7 @@ import {
     getSignedCredentialDeploymentTransactionHash,
     JsonRpcClient,
 } from '@concordium/web-sdk';
-import { storedCurrentNetwork } from '@shared/storage/access';
+import { sessionCreatingCredential, storedCurrentNetwork, storedSelectedAccount } from '@shared/storage/access';
 import { CreationStatus, PendingWalletCredential } from '@shared/storage/types';
 import { BackgroundResponseStatus, CredentialDeploymentBackgroundResponse } from '@shared/utils/types';
 import { addCredential } from './update';
@@ -42,6 +42,10 @@ async function createAndSendCredential(credIn: CredentialInputV1): Promise<Crede
 
     // Add Pending
     await addCredential(newCred);
+    // Set Selected to new account
+    await storedSelectedAccount.set(address);
+    // Remove guard stopping another credential being created
+    await sessionCreatingCredential.set(false);
 
     return {
         status: BackgroundResponseStatus.Success,

--- a/packages/browser-wallet/src/background/identity-issuance.ts
+++ b/packages/browser-wallet/src/background/identity-issuance.ts
@@ -74,6 +74,7 @@ export const identityIssuanceHandler: ExtensionMessageHandler = (msg) => {
                     status: CreationStatus.Pending,
                     location: response.result,
                 });
+                await sessionPendingIdentity.remove();
             }
         }
         await openWindow();

--- a/packages/browser-wallet/src/popup/pages/AddAccount/Confirm.tsx
+++ b/packages/browser-wallet/src/popup/pages/AddAccount/Confirm.tsx
@@ -4,7 +4,7 @@ import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { useNavigate } from 'react-router-dom';
 import IdCard from '@popup/shared/IdCard';
 import { identityProvidersAtom, selectedIdentityAtom } from '@popup/store/identity';
-import { credentialsAtom, selectedAccountAtom, creatingCredentialRequestAtom } from '@popup/store/account';
+import { credentialsAtom, creatingCredentialRequestAtom } from '@popup/store/account';
 import { networkConfigurationAtom, seedPhraseAtom } from '@popup/store/settings';
 import { CreationStatus, WalletCredential } from '@shared/storage/types';
 import { JsonRpcClient, HttpProvider } from '@concordium/web-sdk';
@@ -25,7 +25,6 @@ export default function Confirm() {
     const nav = useNavigate();
     const selectedIdentity = useAtomValue(selectedIdentityAtom);
     const credentials = useAtomValue(credentialsAtom);
-    const setSelectedAccount = useSetAtom(selectedAccountAtom);
     const seedPhrase = useAtomValue(seedPhraseAtom);
     const network = useAtomValue(networkConfigurationAtom);
     const providers = useAtomValue(identityProvidersAtom);
@@ -88,7 +87,6 @@ export default function Confirm() {
             );
 
             if (response.status === BackgroundResponseStatus.Success) {
-                setSelectedAccount(response.address);
                 nav(absoluteRoutes.home.account.path);
             } else {
                 addToast(response.error);

--- a/packages/browser-wallet/src/popup/pages/IdentityIssuance/IdentityIssuanceEnd.tsx
+++ b/packages/browser-wallet/src/popup/pages/IdentityIssuance/IdentityIssuanceEnd.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useContext, useMemo } from 'react';
-import { useAtom, useAtomValue, useSetAtom } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
 import {
-    pendingIdentityAtom,
     identityProvidersAtom,
     selectedIdentityAtom,
     selectedIdentityIndexAtom,
@@ -35,7 +34,6 @@ export default function IdentityIssuanceEnd({ onFinish }: Props) {
     const { state } = useLocation() as Location;
     const { t } = useTranslation('identityIssuance');
     const providers = useAtomValue(identityProvidersAtom);
-    const [pendingIdentity, setPendingIdentity] = useAtom(pendingIdentityAtom);
     const { withClose, onClose } = useContext(fullscreenPromptContext);
     const selectedIdentity = useAtomValue(selectedIdentityAtom);
     const identities = useAtomValue(identitiesAtom);
@@ -49,11 +47,10 @@ export default function IdentityIssuanceEnd({ onFinish }: Props) {
     useEffect(() => onClose(onFinish), [onClose, onFinish]);
 
     useEffect(() => {
-        if (pendingIdentity && identities.length) {
+        if (identities.length) {
             setSelectedIdentityIndex(identities.length - 1);
-            setPendingIdentity(undefined);
         }
-    }, [pendingIdentity, identities.length]);
+    }, [identities.length]);
 
     return (
         <>
@@ -72,9 +69,9 @@ export default function IdentityIssuanceEnd({ onFinish }: Props) {
                         <p className="identity-issuance__text">{t('successExplanation')}</p>
                         <IdCard
                             className="identity-issuance__card"
-                            name={pendingIdentity?.name || selectedIdentity?.name || 'Identity'}
+                            name={selectedIdentity?.name || 'Identity'}
                             provider={<IdentityProviderIcon provider={identityProvider} />}
-                            status={pendingIdentity?.status || selectedIdentity?.status || CreationStatus.Pending}
+                            status={selectedIdentity?.status || CreationStatus.Pending}
                         />
                     </>
                 )}

--- a/packages/browser-wallet/src/popup/shared/AccountInfoListenerContext/AccountInfoListenerContext.tsx
+++ b/packages/browser-wallet/src/popup/shared/AccountInfoListenerContext/AccountInfoListenerContext.tsx
@@ -15,8 +15,7 @@ import { AccountInfoListener } from '../account-info-listener';
 export const accountInfoAtom = atomWithChromeStorage<Record<string, string>>(
     ChromeStorageKey.AccountInfoCache,
     {},
-    false,
-    true
+    false
 );
 export const AccountInfoListenerContext = createContext<AccountInfoListener | undefined>(undefined);
 

--- a/packages/browser-wallet/src/popup/store/account.ts
+++ b/packages/browser-wallet/src/popup/store/account.ts
@@ -6,12 +6,11 @@ import { ChromeStorageKey, WalletCredential } from '@shared/storage/types';
 import { EventType } from '@concordium/browser-wallet-api-helpers';
 import { atomWithChromeStorage } from './utils';
 
-export const credentialsAtom = atomWithChromeStorage<WalletCredential[]>(ChromeStorageKey.Credentials, [], false, true);
+export const credentialsAtom = atomWithChromeStorage<WalletCredential[]>(ChromeStorageKey.Credentials, [], false);
 
 export const storedConnectedSitesAtom = atomWithChromeStorage<Record<string, string[]>>(
     ChromeStorageKey.ConnectedSites,
     {},
-    true,
     true
 );
 

--- a/packages/browser-wallet/src/popup/store/identity.ts
+++ b/packages/browser-wallet/src/popup/store/identity.ts
@@ -3,7 +3,7 @@ import { atom } from 'jotai';
 import { selectAtom } from 'jotai/utils';
 import { atomWithChromeStorage } from './utils';
 
-export const identitiesAtom = atomWithChromeStorage<Identity[]>(ChromeStorageKey.Identities, [], false, true);
+export const identitiesAtom = atomWithChromeStorage<Identity[]>(ChromeStorageKey.Identities, [], false);
 export const pendingIdentityAtom = atomWithChromeStorage<Omit<PendingIdentity, 'location'> | undefined>(
     ChromeStorageKey.PendingIdentity,
     undefined

--- a/packages/browser-wallet/src/popup/store/utils.ts
+++ b/packages/browser-wallet/src/popup/store/utils.ts
@@ -60,7 +60,7 @@ export function atomWithChromeStorage<V>(
  * @description
  * Create an atom that automatically syncs with chrome local storage.
  */
-export function atomWithChromeStorage<V>(key: ChromeStorageKey, fallback: V, withLoading = false, withSync = false) {
+export function atomWithChromeStorage<V>(key: ChromeStorageKey, fallback: V, withLoading = false, withSync = true) {
     const accessor = accessorMap[key] as unknown as StorageAccessor<V>;
 
     if (accessor === undefined) {

--- a/packages/browser-wallet/src/shared/storage/access.ts
+++ b/packages/browser-wallet/src/shared/storage/access.ts
@@ -129,7 +129,7 @@ export const sessionPendingIdentity = makeStorageAccessor<Omit<PendingIdentity, 
     'session',
     ChromeStorageKey.PendingIdentity
 );
-export const sessionCreatingCredential = makeStorageAccessor<string>('session', ChromeStorageKey.IsCreatingCredential);
+export const sessionCreatingCredential = makeStorageAccessor<boolean>('session', ChromeStorageKey.IsCreatingCredential);
 export const sessionAccountInfoCache = makeIndexedStorageAccessor<Record<string, string>>(
     'session',
     ChromeStorageKey.AccountInfoCache


### PR DESCRIPTION
## Purpose

Ensure that the checks that prevents duplicate account/identity creation is set in the background script.

## Changes

Move the update of the checks from popup to background.
Set atomsWithStorage to have sync as default.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
