### PR TITLE
Handle account limit when picking identity to create a new account with

### DIFF
--- a/packages/browser-wallet/src/popup/pages/AddAccount/AddAccount.scss
+++ b/packages/browser-wallet/src/popup/pages/AddAccount/AddAccount.scss
@@ -28,4 +28,13 @@
         margin-top: auto;
         margin-bottom: rem(40px);
     }
+
+    &__disabled-identity-card {
+        filter: brightness(75%);
+    }
+
+    &__error-message {
+        max-width: 75%;
+        text-align: center;
+    }
 }

--- a/packages/browser-wallet/src/popup/pages/AddAccount/AddAccount.scss
+++ b/packages/browser-wallet/src/popup/pages/AddAccount/AddAccount.scss
@@ -28,13 +28,4 @@
         margin-top: auto;
         margin-bottom: rem(40px);
     }
-
-    &__disabled-identity-card {
-        filter: brightness(75%);
-    }
-
-    &__error-message {
-        max-width: 75%;
-        text-align: center;
-    }
 }

--- a/packages/browser-wallet/src/popup/pages/AddAccount/ChooseIdentity.tsx
+++ b/packages/browser-wallet/src/popup/pages/AddAccount/ChooseIdentity.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { useAtomValue, useSetAtom } from 'jotai';
@@ -6,13 +6,22 @@ import IdentityProviderIcon from '@popup/shared/IdentityProviderIcon';
 
 import IdCard from '@popup/shared/IdCard';
 import { identitiesAtom, selectedIdentityIndexAtom, identityProvidersAtom } from '@popup/store/identity';
-import { Identity, CreationStatus } from '@shared/storage/types';
+import { Identity, CreationStatus, WalletCredential, ConfirmedIdentity } from '@shared/storage/types';
 import { absoluteRoutes } from '@popup/constants/routes';
 import Button from '@popup/shared/Button';
 import { credentialsAtom } from '@popup/store/account';
 import { getMaxAccountsForIdentity, isIdentityOfCredential } from '@shared/utils/identity-helpers';
-import ErrorMessage from '@popup/shared/Form/ErrorMessage';
 import { getNextEmptyCredNumber } from '@popup/shared/utils/account-helpers';
+import Modal from '@popup/shared/Modal';
+import i18n from '@popup/shell/i18n';
+
+function validateValidForAccountCreation(identity: ConfirmedIdentity, creds: WalletCredential[]): string | undefined {
+    const nextCredNumber = getNextEmptyCredNumber(creds);
+    if (nextCredNumber >= getMaxAccountsForIdentity(identity)) {
+        return i18n.t('maxAccountsReached', { ns: 'addAccount' });
+    }
+    return undefined;
+}
 
 export default function ChooseIdentity() {
     const { t } = useTranslation('addAccount');
@@ -21,6 +30,7 @@ export default function ChooseIdentity() {
     const nav = useNavigate();
     const providers = useAtomValue(identityProvidersAtom);
     const credentials = useAtomValue(credentialsAtom);
+    const [modalMessage, setModalMessage] = useState<string>();
 
     const findProvider = useCallback(
         (identity: Identity) => providers.find((p) => p.ipInfo.ipIdentity === identity.providerIndex),
@@ -44,40 +54,34 @@ export default function ChooseIdentity() {
 
     return (
         <div className="flex-column align-center">
+            <Modal open={Boolean(modalMessage)} onClose={() => setModalMessage(undefined)}>
+                {modalMessage}
+            </Modal>
             <p className="m-t-20 text-center p-h-10">{t('chooseIdentity')}</p>
             {identities.map((identity, i) => {
                 if (identity.status !== CreationStatus.Confirmed) {
                     return null;
                 }
                 const credsOfCurrentIdentity = credentials.filter(isIdentityOfCredential(identity));
-                const nextCredNumber = getNextEmptyCredNumber(credsOfCurrentIdentity);
-                if (nextCredNumber < getMaxAccountsForIdentity(identity)) {
-                    return (
-                        <IdCard
-                            name={identity.name}
-                            key={`${identity.providerIndex}-${identity.index}`}
-                            provider={<IdentityProviderIcon provider={findProvider(identity)} />}
-                            status={identity.status}
-                            className="m-t-10"
-                            onClick={() => {
-                                setSelectedIdentityIndex(i);
-                                nav('confirm');
-                            }}
-                        />
-                    );
-                }
+                const reason = validateValidForAccountCreation(identity, credsOfCurrentIdentity);
+
                 return (
-                    <Fragment key={`${identity.providerIndex}-${identity.index}`}>
-                        <IdCard
-                            name={identity.name}
-                            provider={<IdentityProviderIcon provider={findProvider(identity)} />}
-                            status={identity.status}
-                            className="m-t-10 add-account-page__disabled-identity-card"
-                        />
-                        <ErrorMessage className="m-t-10 add-account-page__error-message">
-                            {t('maxAccountsReached')}
-                        </ErrorMessage>
-                    </Fragment>
+                    <IdCard
+                        name={identity.name}
+                        key={`${identity.providerIndex}-${identity.index}`}
+                        provider={<IdentityProviderIcon provider={findProvider(identity)} />}
+                        status={identity.status}
+                        disabled={Boolean(reason)}
+                        className="m-t-10"
+                        onClick={
+                            reason
+                                ? () => setModalMessage(reason)
+                                : () => {
+                                      setSelectedIdentityIndex(i);
+                                      nav('confirm');
+                                  }
+                        }
+                    />
                 );
             })}
         </div>

--- a/packages/browser-wallet/src/popup/pages/AddAccount/i18n/da.ts
+++ b/packages/browser-wallet/src/popup/pages/AddAccount/i18n/da.ts
@@ -5,6 +5,7 @@ const t: typeof en = {
     createAccount: 'Opret konto',
     noIdentities: 'Du har ingen identiter, men en identitet er nødvendig for at oprette en konto.',
     createIdentity: 'Opret identitet',
+    maxAccountsReached: 'Denne identitet har allerede lavet alle tilladte konti',
 };
 
 export default t;

--- a/packages/browser-wallet/src/popup/pages/AddAccount/i18n/en.ts
+++ b/packages/browser-wallet/src/popup/pages/AddAccount/i18n/en.ts
@@ -3,6 +3,7 @@ const t = {
     createAccount: 'Create new account',
     noIdentities: 'You have no identities, however you need an identity to create an account.',
     createIdentity: 'Create new identity',
+    maxAccountsReached: 'This identity has already reached its account creation limit',
 };
 
 export default t;

--- a/packages/browser-wallet/src/popup/shared/IdCard/IdCard.scss
+++ b/packages/browser-wallet/src/popup/shared/IdCard/IdCard.scss
@@ -8,6 +8,7 @@
     background-color: $color-bg;
     color: $color-text;
 
+    &--disabled,
     &--pending {
         border-color: $color-grey;
     }
@@ -30,6 +31,7 @@
         align-items: center;
         justify-content: center;
 
+        .id-card--disabled &,
         .id-card--pending & {
             background-color: $color-grey;
         }
@@ -55,6 +57,10 @@
                 top: 50%;
                 transform: translate(50%, -50%);
                 width: rem(10px);
+
+                .id-card--disabled & {
+                    fill: $color-grey;
+                }
             }
         }
     }
@@ -137,6 +143,12 @@
             }
         }
 
