### PR TITLE
Ensure that bigints in accountInfo are not converted to numbers

### DIFF
--- a/packages/browser-wallet/package.json
+++ b/packages/browser-wallet/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/browser-wallet",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "description": "Browser extensions wallet for the Concordium blockchain",
     "author": "Concordium",
     "license": "Apache",

--- a/packages/browser-wallet/package.json
+++ b/packages/browser-wallet/package.json
@@ -36,7 +36,7 @@
         "react-window": "^1.8.7",
         "react-window-infinite-loader": "^1.0.8",
         "uuid": "^8.3.2",
-        "wallet-common-helpers": "https://github.com/Concordium/concordium-wallet-common-helpers.git#fbcc45df74e4762a2f3eef986bc9445ee5d90063"
+        "wallet-common-helpers": "https://github.com/Concordium/concordium-wallet-common-helpers.git#ec7dbd18f8fc0666087887c15455a834593d9bca"
     },
     "devDependencies": {
         "@babel/core": "^7.18.2",

--- a/packages/browser-wallet/package.json
+++ b/packages/browser-wallet/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/browser-wallet",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "description": "Browser extensions wallet for the Concordium blockchain",
     "author": "Concordium",
     "license": "Apache",

--- a/packages/browser-wallet/src/popup/shared/AccountInfoListenerContext/AccountInfoListenerContext.tsx
+++ b/packages/browser-wallet/src/popup/shared/AccountInfoListenerContext/AccountInfoListenerContext.tsx
@@ -2,10 +2,9 @@ import { AccountAddress, AccountInfo, HttpProvider, JsonRpcClient } from '@conco
 import { networkConfigurationAtom } from '@popup/store/settings';
 import { useAtomValue, useSetAtom } from 'jotai';
 import React, { createContext, ReactNode, useContext, useEffect, useMemo, useState } from 'react';
-import JSONBig from 'json-bigint';
 import { atomWithChromeStorage } from '@popup/store/utils';
 import { ChromeStorageKey, CreationStatus, WalletCredential } from '@shared/storage/types';
-import { noOp } from 'wallet-common-helpers';
+import { noOp, parse, stringify } from 'wallet-common-helpers';
 import { addToastAtom } from '@popup/state';
 import { useTranslation } from 'react-i18next';
 import { getGenesisHash, sessionAccountInfoCache, useIndexedStorage } from '@shared/storage/access';
@@ -67,7 +66,7 @@ export function useAccountInfo(account: WalletCredential): AccountInfo | undefin
 
     useEffect(() => {
         if (accountInfoCache[address]) {
-            setAccountInfo(JSONBig.parse(accountInfoCache[address]));
+            setAccountInfo(parse(accountInfoCache[address]));
         } else if (account.status === CreationStatus.Confirmed) {
             const client = new JsonRpcClient(new HttpProvider(jsonRpcUrl));
             client
@@ -81,7 +80,7 @@ export function useAccountInfo(account: WalletCredential): AccountInfo | undefin
                                     accountInfoCacheLock,
                                     useIndexedStorage(sessionAccountInfoCache, getGenesisHash),
                                     newAccountInfo.accountAddress,
-                                    JSONBig.stringify(newAccountInfo)
+                                    stringify(newAccountInfo)
                                 );
                             }
                         })

--- a/packages/browser-wallet/src/popup/shared/account-info-listener.ts
+++ b/packages/browser-wallet/src/popup/shared/account-info-listener.ts
@@ -4,7 +4,7 @@ import { NetworkConfiguration } from '@shared/storage/types';
 import { accountInfoCacheLock, updateRecord } from '@shared/storage/update';
 
 import EventEmitter from 'events';
-import JSONBig from 'json-bigint';
+import { stringify } from 'wallet-common-helpers';
 
 const accountInfoRetrievalIntervalMs = 15000;
 
@@ -56,7 +56,7 @@ export class AccountInfoListener extends EventEmitter {
                                 accountInfoCacheLock,
                                 useIndexedStorage(sessionAccountInfoCache, async () => this.genesisHash),
                                 accountInfo.accountAddress,
-                                JSONBig.stringify(accountInfo)
+                                stringify(accountInfo)
                             );
                         }
                     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1975,7 +1975,7 @@ __metadata:
     tsconfig-paths-webpack-plugin: ^3.5.2
     typescript: ^4.3.5
     uuid: ^8.3.2
-    wallet-common-helpers: "https://github.com/Concordium/concordium-wallet-common-helpers.git#fbcc45df74e4762a2f3eef986bc9445ee5d90063"
+    wallet-common-helpers: "https://github.com/Concordium/concordium-wallet-common-helpers.git#ec7dbd18f8fc0666087887c15455a834593d9bca"
   languageName: unknown
   linkType: soft
 
@@ -19444,9 +19444,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wallet-common-helpers@https://github.com/Concordium/concordium-wallet-common-helpers.git#fbcc45df74e4762a2f3eef986bc9445ee5d90063":
+"wallet-common-helpers@https://github.com/Concordium/concordium-wallet-common-helpers.git#ec7dbd18f8fc0666087887c15455a834593d9bca":
   version: 1.5.0
-  resolution: "wallet-common-helpers@https://github.com/Concordium/concordium-wallet-common-helpers.git#commit=fbcc45df74e4762a2f3eef986bc9445ee5d90063"
+  resolution: "wallet-common-helpers@https://github.com/Concordium/concordium-wallet-common-helpers.git#commit=ec7dbd18f8fc0666087887c15455a834593d9bca"
   dependencies:
     "@concordium/common-sdk": ^2.3.2
     buffer: ^6.0.3
@@ -19457,7 +19457,7 @@ __metadata:
   peerDependencies:
     react: ">=16"
     react-dom: ">=16"
-  checksum: 1640a19b56ff504c76e3a31c7566a076dd46c3b7bfc4aa9c747e614f921683e61c44dce2bdfbfb91b2a81bd876ebd46175eed1d93eea5a23bf4fdeffe51d09c9
+  checksum: b737803f80d3635877cffdb68f927e52ce22641b41acfc937b647ac05d697dd5956268178772348dfc38a9072b14f38492144694e8b72209f47236e4e92b3bfa
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Purpose

Fix crashing account view
(also merges 0.5.0 bump into main)

## Changes

Use out internal json stringify/parse functions for accountInfo to not corrupt bigints.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
