### PR TITLE
Fix getCurrentOpenTabUrl throwing error

### DIFF
--- a/packages/browser-wallet/src/popup/pages/Account/Account.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/Account.tsx
@@ -6,6 +6,7 @@ import { accountsAtom } from '@popup/store/account';
 import MenuButton from '@popup/shared/MenuButton';
 import { useSelectedCredential } from '@popup/shared/utils/account-helpers';
 import { CreationStatus } from '@shared/storage/types';
+import { useCurrentOpenTabUrl } from '@popup/shared/utils/tabs';
 import { accountRoutes } from './routes';
 import { accountSettingsRoutes } from './AccountSettings/routes';
 import AccountActions from './AccountActions';
@@ -25,6 +26,7 @@ function Account({
 }) {
     const { t } = useTranslation('account');
     const accounts = useAtomValue(accountsAtom);
+    const currentUrl = useCurrentOpenTabUrl();
 
     const selectedCred = useSelectedCredential();
 
@@ -44,6 +46,7 @@ function Account({
                             />
                             <AccountDetails expanded={detailsExpanded} account={selectedCred} />
                             <ConnectedBox
+                                url={currentUrl}
                                 link={`${accountRoutes.settings}/${accountSettingsRoutes.connectedSites}`}
                                 onNavigate={() => setDetailsExpanded(false)}
                                 accountAddress={selectedCred.address}

--- a/packages/browser-wallet/src/popup/pages/Account/AccountSettings/ConnectedSites.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/AccountSettings/ConnectedSites.tsx
@@ -1,11 +1,11 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { useAtom, useAtomValue } from 'jotai';
 import { selectedAccountAtom, storedConnectedSitesAtom } from '@popup/store/account';
 import Button from '@popup/shared/Button';
 import { useTranslation } from 'react-i18next';
 import { popupMessageHandler } from '@popup/shared/message-handler';
 import { EventType } from '@concordium/browser-wallet-api-helpers';
-import { getCurrentOpenTabUrl } from '@popup/shared/utils/tabs';
+import { useCurrentOpenTabUrl } from '@popup/shared/utils/tabs';
 import { displayUrl } from '@popup/shared/utils/string-helpers';
 
 export default function ConnectedSites() {
@@ -13,11 +13,7 @@ export default function ConnectedSites() {
     const selectedAccount = useAtomValue(selectedAccountAtom);
     const [connectedSitesLoading, setConnectedSites] = useAtom(storedConnectedSitesAtom);
     const connectedSites = connectedSitesLoading.value;
-    const [openTabUrl, setOpenTabUrl] = useState<string>();
-
-    useEffect(() => {
-        getCurrentOpenTabUrl().then(setOpenTabUrl);
-    }, []);
+    const openTabUrl = useCurrentOpenTabUrl();
 
     if (!selectedAccount || !openTabUrl) {
         return null;

--- a/packages/browser-wallet/src/popup/pages/Account/ConnectedBox.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/ConnectedBox.tsx
@@ -3,12 +3,11 @@ import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { storedConnectedSitesAtom } from '@popup/store/account';
-import { getCurrentOpenTabUrl } from '@popup/shared/utils/tabs';
 import clsx from 'clsx';
 
 type Props = {
     accountAddress?: string;
-    getUrl?: () => Promise<string>;
+    url?: string;
 } & (
     | { link: string; onNavigate?: () => void }
     | {
@@ -17,21 +16,17 @@ type Props = {
       }
 );
 
-export default function ConnectedBox({ accountAddress, getUrl = getCurrentOpenTabUrl, link, onNavigate }: Props) {
+export default function ConnectedBox({ accountAddress, url, link, onNavigate }: Props) {
     const { t } = useTranslation('account');
     const connectedSites = useAtomValue(storedConnectedSitesAtom);
     const [isConnectedToSite, setIsConnectedToSite] = useState<boolean>();
 
     useMemo(() => {
-        if (accountAddress && !connectedSites.loading) {
-            getUrl().then((url) => {
-                if (url) {
-                    const connectedSitesForAccount = connectedSites.value[accountAddress] ?? [];
-                    setIsConnectedToSite(connectedSitesForAccount.includes(url));
-                }
-            });
+        if (accountAddress && !connectedSites.loading && url) {
+            const connectedSitesForAccount = connectedSites.value[accountAddress] ?? [];
+            setIsConnectedToSite(connectedSitesForAccount.includes(url));
         }
-    }, [accountAddress, connectedSites]);
+    }, [accountAddress, connectedSites, url]);
 
     if (!link) {
         return (

--- a/packages/browser-wallet/src/popup/pages/SendTransaction/SendTransaction.tsx
+++ b/packages/browser-wallet/src/popup/pages/SendTransaction/SendTransaction.tsx
@@ -93,7 +93,7 @@ export default function SendTransaction({ onSubmit, onReject }: Props) {
 
     return (
         <>
-            <ConnectedBox accountAddress={accountAddress} getUrl={() => Promise.resolve(new URL(url).origin)} />
+            <ConnectedBox accountAddress={accountAddress} url={new URL(url).origin} />
             <div className="h-full flex-column align-center">
                 <div>{t('description', { dApp: displayUrl(url) })}</div>
                 <TransactionReceipt

--- a/packages/browser-wallet/src/popup/pages/SignMessage/SignMessage.tsx
+++ b/packages/browser-wallet/src/popup/pages/SignMessage/SignMessage.tsx
@@ -43,7 +43,7 @@ export default function SignMessage({ onSubmit, onReject }: Props) {
 
     return (
         <>
-            <ConnectedBox accountAddress={accountAddress} getUrl={() => Promise.resolve(new URL(url).origin)} />
+            <ConnectedBox accountAddress={accountAddress} url={new URL(url).origin} />
             <div className="h-full flex-column align-center">
                 <div>{t('description', { dApp: displayUrl(url) })}</div>
                 <TextArea className="m-v-20 w-full flex-child-fill" value={state.payload.message} />

--- a/packages/browser-wallet/src/popup/shared/utils/tabs.ts
+++ b/packages/browser-wallet/src/popup/shared/utils/tabs.ts
@@ -22,8 +22,8 @@ export function useCurrentOpenTabUrl(): string | undefined {
 
     useEffect(() => {
         const listener = (_tabId: number, _changeInfo: unknown, tab: chrome.tabs.Tab) => {
-            if (tab.active) {
-                setUrl(tab.url && new URL(tab.url).origin);
+            if (tab.active && tab.url) {
+                setUrl(new URL(tab.url).origin);
             }
         };
         chrome.tabs.onUpdated.addListener(listener);

--- a/packages/browser-wallet/src/popup/shared/utils/tabs.ts
+++ b/packages/browser-wallet/src/popup/shared/utils/tabs.ts
@@ -1,14 +1,34 @@
+import { useEffect, useState } from 'react';
+
 /**
  * Retrieves the URL of the tab that is currently open.
  * @returns the URL origin, as a string, of the tab that is currently open
  */
-export async function getCurrentOpenTabUrl(): Promise<string> {
+export async function getCurrentOpenTabUrl(): Promise<string | undefined> {
     const tabs = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
-    const { url } = tabs[0];
+    const url = tabs[0]?.url;
     if (!url) {
-        throw new Error(
-            'The URL was not available from the tab. This only happens if the manifest does not include the <tabs> permission.'
-        );
+        return undefined;
     }
     return new URL(url).origin;
+}
+
+export function useCurrentOpenTabUrl(): string | undefined {
+    const [url, setUrl] = useState<string>();
+
+    useEffect(() => {
+        getCurrentOpenTabUrl().then(setUrl);
+    }, []);
+
+    useEffect(() => {
+        const listener = (_tabId: number, _changeInfo: unknown, tab: chrome.tabs.Tab) => {
+            if (tab.active) {
+                setUrl(tab.url && new URL(tab.url).origin);
+            }
+        };
+        chrome.tabs.onUpdated.addListener(listener);
+        return () => chrome.tabs.onUpdated.removeListener(listener);
+    }, []);
+
+    return url;
 }


### PR DESCRIPTION
## Purpose

Ensured that getCurrentOpenTabUrl doesn't throw an error.

## Changes

Now getCurrentOpenTabUrl return undefined if there is no tab.
 + added a hook for gettting the current url.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
