### PR TITLE
Add exit button for recovery finish screen, if not a spawned window

### DIFF
--- a/packages/browser-wallet/src/popup/pages/Recovery/Recovery.scss
+++ b/packages/browser-wallet/src/popup/pages/Recovery/Recovery.scss
@@ -61,4 +61,10 @@
             margin-bottom: rem(10px);
         }
     }
+
+    &__exit-button {
+        position: absolute;
+        right: rem(17px);
+        top: rem(17px);
+    }
 }

--- a/packages/browser-wallet/src/popup/pages/Recovery/RecoveryFinish.tsx
+++ b/packages/browser-wallet/src/popup/pages/Recovery/RecoveryFinish.tsx
@@ -12,6 +12,10 @@ import { IdentityIdentifier, BackgroundResponseStatus, RecoveryBackgroundRespons
 import { fullscreenPromptContext } from '@popup/page-layouts/FullscreenPromptLayout';
 import PageHeader from '@popup/shared/PageHeader';
 import { identityMatch, isIdentityOfCredential } from '@shared/utils/identity-helpers';
+import CloseButton from '@popup/shared/CloseButton';
+import { isSpawnedWindow } from '@popup/shared/window-helpers';
+
+const RETURN_LOCATION = absoluteRoutes.home.account.path;
 
 interface Location {
     state: {
@@ -88,10 +92,13 @@ export default function DisplayRecoveryResult() {
     const { t } = useTranslation('recovery');
     const navigate = useNavigate();
 
-    useEffect(() => setReturnLocation(absoluteRoutes.home.account.path), []);
+    useEffect(() => setReturnLocation(RETURN_LOCATION), []);
 
     return (
         <>
+            {!isSpawnedWindow && (
+                <CloseButton className="recovery__exit-button" onClick={() => navigate(RETURN_LOCATION)} />
+            )}
             <PageHeader>{t('main.title')}</PageHeader>
             <div className="recovery__main onboarding-setup__page-with-header">
                 {payload.status === BackgroundResponseStatus.Success && (


### PR DESCRIPTION
## Purpose

Add an exit button when recovery has failed, so that you are not "stuck".

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [] (If necessary) I have updated the CHANGELOG.


