### PR TITLE
Adjust to cookie-supporting JSON-RPC client

### DIFF
--- a/packages/browser-wallet-api-helpers/package.json
+++ b/packages/browser-wallet-api-helpers/package.json
@@ -19,7 +19,7 @@
         "url": "https://concordium.com"
     },
     "dependencies": {
-        "@concordium/web-sdk": "^2.0.0"
+        "@concordium/web-sdk": "^2.1.0"
     },
     "devDependencies": {
         "@babel/core": "^7.17.10",

--- a/packages/browser-wallet-api/package.json
+++ b/packages/browser-wallet-api/package.json
@@ -7,7 +7,7 @@
     "license": "Apache-2.0",
     "dependencies": {
         "@concordium/browser-wallet-api-helpers": "workspace:^",
-        "@concordium/common-sdk": "^5.0.0",
+        "@concordium/common-sdk": "^5.1.0",
         "json-bigint": "^1.0.0"
     },
     "devDependencies": {

--- a/packages/browser-wallet/package.json
+++ b/packages/browser-wallet/package.json
@@ -17,7 +17,7 @@
     "dependencies": {
         "@concordium/browser-wallet-api": "workspace:^",
         "@concordium/browser-wallet-api-helpers": "workspace:^",
-        "@concordium/web-sdk": "^2.0.0",
+        "@concordium/web-sdk": "^2.1.0",
         "@scure/bip39": "^1.1.0",
         "axios": "^0.27.2",
         "buffer": "^6.0.3",

--- a/packages/browser-wallet/src/popup/pages/AddAccount/Confirm.tsx
+++ b/packages/browser-wallet/src/popup/pages/AddAccount/Confirm.tsx
@@ -5,7 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import IdCard from '@popup/shared/IdCard';
 import { identityProvidersAtom, selectedIdentityAtom } from '@popup/store/identity';
 import { credentialsAtom, creatingCredentialRequestAtom } from '@popup/store/account';
-import { networkConfigurationAtom } from '@popup/store/settings';
+import { jsonRpcClientAtom, networkConfigurationAtom } from '@popup/store/settings';
 import { CreationStatus, WalletCredential } from '@shared/storage/types';
 import Button from '@popup/shared/Button';
 import ArrowIcon from '@assets/svg/arrow.svg';
@@ -28,6 +28,7 @@ export default function Confirm() {
     const selectedIdentity = useAtomValue(selectedIdentityAtom);
     const credentials = useAtomValue(credentialsAtom);
     const network = useAtomValue(networkConfigurationAtom);
+    const client = useAtomValue(jsonRpcClientAtom);
     const providers = useAtomValue(identityProvidersAtom);
     const addToast = useSetAtom(addToastAtom);
     const seedPhrase = useDecryptedSeedPhrase((e) => addToast(e.message));
@@ -54,7 +55,7 @@ export default function Confirm() {
                 throw new Error('Selected identity is not defined or not confirmed');
             }
 
-            const global = await getGlobal(network);
+            const global = await getGlobal(client);
 
             // Make request
             const expiry = Math.floor(Date.now() / 1000) + 720;

--- a/packages/browser-wallet/src/popup/pages/IdentityIssuance/IdentityIssuanceStart.tsx
+++ b/packages/browser-wallet/src/popup/pages/IdentityIssuance/IdentityIssuanceStart.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useAtomValue, useAtom, useSetAtom } from 'jotai';
 import { useTranslation } from 'react-i18next';
-import { networkConfigurationAtom } from '@popup/store/settings';
+import { jsonRpcClientAtom, networkConfigurationAtom } from '@popup/store/settings';
 import { pendingIdentityAtom, identitiesAtom, identityProvidersAtom } from '@popup/store/identity';
 import { popupMessageHandler } from '@popup/shared/message-handler';
 import { getIdentityProviders } from '@popup/shared/utils/wallet-proxy';
@@ -22,6 +22,7 @@ function IdentityIssuanceStart({ onStart }: InnerProps) {
     const { t } = useTranslation('identityIssuance');
     const [providers, setProviders] = useAtom(identityProvidersAtom);
     const network = useAtomValue(networkConfigurationAtom);
+    const client = useAtomValue(jsonRpcClientAtom);
     const updatePendingIdentity = useSetAtom(pendingIdentityAtom);
     const identities = useAtomValue(identitiesAtom);
     const [buttonDisabled, setButtonDisabled] = useState(false);
@@ -46,7 +47,7 @@ function IdentityIssuanceStart({ onStart }: InnerProps) {
                     return;
                 }
 
-                const global = await getGlobal(network);
+                const global = await getGlobal(client);
 
                 const providerIndex = provider.ipInfo.ipIdentity;
 

--- a/packages/browser-wallet/src/popup/pages/Recovery/RecoveryMain.tsx
+++ b/packages/browser-wallet/src/popup/pages/Recovery/RecoveryMain.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { useTranslation } from 'react-i18next';
-import { networkConfigurationAtom } from '@popup/store/settings';
+import { jsonRpcClientAtom, networkConfigurationAtom } from '@popup/store/settings';
 import { identityProvidersAtom, isRecoveringAtom, setRecoveryPayloadAtom } from '@popup/store/identity';
 import PendingArrows from '@assets/svg/pending-arrows.svg';
 import { BackgroundResponseStatus } from '@shared/utils/types';
@@ -14,6 +14,7 @@ import { absoluteRoutes } from '@popup/constants/routes';
 export default function RecoveryMain() {
     const { t } = useTranslation('recovery');
     const network = useAtomValue(networkConfigurationAtom);
+    const client = useAtomValue(jsonRpcClientAtom);
     const [providers, setProviders] = useAtom(identityProvidersAtom);
     const [isRecovering, setIsRecovering] = useAtom(isRecoveringAtom);
     const setRecoveryStatus = useSetAtom(setRecoveryPayloadAtom);
@@ -47,7 +48,7 @@ export default function RecoveryMain() {
             return;
         }
 
-        getGlobal(network)
+        getGlobal(client)
             .then(async (global) => {
                 await setRecoveryStatus({
                     providers,

--- a/packages/browser-wallet/src/popup/shared/AccountInfoListenerContext/AccountInfoListenerContext.tsx
+++ b/packages/browser-wallet/src/popup/shared/AccountInfoListenerContext/AccountInfoListenerContext.tsx
@@ -1,6 +1,6 @@
 import { AccountAddress, AccountInfo } from '@concordium/web-sdk';
 import { networkConfigurationAtom, jsonRpcClientAtom, cookieAtom } from '@popup/store/settings';
-import { useAtomValue, useSetAtom } from 'jotai';
+import { useAtomValue, useSetAtom, useAtom } from 'jotai';
 import React, { createContext, ReactNode, useContext, useEffect, useMemo, useState } from 'react';
 import { atomWithChromeStorage } from '@popup/store/utils';
 import { ChromeStorageKey, CreationStatus, WalletCredential } from '@shared/storage/types';
@@ -25,12 +25,12 @@ interface Props {
 export default function AccountInfoListenerContextProvider({ children }: Props) {
     const network = useAtomValue(networkConfigurationAtom);
     const addToast = useSetAtom(addToastAtom);
-    const cookie = useAtomValue(cookieAtom);
+    const [cookie, setCookie] = useAtom(cookieAtom);
     const [accountInfoListener, setAccountInfoListener] = useState<AccountInfoListener>();
     const { t } = useTranslation();
 
     useEffect(() => {
-        const listener = new AccountInfoListener(network, cookie);
+        const listener = new AccountInfoListener(network, setCookie, cookie);
         listener.listen();
         setAccountInfoListener(listener);
         const errorListener = () => addToast(t('account.error'));

--- a/packages/browser-wallet/src/popup/shared/account-info-listener.ts
+++ b/packages/browser-wallet/src/popup/shared/account-info-listener.ts
@@ -17,9 +17,9 @@ export class AccountInfoListener extends EventEmitter {
 
     private accountsMap: Map<string, number> = new Map();
 
-    constructor(network: NetworkConfiguration) {
+    constructor(network: NetworkConfiguration, cookie?: string) {
         super();
-        this.client = new JsonRpcClient(new HttpProvider(network.jsonRpcUrl));
+        this.client = new JsonRpcClient(new HttpProvider(network.jsonRpcUrl, undefined, undefined, cookie));
         this.genesisHash = network.genesisHash;
     }
 

--- a/packages/browser-wallet/src/popup/shared/account-info-listener.ts
+++ b/packages/browser-wallet/src/popup/shared/account-info-listener.ts
@@ -17,9 +17,9 @@ export class AccountInfoListener extends EventEmitter {
 
     private accountsMap: Map<string, number> = new Map();
 
-    constructor(network: NetworkConfiguration, cookie?: string) {
+    constructor(network: NetworkConfiguration, onSetCookie: (cookie: string) => void, cookie?: string) {
         super();
-        this.client = new JsonRpcClient(new HttpProvider(network.jsonRpcUrl, undefined, undefined, cookie));
+        this.client = new JsonRpcClient(new HttpProvider(network.jsonRpcUrl, undefined, onSetCookie, cookie));
         this.genesisHash = network.genesisHash;
     }
 

--- a/packages/browser-wallet/src/popup/store/settings.ts
+++ b/packages/browser-wallet/src/popup/store/settings.ts
@@ -37,7 +37,14 @@ export const cookieAtom = atomWithChromeStorage<string | undefined>(ChromeStorag
 export const jsonRpcClientAtom = atom<JsonRpcClient>((get) => {
     const network = get(storedNetworkConfigurationAtom);
     const cookie = get(cookieAtom);
-    return new JsonRpcClient(new HttpProvider(network.jsonRpcUrl, undefined, sessionCookie.set, cookie));
+    return new JsonRpcClient(
+        new HttpProvider(
+            network.jsonRpcUrl,
+            undefined,
+            (value: string) => sessionCookie.set(network.genesisHash, value),
+            cookie
+        )
+    );
 });
 
 export const sessionPasscodeAtom = atomWithChromeStorage<string | undefined>(

--- a/packages/browser-wallet/src/popup/store/utils.ts
+++ b/packages/browser-wallet/src/popup/store/utils.ts
@@ -50,7 +50,7 @@ const accessorMap = {
     [ChromeStorageKey.Tokens]: useIndexedStorage(storedTokens, getGenesisHash),
     [ChromeStorageKey.TokenMetadata]: storedTokenMetadata,
     [ChromeStorageKey.PendingTransactions]: useIndexedStorage(sessionPendingTransactions, getGenesisHash),
-    [ChromeStorageKey.Cookie]: sessionCookie,
+    [ChromeStorageKey.Cookie]: useIndexedStorage(sessionCookie, getGenesisHash),
 };
 
 export type AsyncWrapper<V> = {

--- a/packages/browser-wallet/src/popup/store/utils.ts
+++ b/packages/browser-wallet/src/popup/store/utils.ts
@@ -23,6 +23,7 @@ import {
     storedTokens,
     storedTokenMetadata,
     sessionPendingTransactions,
+    sessionCookie,
 } from '@shared/storage/access';
 import { ChromeStorageKey } from '@shared/storage/types';
 import { atom, WritableAtom } from 'jotai';
@@ -49,6 +50,7 @@ const accessorMap = {
     [ChromeStorageKey.Tokens]: useIndexedStorage(storedTokens, getGenesisHash),
     [ChromeStorageKey.TokenMetadata]: storedTokenMetadata,
     [ChromeStorageKey.PendingTransactions]: useIndexedStorage(sessionPendingTransactions, getGenesisHash),
+    [ChromeStorageKey.Cookie]: sessionCookie,
 };
 
 export type AsyncWrapper<V> = {

--- a/packages/browser-wallet/src/shared/storage/access.ts
+++ b/packages/browser-wallet/src/shared/storage/access.ts
@@ -158,7 +158,7 @@ export const sessionIsRecovering = makeStorageAccessor<boolean>('session', Chrom
 export const sessionRecoveryStatus = makeStorageAccessor<RecoveryStatus>('session', ChromeStorageKey.RecoveryStatus);
 export const sessionOnboardingLocation = makeStorageAccessor<string>('session', ChromeStorageKey.OnboardingLocation);
 export const sessionIdpTab = makeStorageAccessor<number>('session', ChromeStorageKey.IdpTab);
-export const sessionCookie = makeStorageAccessor<string>('session', ChromeStorageKey.Cookie);
+export const sessionCookie = makeIndexedStorageAccessor<string>('session', ChromeStorageKey.Cookie);
 
 export const sessionPendingTransactions = makeIndexedStorageAccessor<string[]>( // Underlying type is serialized BrowserWalletAccountTransaction[]
     'session',

--- a/packages/browser-wallet/src/shared/storage/access.ts
+++ b/packages/browser-wallet/src/shared/storage/access.ts
@@ -158,6 +158,7 @@ export const sessionIsRecovering = makeStorageAccessor<boolean>('session', Chrom
 export const sessionRecoveryStatus = makeStorageAccessor<RecoveryStatus>('session', ChromeStorageKey.RecoveryStatus);
 export const sessionOnboardingLocation = makeStorageAccessor<string>('session', ChromeStorageKey.OnboardingLocation);
 export const sessionIdpTab = makeStorageAccessor<number>('session', ChromeStorageKey.IdpTab);
+export const sessionCookie = makeStorageAccessor<string>('session', ChromeStorageKey.Cookie);
 
 export const sessionPendingTransactions = makeIndexedStorageAccessor<string[]>( // Underlying type is serialized BrowserWalletAccountTransaction[]
     'session',

--- a/packages/browser-wallet/src/shared/storage/types.ts
+++ b/packages/browser-wallet/src/shared/storage/types.ts
@@ -22,6 +22,7 @@ export enum ChromeStorageKey {
     Tokens = 'tokens',
     TokenMetadata = 'tokenMetadata',
     PendingTransactions = 'pendingTransactions',
+    Cookie = 'cookie',
 }
 
 export enum Theme {

--- a/packages/browser-wallet/src/shared/utils/network-helpers.ts
+++ b/packages/browser-wallet/src/shared/utils/network-helpers.ts
@@ -1,4 +1,4 @@
-import { Network, JsonRpcClient, HttpProvider, CryptographicParameters } from '@concordium/web-sdk';
+import { Network, JsonRpcClient, CryptographicParameters } from '@concordium/web-sdk';
 import { NetworkConfiguration } from '@shared/storage/types';
 
 export const mainnetGenesisHash = '9dd9ca4d19e9393877d2c44b70f89acbfc0883c2243e5eeaecc0d1cd0503f478';
@@ -10,8 +10,8 @@ export function isMainnet(network: NetworkConfiguration) {
 export function getNet(network: NetworkConfiguration): Network {
     return isMainnet(network) ? 'Mainnet' : 'Testnet';
 }
-export async function getGlobal(network: NetworkConfiguration): Promise<CryptographicParameters> {
-    const client = new JsonRpcClient(new HttpProvider(network.jsonRpcUrl));
+
+export async function getGlobal(client: JsonRpcClient): Promise<CryptographicParameters> {
     const global = await client.getCryptographicParameters();
     if (!global) {
         throw new Error('no global fetched');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1891,7 +1891,7 @@ __metadata:
     "@babel/plugin-transform-modules-commonjs": ^7.12.1
     "@babel/plugin-transform-runtime": ^7.12.1
     "@babel/preset-env": ^7.12.1
-    "@concordium/web-sdk": ^2.0.0
+    "@concordium/web-sdk": ^2.1.0
     typescript: ^4.3.5
     webpack: ^5.72.0
     webpack-cli: ^4.9.2
@@ -1903,7 +1903,7 @@ __metadata:
   resolution: "@concordium/browser-wallet-api@workspace:packages/browser-wallet-api"
   dependencies:
     "@concordium/browser-wallet-api-helpers": "workspace:^"
-    "@concordium/common-sdk": ^5.0.0
+    "@concordium/common-sdk": ^5.1.0
     "@types/json-bigint": ^1.0.1
     json-bigint: ^1.0.0
     typescript: ^4.3.5
@@ -1928,7 +1928,7 @@ __metadata:
     "@babel/core": ^7.18.2
     "@concordium/browser-wallet-api": "workspace:^"
     "@concordium/browser-wallet-api-helpers": "workspace:^"
-    "@concordium/web-sdk": ^2.0.0
+    "@concordium/web-sdk": ^2.1.0
     "@craftamap/esbuild-plugin-html": ^0.4.0
     "@mdx-js/react": ^1.6.22
     "@scure/bip39": ^1.1.0
@@ -2005,7 +2005,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@concordium/common-sdk@npm:5.0.0, @concordium/common-sdk@npm:^5.0.0":
+"@concordium/common-sdk@npm:5.0.0":
   version: 5.0.0
   resolution: "@concordium/common-sdk@npm:5.0.0"
   dependencies:
@@ -2019,6 +2019,23 @@ __metadata:
     json-bigint: ^1.0.0
     uuid: ^8.3.2
   checksum: f6596b37654e515c24b29441b3b28a5972e123170cecad52c172802bfaad8b0e9d509e9e67a158444470517d56e0e0d00dbfbfc9489dce8e8afe6bb8b14f429e
+  languageName: node
+  linkType: hard
+
+"@concordium/common-sdk@npm:5.1.0, @concordium/common-sdk@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "@concordium/common-sdk@npm:5.1.0"
+  dependencies:
+    "@concordium/rust-bindings": 0.5.0
+    "@noble/ed25519": ^1.7.1
+    "@scure/bip39": ^1.1.0
+    bs58check: ^2.1.2
+    buffer: ^6.0.3
+    cross-fetch: 3.1.5
+    hash.js: ^1.1.7
+    json-bigint: ^1.0.0
+    uuid: ^8.3.2
+  checksum: e457420747fb8ba459c1bf8046ad91505d5023d354493d22a937a831d9bf68ed7506940606585356e082acd229b31a5eea715a87cc7127e4e95494bfa103bd7c
   languageName: node
   linkType: hard
 
@@ -2078,6 +2095,18 @@ __metadata:
     buffer: ^6.0.3
     process: ^0.11.10
   checksum: e122cc1a7c1d094989d9a20b855676825af8162856310b350396c26e5fdb2e8f572253e30ab8d7b9f5570c9d4fe501363c608b688001923586fc30a324ab3dcd
+  languageName: node
+  linkType: hard
+
+"@concordium/web-sdk@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@concordium/web-sdk@npm:2.1.0"
+  dependencies:
+    "@concordium/common-sdk": 5.1.0
+    "@concordium/rust-bindings": 0.5.0
+    buffer: ^6.0.3
+    process: ^0.11.10
+  checksum: 0f9b70c969b0f8e74484d82aaadeb93ad241a03d5bd0f751d1263afa29476cdfd4c7cf02060a408109e8e4724d32721435a060206a2de66f3588bfae6a14a601
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Purpose

Use cookies for communication with JSON-RPC.

## Changes

- jsonRpcClientAtom now uses/updates a cookie.
- Use jsonRpcClientAtom where possible.
- Update Web-SDK.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

