### PR TITLE
Always use mainnet proxy for terms and conditions

### DIFF
--- a/packages/browser-wallet/src/background/index.ts
+++ b/packages/browser-wallet/src/background/index.ts
@@ -124,9 +124,8 @@ async function reportVersion(network?: NetworkConfiguration) {
 
 async function checkForNewTermsAndConditions() {
     const current = await storedAcceptedTerms.get();
-    const network = await storedCurrentNetwork.get();
     try {
-        const config = await getTermsAndConditionsConfig(network?.explorerUrl);
+        const config = await getTermsAndConditionsConfig();
         if (config?.version && (!current || current.version !== config.version)) {
             storedAcceptedTerms.set({ accepted: false, version: config.version });
         }

--- a/packages/browser-wallet/src/popup/pages/TermsAndConditions/AcceptTerms.tsx
+++ b/packages/browser-wallet/src/popup/pages/TermsAndConditions/AcceptTerms.tsx
@@ -8,8 +8,8 @@ import FormCheckbox from '@popup/shared/Form/Checkbox';
 import ExternalLink from '@popup/shared/ExternalLink';
 import urls from '@shared/constants/url';
 import Submit from '@popup/shared/Form/Submit';
-import { useAtom, useAtomValue } from 'jotai';
-import { acceptedTermsAtom, networkConfigurationAtom } from '@popup/store/settings';
+import { useAtom } from 'jotai';
+import { acceptedTermsAtom } from '@popup/store/settings';
 import { getTermsAndConditionsConfig } from '@shared/utils/network-helpers';
 import { useAsyncMemo } from 'wallet-common-helpers';
 
@@ -25,8 +25,7 @@ type Props = {
 export default function AcceptTerms({ children, onSubmit }: Props) {
     const { t } = useTranslation('termsAndConditions');
     const [{ loading, value: acceptedTerms }, setAcceptedTerms] = useAtom(acceptedTermsAtom);
-    const network = useAtomValue(networkConfigurationAtom);
-    const config = useAsyncMemo(() => getTermsAndConditionsConfig(network.explorerUrl), undefined, []);
+    const config = useAsyncMemo(() => getTermsAndConditionsConfig(), undefined, []);
 
     const handleSubmit: SubmitHandler<FormValues> = async () => {
         const version = config?.version || acceptedTerms?.version;

--- a/packages/browser-wallet/src/popup/pages/TermsAndConditions/AcceptTerms.tsx
+++ b/packages/browser-wallet/src/popup/pages/TermsAndConditions/AcceptTerms.tsx
@@ -25,7 +25,7 @@ type Props = {
 export default function AcceptTerms({ children, onSubmit }: Props) {
     const { t } = useTranslation('termsAndConditions');
     const [{ loading, value: acceptedTerms }, setAcceptedTerms] = useAtom(acceptedTermsAtom);
-    const config = useAsyncMemo(() => getTermsAndConditionsConfig(), undefined, []);
+    const config = useAsyncMemo(getTermsAndConditionsConfig, undefined, []);
 
     const handleSubmit: SubmitHandler<FormValues> = async () => {
         const version = config?.version || acceptedTerms?.version;

--- a/packages/browser-wallet/src/shared/utils/network-helpers.ts
+++ b/packages/browser-wallet/src/shared/utils/network-helpers.ts
@@ -18,9 +18,10 @@ export async function getGlobal(client: JsonRpcClient): Promise<CryptographicPar
     return global.value;
 }
 
-export async function getTermsAndConditionsConfig(
-    explorerUrl: string = mainnet.explorerUrl
-): Promise<{ version: string; url: string } | undefined> {
-    const response = await fetch(`${explorerUrl}/v0/termsAndConditionsVersion`);
+/**
+ * Fetches the current terms and condition version (and url) from the mainnet wallet proxy.
+ */
+export async function getTermsAndConditionsConfig(): Promise<{ version: string; url: string } | undefined> {
+    const response = await fetch(`${mainnet.explorerUrl}/v0/termsAndConditionsVersion`);
     return response.json();
 }


### PR DESCRIPTION
## Purpose

To remove the burden of keeping the wallet-proxy versions in sync (or risk extra prompts), we will only use the mainnet one.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
