### PR TITLE
Fix undefined signal

### DIFF
--- a/packages/browser-wallet/src/background/confirmation.ts
+++ b/packages/browser-wallet/src/background/confirmation.ts
@@ -36,12 +36,15 @@ async function monitorCredentialStatus(
                 const isSuccessful = Object.values(response?.outcomes || {}).some(
                     (outcome) => outcome.result.outcome === 'success'
                 );
-                await updateCredentials([
-                    {
-                        ...info,
-                        status: isSuccessful ? CreationStatus.Confirmed : CreationStatus.Rejected,
-                    },
-                ]);
+                await updateCredentials(
+                    [
+                        {
+                            ...info,
+                            status: isSuccessful ? CreationStatus.Confirmed : CreationStatus.Rejected,
+                        },
+                    ],
+                    genesisHash
+                );
                 repeat = false;
             }
         } finally {
@@ -79,22 +82,28 @@ async function monitorIdentityStatus({ location, ...identity }: PendingIdentity,
         try {
             const response = (await (await fetch(location)).json()) as IdentityTokenContainer;
             if (response.status === IdentityProviderIdentityStatus.Error) {
-                await updateIdentities([
-                    {
-                        ...identity,
-                        status: CreationStatus.Rejected,
-                        error: response.detail,
-                    },
-                ]);
+                await updateIdentities(
+                    [
+                        {
+                            ...identity,
+                            status: CreationStatus.Rejected,
+                            error: response.detail,
+                        },
+                    ],
+                    genesisHash
+                );
                 repeat = false;
             } else if (response.status === IdentityProviderIdentityStatus.Done) {
-                await updateIdentities([
-                    {
-                        ...identity,
-                        status: CreationStatus.Confirmed,
-                        idObject: response.token.identityObject,
-                    },
-                ]);
+                await updateIdentities(
+                    [
+                        {
+                            ...identity,
+                            status: CreationStatus.Confirmed,
+                            idObject: response.token.identityObject,
+                        },
+                    ],
+                    genesisHash
+                );
                 repeat = false;
             }
         } finally {

--- a/packages/browser-wallet/src/background/credential-deployment.ts
+++ b/packages/browser-wallet/src/background/credential-deployment.ts
@@ -44,8 +44,8 @@ async function createAndSendCredential(credIn: CredentialInputV1): Promise<Crede
         }
 
         // Add Pending
-        await addCredential(newCred);
-        confirmCredential(newCred, url);
+        await addCredential(newCred, network.genesisHash);
+        confirmCredential(newCred, url, network.genesisHash);
         // Set Selected to new account
         await storedSelectedAccount.set(address);
     } finally {

--- a/packages/browser-wallet/src/background/index.ts
+++ b/packages/browser-wallet/src/background/index.ts
@@ -13,7 +13,7 @@ import {
 } from '@shared/storage/access';
 
 import JSONBig from 'json-bigint';
-import { ChromeStorageKey } from '@shared/storage/types';
+import { ChromeStorageKey, NetworkConfiguration } from '@shared/storage/types';
 import bgMessageHandler from './message-handler';
 import { forwardToPopup, HandleMessage, HandleResponse, RunCondition, setPopupSize } from './window-management';
 import { identityIssuanceHandler } from './identity-issuance';
@@ -95,17 +95,21 @@ const injectScript: ExtensionMessageHandler = (_msg, sender, respond) => {
     return true;
 };
 
-const startupHandler = () => startMonitoringPendingStatus();
-const networkChangeHandler = () => startMonitoringPendingStatus();
+const startupHandler = async () => {
+    const network = await storedCurrentNetwork.get();
+    if (network) {
+        startMonitoringPendingStatus(network);
+    }
+};
+const networkChangeHandler = (network: NetworkConfiguration) => startMonitoringPendingStatus(network);
 
 chrome.storage.local.onChanged.addListener((changes) => {
     if (ChromeStorageKey.NetworkConfiguration in changes) {
-        networkChangeHandler();
+        networkChangeHandler(changes[ChromeStorageKey.NetworkConfiguration].newValue);
     }
 });
 
 chrome.runtime.onStartup.addListener(startupHandler);
-chrome.runtime.onInstalled.addListener(startupHandler);
 
 bgMessageHandler.handleMessage(
     createMessageTypeFilter(InternalMessageType.SendCredentialDeployment),

--- a/packages/browser-wallet/src/background/index.ts
+++ b/packages/browser-wallet/src/background/index.ts
@@ -110,6 +110,7 @@ chrome.storage.local.onChanged.addListener((changes) => {
 });
 
 chrome.runtime.onStartup.addListener(startupHandler);
+chrome.runtime.onInstalled.addListener(startupHandler);
 
 bgMessageHandler.handleMessage(
     createMessageTypeFilter(InternalMessageType.SendCredentialDeployment),

--- a/packages/browser-wallet/src/background/recovery.ts
+++ b/packages/browser-wallet/src/background/recovery.ts
@@ -154,8 +154,8 @@ async function performRecovery({ providers, ...recoveryInputs }: Payload) {
                 identityIndex += 1;
             }
         }
-        await addIdentity(identitiesToAdd);
-        await addCredential(credsToAdd);
+        await addIdentity(identitiesToAdd, network.genesisHash);
+        await addCredential(credsToAdd, network.genesisHash);
         return {
             identities: identitiesToAdd.map((id) => ({ index: id.index, providerIndex: id.providerIndex })),
             accounts: credsToAdd.map((cred) => cred.address),

--- a/packages/browser-wallet/src/background/update.ts
+++ b/packages/browser-wallet/src/background/update.ts
@@ -1,4 +1,4 @@
-import { getGenesisHash, storedCredentials, storedIdentities, useIndexedStorage } from '@shared/storage/access';
+import { storedCredentials, storedIdentities, useIndexedStorage } from '@shared/storage/access';
 import { addToList, editList } from '@shared/storage/update';
 import { Identity, WalletCredential } from '@shared/storage/types';
 import { identityMatch } from '@shared/utils/identity-helpers';
@@ -6,28 +6,36 @@ import { identityMatch } from '@shared/utils/identity-helpers';
 const identityLock = 'concordium_identity_lock';
 const credentialLock = 'concordium_credential_lock';
 
-export async function addIdentity(identity: Identity | Identity[]): Promise<void> {
-    return addToList(identityLock, identity, useIndexedStorage(storedIdentities, getGenesisHash));
+export async function addIdentity(identity: Identity | Identity[], genesisHash: string): Promise<void> {
+    return addToList(
+        identityLock,
+        identity,
+        useIndexedStorage(storedIdentities, async () => genesisHash)
+    );
 }
 
-export async function addCredential(cred: WalletCredential | WalletCredential[]): Promise<void> {
-    return addToList(credentialLock, cred, useIndexedStorage(storedCredentials, getGenesisHash));
+export async function addCredential(cred: WalletCredential | WalletCredential[], genesisHash: string): Promise<void> {
+    return addToList(
+        credentialLock,
+        cred,
+        useIndexedStorage(storedCredentials, async () => genesisHash)
+    );
 }
 
-export function updateIdentities(updatedIdentities: Identity[]) {
+export function updateIdentities(updatedIdentities: Identity[], genesisHash: string) {
     return editList(
         identityLock,
         updatedIdentities,
         identityMatch,
-        useIndexedStorage(storedIdentities, getGenesisHash)
+        useIndexedStorage(storedIdentities, async () => genesisHash)
     );
 }
 
-export function updateCredentials(updatedCredentials: WalletCredential[]) {
+export function updateCredentials(updatedCredentials: WalletCredential[], genesisHash: string) {
     return editList(
         credentialLock,
         updatedCredentials,
         (cred) => (candidate) => cred.credId === candidate.credId,
-        useIndexedStorage(storedCredentials, getGenesisHash)
+        useIndexedStorage(storedCredentials, async () => genesisHash)
     );
 }


### PR DESCRIPTION
## Purpose

Ensure identityaccount creation doesnt not fail to confirm due to `undefined.signal`

## Changes

- Remove abortController.
- status monitors are now given the current network's genesisHash and terminate the loop if the current network has a different genesisHash.
- change update function to take the genesisHash as a parameter instead of loading it themselves. (To avoid loading the wrong network if it was changed while checking the status)

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

