### PR TITLE
Wrong selected identity when having failed identities

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.3
+
+### Fixed
+
+-   An issue where the wrong identity was selected when choosing an identity during account creation.
+
 ## 0.7.2
 
 ### Fixed

--- a/packages/browser-wallet/src/popup/pages/AddAccount/ChooseIdentity.tsx
+++ b/packages/browser-wallet/src/popup/pages/AddAccount/ChooseIdentity.tsx
@@ -40,21 +40,24 @@ export default function ChooseIdentity() {
     return (
         <div className="flex-column align-center">
             <p className="m-t-20">{t('chooseIdentity')}</p>
-            {identities
-                .filter((identity) => identity.status === CreationStatus.Confirmed)
-                .map((identity, i) => (
-                    <IdCard
-                        name={identity.name}
-                        key={`${identity.providerIndex}-${identity.index}`}
-                        provider={<IdentityProviderIcon provider={findProvider(identity)} />}
-                        status={identity.status}
-                        className="m-t-10"
-                        onClick={() => {
-                            setSelectedIdentityIndex(i);
-                            nav('confirm');
-                        }}
-                    />
-                ))}
+            {identities.map((identity, i) => {
+                if (identity.status === CreationStatus.Confirmed) {
+                    return (
+                        <IdCard
+                            name={identity.name}
+                            key={`${identity.providerIndex}-${identity.index}`}
+                            provider={<IdentityProviderIcon provider={findProvider(identity)} />}
+                            status={identity.status}
+                            className="m-t-10"
+                            onClick={() => {
+                                setSelectedIdentityIndex(i);
+                                nav('confirm');
+                            }}
+                        />
+                    );
+                }
+                return null;
+            })}
         </div>
     );
 }


### PR DESCRIPTION
## Purpose
Fix an issue in account creation where another identity than the one chosen was shown.

## Changes
- Fix the identity index in `ChooseIdentity.tsx`. As the index is the index in the total list, and not just of confirmed identities, we have to ensure that we process all identities when building the list.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.