### PR TITLE
Connected sites per network

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.2
+
+### Fixed
+
+-   Connected sites are now stored per network.
+
 ## 0.7.1
 
 ### Fixed

--- a/packages/browser-wallet/src/popup/pages/ConnectionRequest/ConnectionRequest.tsx
+++ b/packages/browser-wallet/src/popup/pages/ConnectionRequest/ConnectionRequest.tsx
@@ -76,11 +76,7 @@ export default function ConnectionRequest({ onAllow, onReject }: Props) {
                         disabled={connectButtonDisabled}
                         onClick={() => {
                             setConnectButtonDisabled(true);
-                            connectAccount(selectedAccount, new URL(url).origin).then(
-                                withClose(() => {
-                                    onAllow();
-                                })
-                            );
+                            connectAccount(selectedAccount, new URL(url).origin).then(withClose(onAllow));
                         }}
                     >
                         {t('actions.connect')}

--- a/packages/browser-wallet/src/popup/pages/ConnectionRequest/ConnectionRequest.tsx
+++ b/packages/browser-wallet/src/popup/pages/ConnectionRequest/ConnectionRequest.tsx
@@ -3,7 +3,7 @@ import { fullscreenPromptContext } from '@popup/page-layouts/FullscreenPromptLay
 import { selectedAccountAtom, storedConnectedSitesAtom } from '@popup/store/account';
 import { sessionPasscodeAtom } from '@popup/store/settings';
 import { useAtom, useAtomValue } from 'jotai';
-import React, { useContext, useEffect } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, Navigate } from 'react-router-dom';
 import ExternalRequestLayout from '@popup/page-layouts/ExternalRequestLayout';
@@ -24,6 +24,7 @@ export default function ConnectionRequest({ onAllow, onReject }: Props) {
     const [connectedSitesLoading, setConnectedSites] = useAtom(storedConnectedSitesAtom);
     const connectedSites = connectedSitesLoading.value;
     const passcode = useAtomValue(sessionPasscodeAtom);
+    const [connectButtonDisabled, setConnectButtonDisabled] = useState<boolean>(false);
 
     useEffect(() => onClose(onReject), [onClose, onReject]);
 
@@ -41,7 +42,7 @@ export default function ConnectionRequest({ onAllow, onReject }: Props) {
         );
     }
 
