### PR TITLE
Pending transactions indexed by network

### DIFF
--- a/packages/browser-wallet/src/popup/pages/Account/AccountActions/AccountActions.scss
+++ b/packages/browser-wallet/src/popup/pages/Account/AccountActions/AccountActions.scss
@@ -61,6 +61,7 @@
 
     &__link-disabled,
     &__link {
+        border-radius: 0;
         position: relative;
         flex: 1;
         height: 100%;

--- a/packages/browser-wallet/src/popup/pages/Account/TransactionLog/TransactionElement.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/TransactionLog/TransactionElement.tsx
@@ -177,6 +177,10 @@ export default function TransactionElement({ accountAddress, transaction, style,
     const transactionTime = withDate ? withDateAndTime(transactionDate) : onlyTime(transactionDate);
     const failed = transaction.status === TransactionStatus.Failed;
     const isSender = transaction.fromAddress === accountAddress;
+
+    // Flip the amount is selected account is sender, and amount is positive. We expect the transaction list endpoint to sign the amount based on this,
+    // but this is not the case for pending transactions. This seeks to emulate the behaviour of the transaction list endpoint.
+    // TODO: check that this still works when shield, unshield, and encrypted transfers are implemented.
     const amount = isSender && transaction.amount > 0n ? -transaction.amount : transaction.amount;
 
     return (

--- a/packages/browser-wallet/src/popup/pages/Account/TransactionLog/TransactionElement.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/TransactionLog/TransactionElement.tsx
@@ -176,6 +176,8 @@ export default function TransactionElement({ accountAddress, transaction, style,
     const transactionDate = dateFromTimestamp(transaction.time, TimeStampUnit.seconds);
     const transactionTime = withDate ? withDateAndTime(transactionDate) : onlyTime(transactionDate);
     const failed = transaction.status === TransactionStatus.Failed;
+    const isSender = transaction.fromAddress === accountAddress;
+    const amount = isSender && transaction.amount > 0n ? -transaction.amount : transaction.amount;
 
     return (
         <div
@@ -200,7 +202,7 @@ export default function TransactionElement({ accountAddress, transaction, style,
                             isGreenAmount(transaction, accountAddress) && 'transaction-element__amount__greenText'
                         )}
                     >
-                        {displayAsCcd(transaction.cost ? transaction.amount - transaction.cost : transaction.amount)}
+                        {displayAsCcd(transaction.cost && isSender ? amount - transaction.cost : amount)}
                     </p>
                 }
             />
@@ -212,7 +214,9 @@ export default function TransactionElement({ accountAddress, transaction, style,
                     </>
                 }
                 right={
-                    transaction.cost !== undefined ? buildFeeString(transaction.cost, accountAddress, transaction) : ''
+                    transaction.cost !== undefined && isSender
+                        ? buildFeeString(transaction.cost, accountAddress, { ...transaction, amount })
+                        : ''
                 }
             />
         </div>

--- a/packages/browser-wallet/src/popup/shared/account-info-listener.ts
+++ b/packages/browser-wallet/src/popup/shared/account-info-listener.ts
@@ -6,7 +6,7 @@ import { accountInfoCacheLock, updateRecord } from '@shared/storage/update';
 import EventEmitter from 'events';
 import { stringify } from 'wallet-common-helpers';
 
-const accountInfoRetrievalIntervalMs = 15000;
+export const ACCOUNT_INFO_RETRIEVAL_INTERVAL_MS = 15000;
 
 export class AccountInfoListener extends EventEmitter {
     private client: JsonRpcClient;
@@ -64,7 +64,7 @@ export class AccountInfoListener extends EventEmitter {
             } catch (e) {
                 this.emit('error', e);
             }
-        }, accountInfoRetrievalIntervalMs);
+        }, ACCOUNT_INFO_RETRIEVAL_INTERVAL_MS);
     }
 
     stop() {

--- a/packages/browser-wallet/src/popup/store/transactions.ts
+++ b/packages/browser-wallet/src/popup/store/transactions.ts
@@ -72,19 +72,22 @@ const pendingTransactionsAtom = (() => {
                 }
 
                 const networkChanged = network.genesisHash !== currentNetwork.genesisHash;
-                const nextPending = pending.filter((p) => p.transactionHash !== transactionHash);
 
                 if (!networkChanged) {
-                    set(parsed, nextPending);
+                    const next = get(parsed).filter((p) => p.transactionHash !== transactionHash);
+                    set(parsed, next);
                 } else {
-                    const spt = useIndexedStorage(sessionPendingTransactions, async () => currentNetwork.genesisHash);
-                    spt.set(nextPending.map(stringify));
+                    const spt = useIndexedStorage(sessionPendingTransactions, async () => network.genesisHash);
+                    const next = (await spt.get())?.map(parse).filter((p) => p.transactionHash !== transactionHash);
+
+                    spt.set(next?.map(stringify) ?? []);
                 }
             });
         }
     );
 
     derived.onMount = (startMonitoring) => {
+        // setAtom callback starts monitoring a list of transactions + pending transactions currently in store.
         startMonitoring([]);
     };
 

--- a/packages/browser-wallet/src/popup/store/transactions.ts
+++ b/packages/browser-wallet/src/popup/store/transactions.ts
@@ -5,12 +5,13 @@ import { stringify, parse } from 'wallet-common-helpers';
 import { ChromeStorageKey } from '@shared/storage/types';
 import { loop } from '@shared/utils/function-helpers';
 import { getTransactionStatus } from '@popup/shared/utils/wallet-proxy';
-import { sessionPendingTransactions } from '@shared/storage/access';
+import { ACCOUNT_INFO_RETRIEVAL_INTERVAL_MS } from '@popup/shared/account-info-listener';
+import { sessionPendingTransactions, useIndexedStorage } from '@shared/storage/access';
 import { selectedAccountAtom } from './account';
 import { atomWithChromeStorage } from './utils';
 import { networkConfigurationAtom } from './settings';
 
-const TRANSACTION_CHECK_INTERVAL = 10000;
+const TRANSACTION_CHECK_INTERVAL = ACCOUNT_INFO_RETRIEVAL_INTERVAL_MS;
 
 const monitoredMap: Record<string, string[]> = {};
 const monitorTransactionStatus = (genesisHash: string) => {
@@ -43,28 +44,51 @@ const monitorTransactionStatus = (genesisHash: string) => {
 
 const pendingTransactionsAtom = (() => {
     const base = atomWithChromeStorage<string[]>(ChromeStorageKey.PendingTransactions, []);
-
-    return atom<BrowserWalletAccountTransaction[], BrowserWalletAccountTransaction[]>(
+    const parsed = atom<BrowserWalletAccountTransaction[], BrowserWalletAccountTransaction[]>(
         (get) => {
-            const pendingJson = get(base);
-            const pending: BrowserWalletAccountTransaction[] = pendingJson.map(parse);
-            const network = get(networkConfigurationAtom);
-
-            const monitor = monitorTransactionStatus(network.genesisHash);
-            pending.forEach(async ({ transactionHash }) => {
-                const shouldRemove = await monitor(transactionHash);
-
-                if (shouldRemove) {
-                    sessionPendingTransactions.set(pendingJson.filter((json) => !json.includes(transactionHash)));
-                }
-            });
-
+            const pending: BrowserWalletAccountTransaction[] = get(base).map(parse);
             return pending;
         },
         (_, set, update) => {
             set(base, update.map(stringify));
         }
     );
+
+    const derived = atom<BrowserWalletAccountTransaction[], BrowserWalletAccountTransaction[]>(
+        (get) => get(parsed),
+        (get, set, update) => {
+            const pending = [...get(parsed), ...update];
+            set(parsed, pending);
+
+            const network = get(networkConfigurationAtom);
+            const monitor = monitorTransactionStatus(network.genesisHash);
+
+            pending.forEach(async ({ transactionHash }) => {
+                const shouldRemove = await monitor(transactionHash);
+                const currentNetwork = get(networkConfigurationAtom);
+
+                if (!shouldRemove) {
+                    return;
+                }
+
+                const networkChanged = network.genesisHash !== currentNetwork.genesisHash;
+                const nextPending = pending.filter((p) => p.transactionHash !== transactionHash);
+
+                if (!networkChanged) {
+                    set(parsed, nextPending);
+                } else {
+                    const spt = useIndexedStorage(sessionPendingTransactions, async () => currentNetwork.genesisHash);
+                    spt.set(nextPending.map(stringify));
+                }
+            });
+        }
+    );
+
+    derived.onMount = (startMonitoring) => {
+        startMonitoring([]);
+    };
+
+    return derived;
 })();
 
 const isForAccount = (address: string) => (transaction: BrowserWalletAccountTransaction) =>

--- a/packages/browser-wallet/src/shared/storage/access.ts
+++ b/packages/browser-wallet/src/shared/storage/access.ts
@@ -159,7 +159,7 @@ export const sessionRecoveryStatus = makeStorageAccessor<RecoveryStatus>('sessio
 export const sessionOnboardingLocation = makeStorageAccessor<string>('session', ChromeStorageKey.OnboardingLocation);
 export const sessionIdpTab = makeStorageAccessor<number>('session', ChromeStorageKey.IdpTab);
 
-export const sessionPendingTransactions = makeStorageAccessor<string[]>( // Underlying type is serialized BrowserWalletAccountTransaction[]
+export const sessionPendingTransactions = makeIndexedStorageAccessor<string[]>( // Underlying type is serialized BrowserWalletAccountTransaction[]
     'session',
     ChromeStorageKey.PendingTransactions
 );


### PR DESCRIPTION
## Purpose

Discovered some issues when setting up a new account on a freshly added network:

- pending transactions were not network specific
- pending transaction amount displayed wrong
- network specific atoms didn't update when changing network

## Changes

- Refactor pending transactions atom to set value through atom when possible
- Refresh atoms on network change
- Make `TransactionListElement` render pending transactions properly in terms of amount and cost both for sending and receiving accounts

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
