### PR TITLE
Img now defaults to failed image if no src is given

### DIFF
--- a/packages/browser-wallet/src/popup/shared/Img.tsx
+++ b/packages/browser-wallet/src/popup/shared/Img.tsx
@@ -28,7 +28,7 @@ export default function Img({ src, alt, className, ...props }: Props) {
         : props;
 
     const [loaded, setLoaded] = useState(false);
-    const [failed, setFailed] = useState(false);
+    const [failed, setFailed] = useState(!src);
 
     const shouldHide = (!loaded && loadingImage) || (failed && failedImage);
 
@@ -43,7 +43,10 @@ export default function Img({ src, alt, className, ...props }: Props) {
                 className={clsx(shouldHide && 'd-none', className)}
                 src={src}
                 alt={alt}
-                onLoad={() => setLoaded(true)}
+                onLoad={() => {
+                    setLoaded(true);
+                    setFailed(false);
+                }}
                 onError={handleError}
             />
             {shouldHide && <img className={className} src={failed ? failedImage : loadingImage} alt={alt} />}


### PR DESCRIPTION
## Purpose

Tokens with no image now displays failed placeholder image instead loading. 

## Changes

Changes in Img component behaviour.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
