### PR TITLE
Add button to export private key as file

### DIFF
--- a/packages/browser-wallet/manifest.json
+++ b/packages/browser-wallet/manifest.json
@@ -11,7 +11,7 @@
         }
     ],
     "host_permissions": ["<all_urls>"],
-    "permissions": ["tabs", "activeTab", "storage", "scripting", "notifications", "webRequest"],
+    "permissions": ["tabs", "activeTab", "storage", "scripting", "notifications", "webRequest", "downloads"],
     "background": {
         "service_worker": "entryPoint!src/background/index.ts"
     },

--- a/packages/browser-wallet/src/popup/pages/Account/AccountSettings/AccountSettings.scss
+++ b/packages/browser-wallet/src/popup/pages/Account/AccountSettings/AccountSettings.scss
@@ -61,6 +61,14 @@
         background-color: $color-cta;
     }
 
+    &__export-button {
+        position: absolute;
+        bottom: rem(100px);
+        left: 0;
+        right: 0;
+        margin: 0 auto;
+    }
+
     textarea {
         margin-top: rem(30px);
         height: rem(70px);

--- a/packages/browser-wallet/src/popup/pages/Account/AccountSettings/AccountSettings.scss
+++ b/packages/browser-wallet/src/popup/pages/Account/AccountSettings/AccountSettings.scss
@@ -43,35 +43,33 @@
 
 .export-private-key-page {
     width: 100%;
-    padding-left: rem(20px);
-    padding-right: rem(20px);
+    padding-left: rem(19px);
+    padding-right: rem(19px);
     background-color: $color-bg;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
 
     &__description {
         text-align: center;
-        margin-top: rem(30px);
+        margin-top: rem(10px);
     }
 
     &__button {
-        position: absolute;
-        bottom: rem(24px);
-        left: 0;
-        right: 0;
-        margin: 0 auto;
+        margin: 0 auto rem(24px);
         background-color: $color-cta;
     }
 
     &__export-button {
-        position: absolute;
-        bottom: rem(100px);
-        left: 0;
-        right: 0;
         margin: 0 auto;
     }
 
+    &__form {
+        display: contents;
+    }
+
     textarea {
-        margin-top: rem(30px);
-        height: rem(70px);
+        height: rem(55px);
         padding: rem(10px);
     }
 

--- a/packages/browser-wallet/src/popup/pages/Account/AccountSettings/ExportPrivateKey.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/AccountSettings/ExportPrivateKey.tsx
@@ -16,6 +16,29 @@ import { absoluteRoutes } from '@popup/constants/routes';
 import { NetworkConfiguration } from '@shared/storage/types';
 import { getNet } from '@shared/utils/network-helpers';
 
+type CredentialKeys = {
+    threshold: number;
+    keys: Record<number, { signKey: string; verifyKey: string }>;
+};
+
+type AccountKeys = {
+    threshold: number;
+    keys: Record<number, CredentialKeys>;
+};
+
+type AccountExport = {
+    accountKeys: AccountKeys;
+    address: string;
+    credentials: Record<string, string>;
+};
+
+type ExportFormat = {
+    type: 'concordium-browser-wallet-account';
+    v: number;
+    environment: string; // 'testnet' or 'mainnet'
+    value: AccountExport;
+};
+
 function createDownload(
     address: string,
     credId: string,
@@ -23,7 +46,7 @@ function createDownload(
     verifyKey: string,
     network: NetworkConfiguration
 ) {
-    const docContent = JSON.stringify({
+    const docContent: ExportFormat = {
         type: 'concordium-browser-wallet-account',
         v: 0,
         environment: getNet(network).toLowerCase(),
@@ -47,8 +70,8 @@ function createDownload(
             },
             address,
         },
-    });
-    return URL.createObjectURL(new Blob([docContent], { type: 'application/octet-binary' }));
+    };
+    return URL.createObjectURL(new Blob([JSON.stringify(docContent)], { type: 'application/octet-binary' }));
 }
 
 export default function ExportPrivateKey() {

--- a/packages/browser-wallet/src/popup/pages/Account/AccountSettings/ExportPrivateKey.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/AccountSettings/ExportPrivateKey.tsx
@@ -97,15 +97,15 @@ export default function ExportPrivateKey() {
                     <TextArea value={privateKey} readOnly />
                     <CopyButton className="export-private-key-page__copy" value={privateKey} />
                 </div>
+                <Button className="export-private-key-page__export-button" width="medium" onClick={handleExport}>
+                    {t('export')}
+                </Button>
                 <Button
                     className="export-private-key-page__button"
                     width="medium"
                     onClick={() => nav(absoluteRoutes.home.account.path)}
                 >
                     {t('done')}
-                </Button>
-                <Button className="export-private-key-page__export-button" width="medium" onClick={handleExport}>
-                    {t('export')}
                 </Button>
             </div>
         );
@@ -114,7 +114,7 @@ export default function ExportPrivateKey() {
     return (
         <div className="export-private-key-page">
             <div className="export-private-key-page__description">{t('description')}</div>
-            <Form onSubmit={handleSubmit}>
+            <Form className="export-private-key-page__form" onSubmit={handleSubmit}>
                 {(f) => {
                     return (
                         <>
@@ -122,7 +122,7 @@ export default function ExportPrivateKey() {
                                 control={f.control}
                                 name="currentPasscode"
                                 label={tPasscode('labels.currentPasscode')}
-                                className="m-t-30"
+                                className="m-t-10"
                                 rules={{
                                     required: tSetup('setupPasscode.form.passcodeRequired'),
                                     validate: validateCurrentPasscode(),

--- a/packages/browser-wallet/src/popup/pages/Account/i18n/da.ts
+++ b/packages/browser-wallet/src/popup/pages/Account/i18n/da.ts
@@ -32,6 +32,7 @@ const t: typeof en = {
             copyDescription: 'Tryk på knappen for at kopiere din private nøgle.',
             show: 'Vis privatnøgle',
             done: 'Færdig',
+            export: 'Eksporter',
         },
     },
     sendCcd: {

--- a/packages/browser-wallet/src/popup/pages/Account/i18n/en.ts
+++ b/packages/browser-wallet/src/popup/pages/Account/i18n/en.ts
@@ -30,6 +30,7 @@ const t = {
             copyDescription: 'Press the button to copy your private key.',
             show: 'Show private key',
             done: 'Done',
+            export: 'Export',
         },
     },
     sendCcd: {

--- a/packages/browser-wallet/src/popup/shared/utils/account-helpers.ts
+++ b/packages/browser-wallet/src/popup/shared/utils/account-helpers.ts
@@ -41,23 +41,58 @@ export function useSelectedCredential() {
     return useCredential(selectedAccount);
 }
 
-export function usePrivateKey(accountAddress: string | undefined): string | undefined {
-    const credentials = useAtomValue(credentialsAtom);
-    const credential = credentials.find((cred) => cred.address === accountAddress);
+export function useHdWallet(): ConcordiumHdWallet | undefined {
     const network = useAtomValue(networkConfigurationAtom);
     const seedPhrase = useDecryptedSeedPhrase();
+
+    const wallet = useMemo(() => {
+        if (!seedPhrase) {
+            return undefined;
+        }
+
+        return ConcordiumHdWallet.fromHex(seedPhrase, getNet(network));
+    }, [seedPhrase]);
+
+    return wallet;
+}
+
+export function usePrivateKey(accountAddress: string | undefined): string | undefined {
+    const wallet = useHdWallet();
+    const credentials = useAtomValue(credentialsAtom);
+    const credential = credentials.find((cred) => cred.address === accountAddress);
+
     const identity = useIdentityOf(credential);
 
     const privateKey = useMemo(() => {
         // We don't throw errors on missing credentials or identities, as they might just be loading.
-        if (!accountAddress || !credential || !identity || !seedPhrase) {
+        if (!wallet || !identity || !credential) {
             return undefined;
         }
 
-        return ConcordiumHdWallet.fromHex(seedPhrase, getNet(network))
+        return wallet
             .getAccountSigningKey(identity.providerIndex, identity.index, credential.credNumber)
             .toString('hex');
-    }, [credential?.credId, seedPhrase, identity?.index]);
+    }, [credential?.credId, wallet, identity?.index]);
+
+    return privateKey;
+}
+
+export function usePublicKey(accountAddress: string | undefined): string | undefined {
+    const wallet = useHdWallet();
+    const credentials = useAtomValue(credentialsAtom);
+    const credential = credentials.find((cred) => cred.address === accountAddress);
+    const identity = useIdentityOf(credential);
+
+    const privateKey = useMemo(() => {
+        // We don't throw errors on missing credentials or identities, as they might just be loading.
+        if (!wallet || !identity || !credential) {
+            return undefined;
+        }
+
+        return wallet
+            .getAccountSigningKey(identity.providerIndex, identity.index, credential.credNumber)
+            .toString('hex');
+    }, [credential?.credId, wallet, identity?.index]);
 
     return privateKey;
 }

--- a/packages/browser-wallet/src/popup/shared/utils/account-helpers.ts
+++ b/packages/browser-wallet/src/popup/shared/utils/account-helpers.ts
@@ -83,18 +83,18 @@ export function usePublicKey(accountAddress: string | undefined): string | undef
     const credential = credentials.find((cred) => cred.address === accountAddress);
     const identity = useIdentityOf(credential);
 
-    const privateKey = useMemo(() => {
+    const publicKey = useMemo(() => {
         // We don't throw errors on missing credentials or identities, as they might just be loading.
         if (!wallet || !identity || !credential) {
             return undefined;
         }
 
         return wallet
-            .getAccountSigningKey(identity.providerIndex, identity.index, credential.credNumber)
+            .getAccountPublicKey(identity.providerIndex, identity.index, credential.credNumber)
             .toString('hex');
     }, [credential?.credId, wallet, identity?.index]);
 
-    return privateKey;
+    return publicKey;
 }
 
 export function getNextEmptyCredNumber(creds: WalletCredential[]) {


### PR DESCRIPTION
## Purpose

Add a button in export private key to export as a file.

## Changes

- Added that button.
- Created usePublicKey and useHdWallet hooks.
- Fixed textarea in exportPrivateKey not being readOnly. 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

