### PR TITLE
Show malformed transactions in transaction history.

### DIFF
--- a/packages/browser-wallet/src/popup/pages/Account/TransactionLog/TransactionElement.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/TransactionLog/TransactionElement.tsx
@@ -8,6 +8,7 @@ import {
     BrowserWalletTransaction,
     isAccountTransaction,
     RewardType,
+    SpecialTransactionType,
     TransactionStatus,
 } from '@popup/shared/utils/transaction-history-types';
 import { dateFromTimestamp, TimeStampUnit } from 'wallet-common-helpers';
@@ -98,7 +99,7 @@ function buildFeeString(cost: bigint, accountAddress: string, transaction: Brows
 /**
  * Maps transaction type to a displayable text string.
  */
-function mapTypeToText(type: AccountTransactionType | RewardType): string {
+function mapTypeToText(type: AccountTransactionType | RewardType | SpecialTransactionType): string {
     switch (type) {
         case AccountTransactionType.DeployModule:
             return 'Module deployment';
@@ -150,6 +151,8 @@ function mapTypeToText(type: AccountTransactionType | RewardType): string {
             return 'Configure delegation';
         case RewardType.StakingReward:
             return 'Reward payout';
+        case SpecialTransactionType.Malformed:
+            return 'Malformed';
         default:
             return 'Unknown';
     }

--- a/packages/browser-wallet/src/popup/shared/utils/transaction-history-types.ts
+++ b/packages/browser-wallet/src/popup/shared/utils/transaction-history-types.ts
@@ -26,6 +26,10 @@ export enum RewardType {
     StakingReward = 'StakingReward',
 }
 
+export enum SpecialTransactionType {
+    Malformed = 'Malformed',
+}
+
 /**
  * Internal model for transactions that have been fetched externally to be mapped into. Used for keeping
  * a consistent internal model for the display of transactions.
@@ -37,7 +41,7 @@ export interface BrowserWalletTransaction {
     blockHash: string;
     amount: bigint;
     cost?: bigint;
-    type: AccountTransactionType | RewardType;
+    type: AccountTransactionType | RewardType | SpecialTransactionType;
     status: TransactionStatus;
     time: bigint;
     id: number;

--- a/packages/browser-wallet/src/popup/shared/utils/wallet-proxy.ts
+++ b/packages/browser-wallet/src/popup/shared/utils/wallet-proxy.ts
@@ -7,6 +7,7 @@ import {
     BrowserWalletAccountTransaction,
     BrowserWalletTransaction,
     RewardType,
+    SpecialTransactionType,
     TransactionHistoryResult,
     TransactionStatus,
 } from './transaction-history-types';
@@ -49,7 +50,9 @@ export enum TransactionKindString {
     Malformed = 'Malformed account transaction',
 }
 
-function mapTransactionKindStringToTransactionType(kind: TransactionKindString): AccountTransactionType | RewardType {
+function mapTransactionKindStringToTransactionType(
+    kind: TransactionKindString
+): AccountTransactionType | RewardType | SpecialTransactionType {
     switch (kind) {
         case TransactionKindString.DeployModule:
             return AccountTransactionType.DeployModule;
@@ -101,6 +104,8 @@ function mapTransactionKindStringToTransactionType(kind: TransactionKindString):
             return AccountTransactionType.ConfigureDelegation;
         case TransactionKindString.StakingReward:
             return RewardType.StakingReward;
+        case TransactionKindString.Malformed:
+            return SpecialTransactionType.Malformed;
         default:
             throw Error(`Unkown transaction kind was encounted: ${kind}`);
     }
@@ -243,10 +248,8 @@ export async function getTransactions(
 
     const response = await (await getWalletProxy()).get(proxyPath);
     const result: WalletProxyAccTransactionsResult = response.data;
-    const transactionsWithoutMalformed = result.transactions.filter(
-        (t) => t.details.type !== TransactionKindString.Malformed
-    );
-    const transactions = transactionsWithoutMalformed.map((t) => mapTransaction(t, accountAddress));
+    const transactions = result.transactions.map((t) => mapTransaction(t, accountAddress));
+
     return {
         transactions,
         full: result.limit === result.count,


### PR DESCRIPTION
## Purpose

Transactions that were rejected because of malformed body weren't shown in the browser wallet, hiding the full picture of expenses for an account for the user. This enables the transaction type to be shown in the transaction list

## Changes

- Remove filter on transactions endpoint.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
