### PR TITLE
Add indication that tokens can be selected from send page

### DIFF
--- a/packages/browser-wallet/src/popup/pages/Account/SendCcd/CreateTransfer.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/SendCcd/CreateTransfer.tsx
@@ -33,8 +33,10 @@ import { getTokenTransferEnergy, TokenIdentifier, trunctateSymbol } from '@share
 import { jsonRpcClientAtom } from '@popup/store/settings';
 import CcdIcon from '@assets/svg/concordium.svg';
 import { addToastAtom } from '@popup/state';
+import TokenBalance from '@popup/shared/TokenBalance';
+import Button from '@popup/shared/Button';
+import SearchIcon from '@assets/svg/search.svg';
 import { routes } from './routes';
-import DisplayToken from './DisplayToken';
 import PickToken from './PickToken';
 
 export type FormValues = {
@@ -220,15 +222,35 @@ function CreateTransaction({ exchangeRate, tokens, setCost, setDetailsExpanded }
         >
             {(f) => (
                 <>
-                    <div className={clsx('create-transfer__token-picker')}>
-                        <DisplayToken
-                            metadata={tokenMetadata}
-                            balance={currentBalance}
-                            disabled={!accountTokens}
-                            onClick={() => setPickingToken(true)}
-                            className="w-full"
-                            icon={tokenMetadata === CCD_METADATA ? <CcdIcon className="ccd-icon" /> : undefined}
-                        />
+                    <div className="create-transfer__token-picker">
+                        <Button className="token-picker-button" clear onClick={() => setPickingToken(true)}>
+                            <div className="token-picker-button__token-display-container">
+                                <div className="flex align-center">
+                                    {tokenMetadata === CCD_METADATA ? (
+                                        <div className="token-picker-button__token-display">
+                                            <CcdIcon className="ccd-icon" />
+                                        </div>
+                                    ) : (
+                                        <img
+                                            alt={tokenMetadata.name}
+                                            className="token-picker-button__token-display"
+                                            src={tokenMetadata.thumbnail?.url ?? tokenMetadata.display?.url}
+                                        />
+                                    )}
+                                    <div className="token-picker-button__details">
+                                        <div className="clamp-1 w-full">{tokenMetadata.name}</div>
+                                        <div className="token-picker-button__balance">
+                                            <TokenBalance
+                                                decimals={tokenMetadata.decimals || 0}
+                                                symbol={tokenMetadata.symbol}
+                                                balance={currentBalance}
+                                            />
+                                        </div>
+                                    </div>
+                                </div>
+                                <SearchIcon className="token-picker-button__search-icon" />
+                            </div>
+                        </Button>
                     </div>
                     <AmountInput
                         register={f.register}

--- a/packages/browser-wallet/src/popup/pages/Account/SendCcd/SendCcd.scss
+++ b/packages/browser-wallet/src/popup/pages/Account/SendCcd/SendCcd.scss
@@ -71,7 +71,8 @@ $error-spacing: rem(13.286px);
     }
 }
 
-.display-token {
+.display-token,
+.token-picker-button {
     border: rem(1px) solid $color-cta;
     border-radius: rem(5px);
     padding: rem(5px);
@@ -94,9 +95,27 @@ $error-spacing: rem(13.286px);
         max-width: rem(40px);
         margin-right: rem(5px);
     }
+}
 
+.display-token {
     &__details {
         text-align: right;
         width: calc(100% - #{rem(45px)}); // subtract max-width + margin of &__token-display.
+    }
+}
+
+.token-picker-button {
+    width: 100%;
+
+    &__search-icon {
+        height: rem(16px);
+
+        path {
+            fill: $color-text;
+        }
+    }
+
+    &__details {
+        text-align: left;
     }
 }


### PR DESCRIPTION
## Purpose

It was hard to see that you could actually select a token from the create transfer page. This adds an indication that you can, while also aligning with the implementation in the mobile wallet.

## Changes

- Add search icon to select token field.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
