### PR TITLE
Fix CIS0 and CIS2 error labels when choosing contract

### DIFF
--- a/packages/browser-wallet/src/popup/pages/Account/i18n/da.ts
+++ b/packages/browser-wallet/src/popup/pages/Account/i18n/da.ts
@@ -65,8 +65,6 @@ const t: typeof en = {
             chooseContract: 'Vælg kontrakt',
             indexRequired: 'Kontrakt indeks er påkrævet',
             noContractFound: 'Ingen kontrakt fundet på indeks',
-            cis0Error: 'Kontrakten supporterer ikke CIS-0',
-            cis2Error: 'Kontrakten supporterer ikke CIS-2',
             noTokensError: 'Ingen tokens fundet i kontrakten',
             failedTokensError: 'En fejl skete under tjekket efter tokens',
             contractIndex: 'Kontrakt indeks',

--- a/packages/browser-wallet/src/popup/pages/Account/i18n/en.ts
+++ b/packages/browser-wallet/src/popup/pages/Account/i18n/en.ts
@@ -63,8 +63,6 @@ const t = {
             chooseContract: 'Choose Contract',
             indexRequired: 'Contract index is required',
             noContractFound: 'No contract found on index',
-            cis0Error: 'Contract does not support CIS-0',
-            cis2Error: 'Contract does not support CIS-2',
             noTokensError: 'No tokens found in contract',
             failedTokensError: 'Error occurred when checking for tokens in the contract',
             contractIndex: 'Contract index',

--- a/packages/browser-wallet/src/popup/shared/i18n/da.ts
+++ b/packages/browser-wallet/src/popup/shared/i18n/da.ts
@@ -72,6 +72,10 @@ const t: typeof en = {
     tokenBalance: {
         noBalance: 'Ingen saldo hentet',
     },
+    addTokens: {
+        cis0Error: 'Kontrakten supporterer ikke CIS-0',
+        cis2Error: 'Kontrakten supporterer ikke CIS-2',
+    },
 };
 
 export default t;

--- a/packages/browser-wallet/src/popup/shared/i18n/en.ts
+++ b/packages/browser-wallet/src/popup/shared/i18n/en.ts
@@ -70,6 +70,10 @@ const t = {
     tokenBalance: {
         noBalance: 'Missing balance',
     },
+    addTokens: {
+        cis0Error: 'Contract does not support CIS-0',
+        cis2Error: 'Contract does not support CIS-2',
+    },
 };
 
 export default t;

--- a/packages/browser-wallet/src/shared/utils/token-helpers.ts
+++ b/packages/browser-wallet/src/shared/utils/token-helpers.ts
@@ -93,14 +93,14 @@ export async function confirmCIS2Contract(
         parameter: getCIS2Identifier(),
     });
     if (!supports || supports.tag === 'failure') {
-        return i18n.t('account.tokens.add.cis0Error');
+        return i18n.t('addTokens.cis0Error');
     }
 
     // Supports return 2 bytes that determine the number of answers. 0100 means there is 1 answer
     // 01 Means the standard is supported.
     // TODO: Handle 02 answer properly (https://proposals.concordium.software/CIS/cis-0.html#response)
     if (supports.returnValue !== '010001') {
-        return i18n.t('account.tokens.add.cis2Error');
+        return i18n.t('addTokens.cis2Error');
     }
 
     return undefined;


### PR DESCRIPTION
## Purpose

I'm not sure who thought this was a good idea, but it turns out, using the i18n outside react, it uses the shared file.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

