### PR TITLE
Improve sendTransaction backwards compatibility

### DIFF
--- a/packages/browser-wallet-api/src/wallet-api.ts
+++ b/packages/browser-wallet-api/src/wallet-api.ts
@@ -116,20 +116,23 @@ class WalletApi extends EventEmitter implements IWalletApi {
         let parsedPayload = payload;
         if (type === AccountTransactionType.InitContract) {
             const initPayload: InitContractPayload = {
-                ...payload,
-                initName: payload.initName || payload.contractName,
+                ...(payload as InitContractPayload),
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                initName: (payload as InitContractPayload).initName || (payload as any).contractName,
             };
             parsedPayload = initPayload;
         } else if (type === AccountTransactionType.Update) {
             const updatePayload: UpdateContractPayload = {
-                ...payload,
-                address: payload.address || payload.contractAddress,
+                ...(payload as UpdateContractPayload),
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                address: (payload as UpdateContractPayload).address || (payload as any).contractAddress,
             };
             parsedPayload = updatePayload;
         } else if (type === AccountTransactionType.DeployModule) {
             const deployPayload: DeployModulePayload = {
-                ...payload,
-                source: payload.source || payload.content,
+                ...(payload as DeployModulePayload),
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                source: (payload as DeployModulePayload).source || (payload as any).content,
             };
             parsedPayload = deployPayload;
         }


### PR DESCRIPTION
## Purpose

Support the differently name fields from older SDK versions for sendTransaction.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
