### PR TITLE
Fix init contract parameter parsing

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.8.5
+
+### Fixed
+
+-   Blank prompt when requesting an `initContract` transaction with parameters.
+
 ## 0.8.4
 
 ### Fixed

--- a/packages/browser-wallet/package.json
+++ b/packages/browser-wallet/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/browser-wallet",
-    "version": "0.8.4",
+    "version": "0.8.5",
     "description": "Browser extension wallet for the Concordium blockchain",
     "author": "Concordium Software",
     "license": "Apache-2.0",

--- a/packages/browser-wallet/src/popup/pages/SendTransaction/util.ts
+++ b/packages/browser-wallet/src/popup/pages/SendTransaction/util.ts
@@ -65,7 +65,7 @@ export function parsePayload(
                 parameter = Buffer.alloc(0);
             } else {
                 parameter = serializeInitContractParameters(
-                    payload.contractName,
+                    payload.initName,
                     parameters,
                     Buffer.from(schema, 'base64'),
                     schemaVersion


### PR DESCRIPTION
## Purpose

Fix blank prompt when requesting an `initContract` transaction with parameters.

## Changes

Fixed the field name used for serializing the parameter. 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.