### PR TITLE
Validate that recipient exists on transfer

### DIFF
--- a/packages/browser-wallet/src/popup/pages/Account/i18n/da.ts
+++ b/packages/browser-wallet/src/popup/pages/Account/i18n/da.ts
@@ -53,6 +53,7 @@ const t: typeof en = {
         unableToSendFailedInvoke: 'Simulering af overførsel fejlede, overførslen er ikke mulig.',
         transferInvokeFailed: 'Simulering af overførsel fejlede: {{ message }}',
         unableToCreatePayload: 'Konstruktion af transaktion fejlede: {{ message}}',
+        nonexistingAccount: 'Modtager findes ikke på kæden',
         fee: 'Estimerede transaktionsomkostninger',
     },
     tokens: {

--- a/packages/browser-wallet/src/popup/pages/Account/i18n/en.ts
+++ b/packages/browser-wallet/src/popup/pages/Account/i18n/en.ts
@@ -51,6 +51,7 @@ const t = {
         unableToSendFailedInvoke: 'Simulation of transfer failed, unable to proceed.',
         transferInvokeFailed: 'Simulation of transfer failed: {{ message }}',
         unableToCreatePayload: 'Unable to create transaction: {{ message}}',
+        nonexistingAccount: 'The recipient is not registered on the chain',
         fee: 'Estimated transaction fee',
     },
     tokens: {


### PR DESCRIPTION
## Purpose

Block user from sending transfers to accounts that have not been created.

## Changes

- Reworked recipient validation function in transfer
- Removed todo for issue that has already been fixed

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
