### PR TITLE
Fix recovery from settings crashing when there is an error

### DIFF
--- a/packages/browser-wallet/package.json
+++ b/packages/browser-wallet/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/browser-wallet",
-    "version": "0.6.1",
+    "version": "0.6.2",
     "description": "Browser extensions wallet for the Concordium blockchain",
     "author": "Concordium",
     "license": "Apache",

--- a/packages/browser-wallet/src/popup/pages/Recovery/RecoveryMain.tsx
+++ b/packages/browser-wallet/src/popup/pages/Recovery/RecoveryMain.tsx
@@ -25,21 +25,21 @@ export default function RecoveryMain() {
     const onError = useCallback(
         (reason: string) =>
             navigate(absoluteRoutes.prompt.recovery.path, {
-                state: { status: BackgroundResponseStatus.Error, reason },
+                state: { payload: { status: BackgroundResponseStatus.Error, reason } },
             }),
         []
     );
 
     useEffect(() => {
-        if (runRecovery && !providers.length) {
+        if (runRecovery && !providers.length && seedPhrase.state === 'hasData') {
             getIdentityProviders()
                 .then(setProviders)
                 .catch(() => onError('Unable to get list of identity providers'));
         }
-    });
+    }, [runRecovery, providers.length, seedPhrase.state]);
 
     useEffect(() => {
-        if (!runRecovery || isRecovering.loading || !providers.length) {
+        if (!runRecovery || isRecovering.loading || !providers.length || seedPhrase.state === 'loading') {
             return;
         }
 
@@ -49,7 +49,11 @@ export default function RecoveryMain() {
             return;
         }
 
-        if (!seedPhrase || seedPhrase.state !== 'hasData') {
+        if (seedPhrase.state === 'hasError') {
+            onError('An Error occurred loading the seed phrase');
+            return;
+        }
+        if (!seedPhrase.data) {
             onError('Seed phrase was not loaded.');
             return;
         }
@@ -65,7 +69,7 @@ export default function RecoveryMain() {
                 });
             })
             .catch((error) => onError(error.message));
-    }, [runRecovery, isRecovering.loading, isRecovering.value, providers.length]);
+    }, [runRecovery, isRecovering.loading, isRecovering.value, providers.length, seedPhrase.state]);
 
     return (
         <>

--- a/packages/browser-wallet/src/popup/shared/utils/seedPhrase-helpers.ts
+++ b/packages/browser-wallet/src/popup/shared/utils/seedPhrase-helpers.ts
@@ -1,0 +1,29 @@
+import { Buffer } from 'buffer/';
+import { useAtomValue } from 'jotai';
+import { encryptedSeedPhraseAtom, sessionPasscodeAtom } from '@popup/store/settings';
+import { noOp, useAsyncMemo } from 'wallet-common-helpers';
+import { mnemonicToSeedSync } from '@scure/bip39';
+import { decrypt } from '../crypto';
+
+export function useDecryptedSeedPhrase(onError: (e: Error) => void = noOp) {
+    const encryptedSeed = useAtomValue(encryptedSeedPhraseAtom);
+    const passcode = useAtomValue(sessionPasscodeAtom);
+
+    const seed = useAsyncMemo(
+        async () => {
+            if (encryptedSeed.loading || passcode.loading) {
+                return undefined;
+            }
+            if (encryptedSeed.value && passcode.value) {
+                return Buffer.from(mnemonicToSeedSync(await decrypt(encryptedSeed.value, passcode.value))).toString(
+                    'hex'
+                );
+            }
+            throw new Error('SeedPhrase should not be retrieved without unlocking the wallet.');
+        },
+        onError,
+        []
+    );
+
+    return seed;
+}

--- a/packages/browser-wallet/src/popup/store/settings.ts
+++ b/packages/browser-wallet/src/popup/store/settings.ts
@@ -1,12 +1,9 @@
-import { Buffer } from 'buffer/';
 import { ChromeStorageKey, EncryptedData, NetworkConfiguration, Theme } from '@shared/storage/types';
 import { atom } from 'jotai';
 import { EventType } from '@concordium/browser-wallet-api-helpers';
 import { popupMessageHandler } from '@popup/shared/message-handler';
-import { decrypt } from '@popup/shared/crypto';
-import { mnemonicToSeedSync } from '@scure/bip39';
 import { mainnet } from '@popup/pages/NetworkSettings/NetworkSettings';
-import { loadable, selectAtom } from 'jotai/utils';
+import { selectAtom } from 'jotai/utils';
 import { HttpProvider, JsonRpcClient } from '@concordium/web-sdk';
 import { storedCredentials } from '@shared/storage/access';
 import { atomWithChromeStorage } from './utils';
@@ -46,20 +43,3 @@ export const sessionPasscodeAtom = atomWithChromeStorage<string | undefined>(
     undefined,
     true
 );
-
-const internalSeedPhraseAtom = atom<Promise<string>, never>(
-    async (get) => {
-        const seed = get(encryptedSeedPhraseAtom).value;
-        const passcode = get(sessionPasscodeAtom).value;
-
-        if (seed && passcode) {
-            return Buffer.from(mnemonicToSeedSync(await decrypt(seed, passcode))).toString('hex');
-        }
-        throw new Error('SeedPhrase should not be retrieved without unlocking the wallet.');
-    },
-    () => {
-        throw new Error('Setting the seedPhrase directly is not supported');
-    }
-);
-
-export const seedPhraseAtom = loadable(internalSeedPhraseAtom);


### PR DESCRIPTION
## Purpose

Fix recovery from settings so that it fails gracefully, instead of exploding the entire wallet. (I also think the normal recovery would explode everything if that also failed)

## Changes

Ensure that we don't navigate from the RecoveryMain component before the seedPhrase loading atom is done loading.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [] (If necessary) I have updated the CHANGELOG.
