### PR TITLE
Reject connection request if no selected account

### DIFF
--- a/packages/browser-wallet/src/background/index.ts
+++ b/packages/browser-wallet/src/background/index.ts
@@ -200,16 +200,16 @@ const runIfNotWhitelisted: RunCondition<string | undefined> = async (_msg, sende
         throw new Error('Expected URL to be available for sender.');
     }
 
-    const locked = await isWalletLocked();
-    if (locked) {
-        return { run: true };
-    }
-
     const selectedAccount = await storedSelectedAccount.get();
 
     // No accounts in the wallet.
     if (selectedAccount === undefined) {
         return { run: false, response: undefined };
+    }
+
+    const locked = await isWalletLocked();
+    if (locked) {
+        return { run: true };
     }
 
     const accountConnectedToSite = await findPrioritizedAccountConnectedToSite(sender.url);


### PR DESCRIPTION
## Purpose
Fix issue when trying to connect to an empty wallet (a wallet without any accounts).

## Changes
- Check if there is a selected account before checking if the wallet is locked, when doing a connection request.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.