+        .id-card--disabled & {
+            path {
+                fill: $color-grey;
+            }
+        }
+
         circle {
             fill: $color-bg;
         }
@@ -174,9 +186,5 @@
                 fill: $color-cta;
             }
         }
-    }
-
-    &--clickable {
-        cursor: pointer;
     }
 }

--- a/packages/browser-wallet/src/popup/shared/IdCard/IdCard.scss
+++ b/packages/browser-wallet/src/popup/shared/IdCard/IdCard.scss
@@ -175,4 +175,8 @@
             }
         }
     }
+
+    &--clickable {
+        cursor: pointer;
+    }
 }

--- a/packages/browser-wallet/src/popup/shared/IdCard/IdCard.tsx
+++ b/packages/browser-wallet/src/popup/shared/IdCard/IdCard.tsx
@@ -89,12 +89,13 @@ type Props = {
     status: IdentityStatus;
     onNameChange?(name: string): void;
     onClick?(): void;
+    disabled?: boolean;
     provider: JSX.Element;
     className?: string;
 };
 // TODO: Fix these
 /* eslint-disable jsx-a11y/no-static-element-interactions , jsx-a11y/click-events-have-key-events */
-export default function IdCard({ name, provider, status, onNameChange, className, onClick }: Props) {
+export default function IdCard({ name, provider, disabled, status, onNameChange, className, onClick }: Props) {
     const { t } = useTranslation();
     const [isEditing, setIsEditing] = useState(false);
     const editNameRef = useRef<HTMLFormElement>(null);
@@ -111,6 +112,7 @@ export default function IdCard({ name, provider, status, onNameChange, className
                 status === 'pending' && 'id-card--pending',
                 status === 'confirmed' && 'id-card--confirmed',
                 status === 'rejected' && 'id-card--rejected',
+                disabled && 'id-card--disabled',
                 onClick !== undefined && 'id-card--clickable',
                 className
             )}

--- a/packages/browser-wallet/src/shared/utils/identity-helpers.ts
+++ b/packages/browser-wallet/src/shared/utils/identity-helpers.ts
@@ -1,4 +1,4 @@
-import { WalletCredential } from '@shared/storage/types';
+import { ConfirmedIdentity, WalletCredential } from '@shared/storage/types';
 import { BackgroundResponseStatus, IdentityIdentifier } from './types';
 
 /** The type of the response from the background script during identityIssuance */
@@ -26,3 +26,10 @@ export const identityMatch = (target: IdentityIdentifier) => (candidate: Identit
  */
 export const isIdentityOfCredential = (id: IdentityIdentifier) => (cred: WalletCredential) =>
     id.index === cred.identityIndex && id.providerIndex === cred.providerIndex;
+
+export function getMaxAccountsForIdentity(identity: ConfirmedIdentity) {
+    if (identity.idObject.v !== 0) {
+        throw new Error('unsupported identity object version');
+    }
+    return identity.idObject.value.attributeList.maxAccounts;
+}


### PR DESCRIPTION
## Purpose

Block user from trying (and failing) to create accounts on identities which has already reached the limit.

## Changes

- Disable identity cards in list when creating new account, if limit has been reached. (and display a message)
- IdCard now have pointer cursor when clickable

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.