### PR TITLE
Fix issue with wrong account info

### DIFF
--- a/packages/browser-wallet/src/popup/shared/AccountInfoListenerContext/AccountInfoListenerContext.tsx
+++ b/packages/browser-wallet/src/popup/shared/AccountInfoListenerContext/AccountInfoListenerContext.tsx
@@ -64,6 +64,10 @@ export function useAccountInfo(account: WalletCredential): AccountInfo | undefin
     const [accountInfo, setAccountInfo] = useState<AccountInfo>();
 
     useEffect(() => {
+        setAccountInfo(undefined);
+    }, [genesisHash, address]);
+
+    useEffect(() => {
         if (accountInfoCache[address]) {
             setAccountInfo(parse(accountInfoCache[address]));
         } else if (account.status === CreationStatus.Confirmed) {
@@ -87,7 +91,7 @@ export function useAccountInfo(account: WalletCredential): AccountInfo | undefin
                 })
                 .catch(() => addToast(t('account.error')));
         }
-    }, [genesisHash, address, accountInfoCache[address]]);
+    }, [genesisHash, address, accountInfoCache[address], account.status]);
 
     useEffect(() => {
         if (account.status === CreationStatus.Confirmed && accountInfoEmitter) {


### PR DESCRIPTION
## Purpose
Fix an issue where the account info from a wrong account was used to display a balance.

## Changes
- Reset account info on genesis change or address change.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.