### PR TITLE
Improve handling of bad balanceOf on tokens

### DIFF
--- a/packages/browser-wallet/src/popup/pages/Account/ManageTokens/utils.ts
+++ b/packages/browser-wallet/src/popup/pages/Account/ManageTokens/utils.ts
@@ -27,7 +27,13 @@ export const manageTokensRoutes = {
 };
 
 export const fetchTokensConfigure =
-    (contractDetails: ContractDetails, client: JsonRpcClient, network: NetworkConfiguration, account: string) =>
+    (
+        contractDetails: ContractDetails,
+        client: JsonRpcClient,
+        network: NetworkConfiguration,
+        account: string,
+        onError?: (error: string) => void
+    ) =>
     async (from?: number): Promise<FetchTokensResponse> => {
         const {
             tokens: cts,
@@ -45,7 +51,8 @@ export const fetchTokensConfigure =
             client,
             network,
             account,
-            cts.map((t) => t.token)
+            cts.map((t) => t.token),
+            onError
         );
 
         return {

--- a/packages/browser-wallet/src/popup/pages/ExternalAddTokens/ExternalAddTokens.tsx
+++ b/packages/browser-wallet/src/popup/pages/ExternalAddTokens/ExternalAddTokens.tsx
@@ -87,7 +87,7 @@ export default function SignMessage({ respond }: Props) {
             addToast(t('filterInvalid'));
         }
 
-        getTokens(contractDetails, client, network, account, filteredIds).then((newTokens) => {
+        getTokens(contractDetails, client, network, account, filteredIds, addToast).then((newTokens) => {
             const tokensToAdd = newTokens
                 .filter((token) => token.metadata)
                 .map(

--- a/packages/browser-wallet/src/popup/shared/TokenBalance.tsx
+++ b/packages/browser-wallet/src/popup/shared/TokenBalance.tsx
@@ -1,19 +1,27 @@
 import { trunctateSymbol } from '@shared/utils/token-helpers';
+import { useTranslation } from 'react-i18next';
 import React from 'react';
 import { addThousandSeparators, integerToFractional, pipe } from 'wallet-common-helpers';
 
 type BalanceProps = {
-    balance: bigint;
+    balance?: bigint;
     decimals: number;
     symbol?: string;
 };
 
 export default function TokenBalance({ balance, decimals, symbol = '' }: BalanceProps) {
     const renderBalance = pipe(integerToFractional(decimals), addThousandSeparators);
+    const hasBalance = balance !== undefined;
+    const { t } = useTranslation('shared');
 
     return (
         <>
-            {renderBalance(balance)} {trunctateSymbol(symbol)}
+            {hasBalance && (
+                <>
+                    {renderBalance(balance)} {trunctateSymbol(symbol)}
+                </>
+            )}
+            {!hasBalance && <i>{t('tokenBalance.noBalance')}</i>}
         </>
     );
 }

--- a/packages/browser-wallet/src/popup/shared/i18n/da.ts
+++ b/packages/browser-wallet/src/popup/shared/i18n/da.ts
@@ -69,6 +69,9 @@ const t: typeof en = {
             remove: 'Fjern token',
         },
     },
+    tokenBalance: {
+        noBalance: 'Ingen saldo hentet',
+    },
 };
 
 export default t;

--- a/packages/browser-wallet/src/popup/shared/i18n/en.ts
+++ b/packages/browser-wallet/src/popup/shared/i18n/en.ts
@@ -67,6 +67,9 @@ const t = {
             remove: 'Remove token',
         },
     },
+    tokenBalance: {
+        noBalance: 'Missing balance',
+    },
 };
 
 export default t;

--- a/packages/browser-wallet/src/popup/store/token.ts
+++ b/packages/browser-wallet/src/popup/store/token.ts
@@ -4,8 +4,7 @@ import { mapRecordValues } from 'wallet-common-helpers/src/utils/basicHelpers';
 import { atomFamily } from 'jotai/utils';
 import { ChromeStorageKey, TokenIdAndMetadata, TokenMetadata, TokenStorage } from '@shared/storage/types';
 import { ContractBalances, getContractBalances } from '@shared/utils/token-helpers';
-import { JsonRpcClient } from '@concordium/web-sdk';
-import { loop } from '@shared/utils/function-helpers';
+import { addToastAtom } from '@popup/state';
 import { AsyncWrapper, atomWithChromeStorage } from './utils';
 import { jsonRpcClientAtom } from './settings';
 import { selectedAccountAtom } from './account';
@@ -129,7 +128,14 @@ const cbf = atomFamily<string, Atom<ContractBalances>>((identifier: string) => {
             const tokenIds = tokens.value[contractIndex]?.map((t) => t.id) ?? [];
 
             if (tokenIds.length !== 0) {
-                const balances = await getContractBalances(client, BigInt(contractIndex), 0n, tokenIds, accountAddress);
+                const balances = await getContractBalances(
+                    client,
+                    BigInt(contractIndex),
+                    0n,
+                    tokenIds,
+                    accountAddress,
+                    (error) => set(addToastAtom, error)
+                );
                 set(baseAtom, balances);
             }
         }

--- a/packages/browser-wallet/src/shared/utils/token-helpers.ts
+++ b/packages/browser-wallet/src/shared/utils/token-helpers.ts
@@ -386,14 +386,21 @@ export async function getTokenTransferEnergy(
     return { execution, total };
 }
 
-export const getTokens = async (
+type GetTokensResult = {
+    id: string;
+    metadataLink: string;
+    metadata: TokenMetadata | undefined;
+    balance: bigint;
+}[];
+
+export async function getTokens(
     contractDetails: ContractDetails,
     client: JsonRpcClient,
     network: NetworkConfiguration,
     account: string,
     ids: string[],
     onError?: (error: string) => void
-) => {
+): Promise<GetTokensResult> {
     const metadataPromise: Promise<[string[], Array<TokenMetadata | undefined>]> = (async () => {
         const metadataUrls = await getTokenUrl(client, ids, contractDetails);
         const metadata = await Promise.all(
@@ -413,15 +420,22 @@ export const getTokens = async (
 
     const [[metadataUrls, metadata], balances] = await Promise.all([metadataPromise, balancesPromise]); // Run in parallel.
 
-    return ids
-        .filter((id, i) => id in balances && metadata[i])
-        .map((id, i) => ({
-            id,
-            metadataLink: metadataUrls[i],
-            metadata: metadata[i],
-            balance: balances[id] ?? 0n,
-        }));
-};
+    return ids.reduce(
+        (acc, id, i) =>
+            id in balances && metadata[i]
+                ? [
+                      ...acc,
+                      {
+                          id,
+                          metadataLink: metadataUrls[i],
+                          metadata: metadata[i],
+                          balance: balances[id] ?? 0n,
+                      },
+                  ]
+                : acc,
+        [] as GetTokensResult
+    );
+}
 
 const MAX_SYMBOL_LENGTH = 10;
 


### PR DESCRIPTION
## Purpose

- Filter tokens with failing `balanceOf` in Manage page 
- Show error when `balanceOf` fails 
- Show no balance instead of nothing in token list/detail if `balanceOf` fails.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