-    function connectAccount(account: string, url: string) {
+    async function connectAccount(account: string, url: string) {
         const updatedConnectedSites = {
             ...connectedSites,
         };
@@ -50,7 +51,7 @@ export default function ConnectionRequest({ onAllow, onReject }: Props) {
         connectedSitesForAccount.push(url);
         updatedConnectedSites[account] = connectedSitesForAccount;
 
-        setConnectedSites(updatedConnectedSites);
+        await setConnectedSites(updatedConnectedSites);
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -72,10 +73,15 @@ export default function ConnectionRequest({ onAllow, onReject }: Props) {
                     </Button>
                     <Button
                         width="narrow"
-                        onClick={withClose(() => {
-                            connectAccount(selectedAccount, new URL(url).origin);
-                            onAllow();
-                        })}
+                        disabled={connectButtonDisabled}
+                        onClick={() => {
+                            setConnectButtonDisabled(true);
+                            connectAccount(selectedAccount, new URL(url).origin).then(
+                                withClose(() => {
+                                    onAllow();
+                                })
+                            );
+                        }}
                     >
                         {t('actions.connect')}
                     </Button>

--- a/packages/browser-wallet/src/popup/store/utils.ts
+++ b/packages/browser-wallet/src/popup/store/utils.ts
@@ -52,12 +52,12 @@ export function atomWithChromeStorage<V>(
     key: ChromeStorageKey,
     fallback: V,
     withLoading: true
-): WritableAtom<AsyncWrapper<V>, V, void>;
+): WritableAtom<AsyncWrapper<V>, V, Promise<void>>;
 export function atomWithChromeStorage<V>(
     key: ChromeStorageKey,
     fallback: V,
     withLoading?: false
-): WritableAtom<V, V, void>;
+): WritableAtom<V, V, Promise<void>>;
 
 /**
  * @description
@@ -101,8 +101,8 @@ export function atomWithChromeStorage<V>(key: ChromeStorageKey, fallback: V, wit
 
     const derived = atom(
         (get) => (withLoading ? get(base) : get(base).value),
-        (_, set, next: V) => {
-            setStoredValue(next);
+        async (_, set, next: V) => {
+            await setStoredValue(next);
             set(base, (v) => ({ ...v, value: next }));
         }
     );

--- a/packages/browser-wallet/src/shared/storage/access.ts
+++ b/packages/browser-wallet/src/shared/storage/access.ts
@@ -104,19 +104,28 @@ export function useIndexedStorage<V>(
     };
 }
 
-export const storedIdentities = makeIndexedStorageAccessor<Identity[]>('local', ChromeStorageKey.Identities);
-export const storedSelectedIdentity = makeStorageAccessor<string>('local', ChromeStorageKey.SelectedIdentity);
-export const storedSeedPhrase = makeStorageAccessor<string>('local', ChromeStorageKey.SeedPhrase);
-
-export const storedConnectedSites = makeStorageAccessor<Record<string, string[]>>(
-    'local',
-    ChromeStorageKey.ConnectedSites
-);
-export const storedCredentials = makeIndexedStorageAccessor<WalletCredential[]>('local', ChromeStorageKey.Credentials);
 export const storedCurrentNetwork = makeStorageAccessor<NetworkConfiguration>(
     'local',
     ChromeStorageKey.NetworkConfiguration
 );
+export const getGenesisHash = () =>
+    storedCurrentNetwork.get().then((network) => {
+        if (!network) {
+            throw new Error('Indexed storage should not be accessed before setting the network');
+        }
+        return network.genesisHash;
+    });
+
+export const storedIdentities = makeIndexedStorageAccessor<Identity[]>('local', ChromeStorageKey.Identities);
+export const storedSelectedIdentity = makeStorageAccessor<string>('local', ChromeStorageKey.SelectedIdentity);
+export const storedSeedPhrase = makeStorageAccessor<string>('local', ChromeStorageKey.SeedPhrase);
+
+const indexedStoredConnectedSites = makeIndexedStorageAccessor<Record<string, string[]>>(
+    'local',
+    ChromeStorageKey.ConnectedSites
+);
+export const storedConnectedSites = useIndexedStorage(indexedStoredConnectedSites, getGenesisHash);
+export const storedCredentials = makeIndexedStorageAccessor<WalletCredential[]>('local', ChromeStorageKey.Credentials);
 export const storedSelectedAccount = makeStorageAccessor<string>('local', ChromeStorageKey.SelectedAccount);
 export const storedEncryptedSeedPhrase = makeStorageAccessor<EncryptedData>('local', ChromeStorageKey.SeedPhrase);
 export const storedTheme = makeStorageAccessor<Theme>('local', ChromeStorageKey.Theme);
@@ -138,11 +147,3 @@ export const sessionAccountInfoCache = makeIndexedStorageAccessor<Record<string,
 );
 export const sessionIsRecovering = makeStorageAccessor<boolean>('session', ChromeStorageKey.IsRecovering);
 export const sessionOnboardingLocation = makeStorageAccessor<string>('session', ChromeStorageKey.OnboardingLocation);
-
-export const getGenesisHash = () =>
-    storedCurrentNetwork.get().then((network) => {
-        if (!network) {
-            throw new Error('Indexed storage should not be accessed before setting the network');
-        }
-        return network.genesisHash;
-    });


### PR DESCRIPTION
## Purpose
Store connected sites per network to avoid cross pollution in the case of multiple testnet networks (in the future).

## Changes
- Make stored connected sites indexed by genesis hash.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.