### PR TITLE
Remove parameters from smart contract payload types in api

### DIFF
--- a/examples/wCCD/src/utils.ts
+++ b/examples/wCCD/src/utils.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import { createContext } from 'react';
 import { detectConcordiumProvider } from '@concordium/browser-wallet-api-helpers';
-import { AccountTransactionType, GtuAmount, toBuffer } from '@concordium/web-sdk';
+import { AccountTransactionType, GtuAmount } from '@concordium/web-sdk';
 
 export const CONTRACT_NAME_PROXY = 'CIS2-wCCD-Proxy';
 export const CONTRACT_NAME_IMPLEMENTATION = 'CIS2-wCCD';
@@ -39,7 +39,6 @@ export const wrap = (
                         },
                         receiveName: `${CONTRACT_NAME_PROXY}.wrap`,
                         maxContractExecutionEnergy: 30000n,
-                        parameter: toBuffer(''),
                     },
                     {
                         data: '',
@@ -95,7 +94,6 @@ export const unwrap = (
                         },
                         receiveName: `${CONTRACT_NAME_PROXY}.unwrap`,
                         maxContractExecutionEnergy: 30000n,
-                        parameter: toBuffer(''),
                     },
                     {
                         amount: amount.toString(),

--- a/packages/browser-wallet-api-helpers/CHANGELOG.md
+++ b/packages/browser-wallet-api-helpers/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.2.1
+
+### Changed
+
+-   Fixed broken link + typos in README
+-   Removed parameters from smart contract types' payloads, due the wallet ignoring it in favor of separate arguments.
+
 ## 0.2.0
 
 ### Added

--- a/packages/browser-wallet-api-helpers/CHANGELOG.md
+++ b/packages/browser-wallet-api-helpers/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.2.1
+## 1.0.0
 
 ### Changed
 

--- a/packages/browser-wallet-api-helpers/package.json
+++ b/packages/browser-wallet-api-helpers/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/browser-wallet-api-helpers",
-    "version": "0.2.1",
+    "version": "1.0.0",
     "license": "Apache-2.0",
     "packageManager": "yarn@3.2.0",
     "main": "lib/index.js",

--- a/packages/browser-wallet-api-helpers/package.json
+++ b/packages/browser-wallet-api-helpers/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/browser-wallet-api-helpers",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "license": "Apache-2.0",
     "packageManager": "yarn@3.2.0",
     "main": "lib/index.js",

--- a/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
+++ b/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
@@ -2,9 +2,16 @@ import type {
     AccountTransactionPayload,
     AccountTransactionSignature,
     AccountTransactionType,
+    InitContractPayload,
     JsonRpcClient,
     SchemaVersion,
+    UpdateContractPayload,
 } from '@concordium/web-sdk';
+
+type SendTransactionPayload =
+    | Exclude<AccountTransactionPayload, UpdateContractPayload | InitContractPayload>
+    | Omit<UpdateContractPayload, 'parameter'>
+    | Omit<InitContractPayload, 'parameter'>;
 
 /**
  * An enumeration of the events that can be emitted by the WalletApi.
@@ -36,7 +43,7 @@ interface MainWalletApi {
      * Note that if the user rejects signing the transaction, this will throw an error.
      * @param accountAddress the address of the account that should sign the transaction
      * @param type the type of transaction that is to be signed and sent.
-     * @param payload the payload of the transaction to be signed and sent.
+     * @param payload the payload of the transaction to be signed and sent. Note that for smart contract transactions, the payload should not contain the parameters, those should instead be provided in the subsequent argument instead.
      * @param parameters parameters for the initContract and updateContract transactions in JSON-like format.
      * @param schema schema used for the initContract and updateContract transactions to serialize the parameters. Should be base64 encoded.
      * @param schemaVersion version of the schema provided. Must be supplied for schemas that use version 0 or 1, as they don't have the version embedded.
@@ -46,7 +53,7 @@ interface MainWalletApi {
         type:
             | AccountTransactionType.UpdateSmartContractInstance
             | AccountTransactionType.InitializeSmartContractInstance,
-        payload: AccountTransactionPayload,
+        payload: SendTransactionPayload,
         parameters: Record<string, unknown>,
         schema: string,
         schemaVersion?: SchemaVersion
@@ -56,12 +63,12 @@ interface MainWalletApi {
      * Note that if the user rejects signing the transaction, this will throw an error.
      * @param accountAddress the address of the account that should sign the transaction
      * @param type the type of transaction that is to be signed and sent.
-     * @param payload the payload of the transaction to be signed and sent.
+     * @param payload the payload of the transaction to be signed and sent. Note that for smart contract transactions, the payload should not contain the parameters, those should instead be provided in the subsequent argument instead.
      */
     sendTransaction(
         accountAddress: string,
         type: AccountTransactionType,
-        payload: AccountTransactionPayload
+        payload: SendTransactionPayload
     ): Promise<string>;
     /**
      * Sends a message to the Concordium Wallet and awaits the users action. If the user signs the message, this will resolve to the signature.


### PR DESCRIPTION
## Purpose

Fix misleading types in the API, which lead users to believe they could supply the parameters for a smart contract as a buffer in the payload, when this is ignored, because we want them not serialized, so we can display them.

## Changes

- Change the typing
- update changelog
- bump api-helpers version

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.