### PR TITLE
wCCD: Improve error handling

### DIFF
--- a/examples/wCCD/src/Root.tsx
+++ b/examples/wCCD/src/Root.tsx
@@ -30,7 +30,17 @@ export default function Root() {
                 <WithWalletConnection network={network} walletConnectOpts={walletConnectOpts}>
                     {(props) => <WCCD {...props} />}
                 </WithWalletConnection>
-                <div>Version: {version}</div>
+                <div>
+                    <a
+                        style={{ color: 'white' }}
+                        href="https://developer.concordium.software/en/mainnet/smart-contracts/tutorials/wCCD/index.html"
+                        target="_blank"
+                        rel="noreferrer"
+                    >
+                        Learn how to make a wrapper like this
+                    </a>{' '}
+                    | Version: {version}
+                </div>
             </main>
         </div>
     );

--- a/examples/wCCD/src/Root.tsx
+++ b/examples/wCCD/src/Root.tsx
@@ -31,6 +31,7 @@ export default function Root() {
                     {(props) => <WCCD {...props} />}
                 </WithWalletConnection>
                 <div>
+                    Version: {version} |{' '}
                     <a
                         style={{ color: 'white' }}
                         href="https://developer.concordium.software/en/mainnet/smart-contracts/tutorials/wCCD/index.html"
@@ -38,8 +39,7 @@ export default function Root() {
                         rel="noreferrer"
                     >
                         Learn how to make a wrapper like this
-                    </a>{' '}
-                    | Version: {version}
+                    </a>
                 </div>
             </main>
         </div>

--- a/examples/wCCD/src/WalletConnectorTypeButton.tsx
+++ b/examples/wCCD/src/WalletConnectorTypeButton.tsx
@@ -2,7 +2,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import React from 'react';
-import { destroy } from './wallet/WalletConnection';
 import { WalletConnectionProps } from './wallet/WithWalletConnection';
 
 function connectorTypeStyle(baseStyle: any, isSelected: boolean, isConnected: boolean) {
@@ -51,7 +50,7 @@ export function WalletConnectionTypeButton(props: Props) {
             onClick={() => {
                 setWaitingForUser(false);
                 if (activeConnector) {
-                    destroy(activeConnector).catch(console.error);
+                    activeConnector.disconnect().catch(console.error);
                 }
                 if (activeConnectorType === connectorType) {
                     setActiveConnectorType(undefined);

--- a/examples/wCCD/src/wCCD.tsx
+++ b/examples/wCCD/src/wCCD.tsx
@@ -229,7 +229,6 @@ export default function wCCD(props: WalletConnectionProps) {
                             </button>
                         </p>
                     )}
-                    {/* {connectionError && <p style={{ color: 'red' }}>Connection Error: {connectionError}.</p>} */}
                     {activeConnectedAccount && (
                         <>
                             <div className="text">Connected to</div>

--- a/examples/wCCD/src/wCCD.tsx
+++ b/examples/wCCD/src/wCCD.tsx
@@ -178,10 +178,10 @@ export default function wCCD(props: WalletConnectionProps) {
         }
     }, [activeConnection, activeConnectedAccount, isFlipped]);
 
-    const [isWaitingForUser, setWaitingForUser] = useState(false);
+    const [isWaitingForTransaction, setWaitingForUser] = useState(false);
     return (
         <>
-            <h1 className="header">CCD &lt;-&gt; WCCD Smart Contract</h1>
+            <h1 className="header">CCD &#8644; wCCD Smart Contract</h1>
             <h3>Wrap and unwrap your CCDs and wCCDs on the Concordium Testnet</h3>
             <div style={blackCardStyle}>
                 <div>
@@ -203,20 +203,13 @@ export default function wCCD(props: WalletConnectionProps) {
                     />
                 </div>
                 <div>
-                    {!activeConnection && isWaitingForUser && (
-                        <p>
-                            <button style={ButtonStyleDisabled} type="button" disabled>
-                                Waiting for user
-                            </button>
-                        </p>
-                    )}
                     {activeConnectorError && <p style={{ color: 'red' }}>Connector Error: {activeConnectorError}.</p>}
-                    {!activeConnectorError && !isWaitingForUser && activeConnectorType && !activeConnector && (
+                    {!activeConnectorError && !isWaitingForTransaction && activeConnectorType && !activeConnector && (
                         <p>
                             <i>Loading connector...</i>
                         </p>
                     )}
-                    {!activeConnection && !isWaitingForUser && activeConnectorType && activeConnector && (
+                    {!activeConnection && !isWaitingForTransaction && activeConnectorType && activeConnector && (
                         <p>
                             <button style={ButtonStyle} type="button" onClick={connect}>
                                 {isActiveConnectorWaitingForUser && 'Connecting...'}
@@ -306,9 +299,9 @@ export default function wCCD(props: WalletConnectionProps) {
                         placeholder="0.000000"
                         ref={inputValue}
                     />
-                    {isWaitingForUser || !activeConnection ? (
+                    {!activeConnection ? (
                         <button style={ButtonStyleDisabled} type="button" disabled>
-                            Waiting for user
+                            Waiting for connection...
                         </button>
                     ) : (
                         <button
@@ -355,10 +348,10 @@ export default function wCCD(props: WalletConnectionProps) {
                     <>
                         <p>
                             <div>Transaction status{hash === '' ? '' : ' (May take a moment to finalize)'}</div>
-                            {!hash && transactionError && <div style={{ color: 'red' }}>{transactionError}.</div>}
-                            {!hash && !transactionError && (
-                                <div className="loadingText">Waiting for transaction...</div>
+                            {!hash && transactionError && (
+                                <div style={{ color: 'red' }}>Error: {transactionError}.</div>
                             )}
+                            {!hash && !transactionError && <div className="loadingText">None</div>}
                             {hash && (
                                 <>
                                     <button

--- a/examples/wCCD/src/wCCD.tsx
+++ b/examples/wCCD/src/wCCD.tsx
@@ -209,15 +209,11 @@ export default function wCCD(props: WalletConnectionProps) {
                         </p>
                     )}
                     {connectorError && <p style={{ color: 'red' }}>{connectorError}.</p>}
-                    {!activeConnection &&
-                        !isWaitingForUser &&
-                        activeConnectorType &&
-                        !activeConnector &&
-                        !connectorError && (
-                            <p>
-                                <i>Loading connector...</i>
-                            </p>
-                        )}
+                    {!isWaitingForUser && activeConnectorType && !activeConnector && !connectorError && (
+                        <p>
+                            <i>Loading connector...</i>
+                        </p>
+                    )}
                     {!activeConnection && !isWaitingForUser && activeConnectorType && activeConnector && (
                         <p>
                             <button style={ButtonStyle} type="button" onClick={connectWallet}>

--- a/examples/wCCD/src/wCCD.tsx
+++ b/examples/wCCD/src/wCCD.tsx
@@ -126,8 +126,16 @@ async function updateWCCDBalanceAccount(
 }
 
 export default function wCCD(props: WalletConnectionProps) {
-    const { activeConnectorType, activeConnector, activeConnection, setActiveConnection, activeConnectedAccount } =
-        props;
+    const {
+        network,
+        activeConnectorType,
+        activeConnector,
+        activeConnection,
+        setActiveConnection,
+        activeConnectionGenesisHash,
+        activeConnectedAccount,
+        connectionError,
+    } = props;
     const [isWaitingForUser, setWaitingForUser] = useState<boolean>(false);
     const connectWallet = useCallback(() => {
         if (activeConnector) {
@@ -248,6 +256,13 @@ export default function wCCD(props: WalletConnectionProps) {
                             <i>Please connect a wallet.</i>
                         </div>
                     )}
+                    {activeConnectionGenesisHash && activeConnectionGenesisHash !== network.genesisHash && (
+                        <p style={{ color: 'red' }}>
+                            Unexpected genesis hash: Please ensure that your wallet is connected to network{' '}
+                            <code>{network.name}</code>.
+                        </p>
+                    )}
+                    {connectionError && <p style={{ color: 'red' }}>{connectionError}</p>}
                 </div>
                 <div className="containerSwitch">
                     <div className="largeText">CCD &nbsp; &nbsp; </div>
@@ -339,8 +354,7 @@ export default function wCCD(props: WalletConnectionProps) {
                                 );
                             }}
                         >
-                            {' '}
-                            {hash}{' '}
+                            {hash}
                         </button>
                         <br />
                     </>
@@ -363,8 +377,7 @@ export default function wCCD(props: WalletConnectionProps) {
                                 );
                             }}
                         >
-                            {' '}
-                            {admin}{' '}
+                            {admin}
                         </button>
                     )}
                 </div>

--- a/examples/wCCD/src/wCCD.tsx
+++ b/examples/wCCD/src/wCCD.tsx
@@ -134,7 +134,7 @@ export default function wCCD(props: WalletConnectionProps) {
         setActiveConnection,
         activeConnectionGenesisHash,
         activeConnectedAccount,
-        connectionError,
+        connectorError,
     } = props;
     const [isWaitingForUser, setWaitingForUser] = useState<boolean>(false);
     const connectWallet = useCallback(() => {
@@ -200,17 +200,31 @@ export default function wCCD(props: WalletConnectionProps) {
                         {...props}
                     />
                 </div>
-                <div>
+                <p>
                     {!activeConnection && isWaitingForUser && (
-                        <button style={ButtonStyleDisabled} type="button" disabled>
-                            Waiting for user
-                        </button>
+                        <p>
+                            <button style={ButtonStyleDisabled} type="button" disabled>
+                                Waiting for user
+                            </button>
+                        </p>
                     )}
-                    {!activeConnection && !isWaitingForUser && activeConnectorType && (
-                        <button style={ButtonStyle} type="button" onClick={connectWallet}>
-                            {activeConnectorType === 'BrowserWallet' && 'Connect Browser Wallet'}
-                            {activeConnectorType === 'WalletConnect' && 'Connect Mobile Wallet'}
-                        </button>
+                    {connectorError && <p style={{ color: 'red' }}>{connectorError}.</p>}
+                    {!activeConnection &&
+                        !isWaitingForUser &&
+                        activeConnectorType &&
+                        !activeConnector &&
+                        !connectorError && (
+                            <p>
+                                <i>Loading connector...</i>
+                            </p>
+                        )}
+                    {!activeConnection && !isWaitingForUser && activeConnectorType && activeConnector && (
+                        <p>
+                            <button style={ButtonStyle} type="button" onClick={connectWallet}>
+                                {activeConnectorType === 'BrowserWallet' && 'Connect Browser Wallet'}
+                                {activeConnectorType === 'WalletConnect' && 'Connect Mobile Wallet'}
+                            </button>
+                        </p>
                     )}
                     {activeConnectedAccount && (
                         <>
@@ -251,19 +265,13 @@ export default function wCCD(props: WalletConnectionProps) {
                             </div>
                         </>
                     )}
-                    {!activeConnectedAccount && (
-                        <div className="text">
-                            <i>Please connect a wallet.</i>
-                        </div>
-                    )}
                     {activeConnectionGenesisHash && activeConnectionGenesisHash !== network.genesisHash && (
                         <p style={{ color: 'red' }}>
                             Unexpected genesis hash: Please ensure that your wallet is connected to network{' '}
                             <code>{network.name}</code>.
                         </p>
                     )}
-                    {connectionError && <p style={{ color: 'red' }}>{connectionError}</p>}
-                </div>
+                </p>
                 <div className="containerSwitch">
                     <div className="largeText">CCD &nbsp; &nbsp; </div>
                     <button className="switch" type="button" onClick={() => setIsWrapping(!isWrapping)}>

--- a/examples/wCCD/src/wallet/BrowserWallet.ts
+++ b/examples/wCCD/src/wallet/BrowserWallet.ts
@@ -1,6 +1,3 @@
-/* eslint-disable no-console */
-
-// eslint-disable-next-line max-classes-per-file
 import { detectConcordiumProvider, WalletApi } from '@concordium/browser-wallet-api-helpers';
 import {
     AccountTransactionPayload,
@@ -28,6 +25,7 @@ export class BrowserWalletConnector implements WalletConnector, WalletConnection
             this.client
                 .getMostRecentlySelectedAccount()
                 .then((a) => delegate.onAccountChanged(this, a))
+                // eslint-disable-next-line no-console
                 .catch(console.error)
         );
     }

--- a/examples/wCCD/src/wallet/BrowserWallet.ts
+++ b/examples/wCCD/src/wallet/BrowserWallet.ts
@@ -38,14 +38,14 @@ export class BrowserWalletConnector implements WalletConnector, WalletConnection
             return new BrowserWalletConnector(client, delegate);
         } catch (e) {
             // Provider detector throws 'undefined' when rejecting!
-            throw new Error('Browser Wallet: Browser extension not detected');
+            throw new Error('Browser Wallet extension not detected');
         }
     }
 
     async connect() {
         const account = await this.client.connect();
         if (!account) {
-            throw new Error('Browser Wallet: Connection failed');
+            throw new Error('Browser Wallet connection failed');
         }
         return this;
     }

--- a/examples/wCCD/src/wallet/BrowserWallet.ts
+++ b/examples/wCCD/src/wallet/BrowserWallet.ts
@@ -51,7 +51,8 @@ export class BrowserWalletConnector implements WalletConnector, WalletConnection
     }
 
     async getConnections() {
-        // Defining "connection" as a connected account.
+        // Defining "connected" as the presence of a connected account.
+        // TODO Would be more stable to base on availability of RPC client?
         const account = await this.getConnectedAccount();
         return account ? [this] : [];
     }

--- a/examples/wCCD/src/wallet/BrowserWallet.ts
+++ b/examples/wCCD/src/wallet/BrowserWallet.ts
@@ -11,6 +11,8 @@ import {
 } from '@concordium/web-sdk';
 import { WalletConnectionDelegate, WalletConnection, WalletConnector } from './WalletConnection';
 
+const BROWSER_WALLET_DETECT_TIMEOUT = 2000;
+
 export class BrowserWalletConnector implements WalletConnector, WalletConnection {
     readonly client: WalletApi;
 
@@ -31,23 +33,19 @@ export class BrowserWalletConnector implements WalletConnector, WalletConnection
     }
 
     static async create(delegate: WalletConnectionDelegate) {
-        // let instance = BrowserWalletConnector.instances.get(delegate);
-        // console.log('cached instance:', instance);
-        // if (!instance) {
-        //     console.log('creating new one');
-        //     const client = await detectConcordiumProvider();
-        //     instance = new BrowserWalletConnector(client, delegate);
-        //     BrowserWalletConnector.instances.set(delegate, instance);
-        // }
-        // return instance;
-        const client = await detectConcordiumProvider();
-        return new BrowserWalletConnector(client, delegate);
+        try {
+            const client = await detectConcordiumProvider(BROWSER_WALLET_DETECT_TIMEOUT);
+            return new BrowserWalletConnector(client, delegate);
+        } catch (e) {
+            // Provider detector throws 'undefined' when rejecting!
+            throw new Error('Browser Wallet: Browser extension not detected');
+        }
     }
 
     async connect() {
         const account = await this.client.connect();
         if (!account) {
-            throw new Error('connection failed');
+            throw new Error('Browser Wallet: Connection failed');
         }
         return this;
     }

--- a/examples/wCCD/src/wallet/BrowserWallet.ts
+++ b/examples/wCCD/src/wallet/BrowserWallet.ts
@@ -12,6 +12,8 @@ import {
 import { WalletConnectionDelegate, WalletConnection, WalletConnector } from './WalletConnection';
 
 export class BrowserWalletConnector implements WalletConnector, WalletConnection {
+    static instances: WeakMap<WalletConnectionDelegate, BrowserWalletConnector> = new WeakMap();
+
     readonly client: WalletApi;
 
     constructor(client: WalletApi, delegate: WalletConnectionDelegate) {
@@ -28,6 +30,15 @@ export class BrowserWalletConnector implements WalletConnector, WalletConnection
     }
 
     static async create(delegate: WalletConnectionDelegate) {
+        // let instance = BrowserWalletConnector.instances.get(delegate);
+        // console.log('cached instance:', instance);
+        // if (!instance) {
+        //     console.log('creating new one');
+        //     const client = await detectConcordiumProvider();
+        //     instance = new BrowserWalletConnector(client, delegate);
+        //     BrowserWalletConnector.instances.set(delegate, instance);
+        // }
+        // return instance;
         const client = await detectConcordiumProvider();
         return new BrowserWalletConnector(client, delegate);
     }
@@ -59,6 +70,10 @@ export class BrowserWalletConnector implements WalletConnector, WalletConnection
     }
 
     async disconnect() {
+        // // Only the wallet can initiate disconnecting individual accounts.
+        // // The connection itself cannot actually be disconnected with the client being cleared from global state.
+        // // This "disconnect" only ensures that we stop interacting with the client and that it doesn't interfere with a future reconnection.
+        // this.client.removeAllListeners();
         // Only the wallet can initiate a disconnect.
         return undefined;
     }

--- a/examples/wCCD/src/wallet/WalletConnect.ts
+++ b/examples/wCCD/src/wallet/WalletConnect.ts
@@ -321,4 +321,9 @@ export class WalletConnectConnector implements WalletConnector {
     async getConnections() {
         return Array.from(this.connections.values());
     }
+
+    async disconnect() {
+        const connections = await this.getConnections();
+        return Promise.all(connections.map((c) => c.disconnect())).then(() => {});
+    }
 }

--- a/examples/wCCD/src/wallet/WalletConnect.ts
+++ b/examples/wCCD/src/wallet/WalletConnect.ts
@@ -310,7 +310,9 @@ export class WalletConnectConnector implements WalletConnector {
             this.isModalOpen = v;
         });
         const rpcClient = new JsonRpcClient(new HttpProvider(this.network.jsonRpcUrl));
-        return new WalletConnectConnection(this, rpcClient, chainId, session);
+        const connection = new WalletConnectConnection(this, rpcClient, chainId, session);
+        this.connections.set(session.topic, connection);
+        return connection;
     }
 
     onDisconnect(connection: WalletConnectConnection) {

--- a/examples/wCCD/src/wallet/WalletConnection.ts
+++ b/examples/wCCD/src/wallet/WalletConnection.ts
@@ -57,7 +57,7 @@ export interface WalletConnectionDelegate {
 }
 
 export interface WalletConnector {
-    connect(): Promise<WalletConnection>;
+    connect(): Promise<WalletConnection | undefined>;
     getConnections(): Promise<WalletConnection[]>;
     disconnect(): Promise<void>;
 }

--- a/examples/wCCD/src/wallet/WalletConnection.ts
+++ b/examples/wCCD/src/wallet/WalletConnection.ts
@@ -59,15 +59,11 @@ export interface WalletConnectionDelegate {
 export interface WalletConnector {
     connect(): Promise<WalletConnection>;
     getConnections(): Promise<WalletConnection[]>;
+    disconnect(): Promise<void>;
 }
 
 export async function withJsonRpcClient<T>(wc: WalletConnection, f: (c: JsonRpcClient) => Promise<T>) {
     return f(wc.getJsonRpcClient());
-}
-
-export async function destroy(connector: WalletConnector) {
-    const connections = await connector.getConnections();
-    return Promise.all(connections.map((c) => c.disconnect())).then((vs) => vs.length);
 }
 
 export async function connectedAccountOf(connection: WalletConnection | undefined) {

--- a/examples/wCCD/src/wallet/WithWalletConnection.tsx
+++ b/examples/wCCD/src/wallet/WithWalletConnection.tsx
@@ -17,10 +17,11 @@ import { WalletConnectConnector } from './WalletConnect';
 interface State {
     activeConnectorType: string | undefined;
     activeConnector: WalletConnector | undefined;
+    activeConnectorError: string;
     activeConnection: WalletConnection | undefined;
+    // activeConnectionError: string | undefined;
     activeConnectionGenesisHash: string | undefined;
     activeConnectedAccount: string | undefined;
-    connectorError: string;
 }
 
 // TODO React appropriately if 'network' changes.
@@ -35,7 +36,6 @@ export interface WalletConnectionProps extends State {
     activeConnectionGenesisHash: string | undefined;
     setActiveConnectorType: (t: string | undefined) => void;
     setActiveConnection: (c: WalletConnection | undefined) => void;
-    connectorError: string;
 }
 
 // eslint-disable-next-line react/prefer-stateless-function
@@ -45,10 +45,11 @@ export class WithWalletConnection extends React.Component<Props, State> implemen
         this.state = {
             activeConnectorType: undefined,
             activeConnector: undefined,
+            activeConnectorError: '',
             activeConnection: undefined,
+            // activeConnectionError: '',
             activeConnectionGenesisHash: undefined,
             activeConnectedAccount: undefined,
-            connectorError: '',
         };
     }
 
@@ -64,17 +65,17 @@ export class WithWalletConnection extends React.Component<Props, State> implemen
             activeConnection: undefined,
             activeConnectionGenesisHash: undefined,
             activeConnectedAccount: undefined,
-            connectorError: '',
+            activeConnectorError: '',
         });
         if (type) {
             this.createConnector(type, network)
                 .then(this.setActiveConnector)
-                .catch((err: unknown) => {
+                .catch((err) => {
                     // eslint-disable-next-line react/destructuring-assignment
                     if (this.state.activeConnectorType === type) {
                         // Don't set error if user switched connector type since initializing this connector.
                         // It's OK to show it if the user switched away and back...
-                        this.setState({ connectorError: (err as Error).message });
+                        this.setState({ activeConnectorError: (err as Error).message });
                     }
                 });
         }
@@ -82,7 +83,7 @@ export class WithWalletConnection extends React.Component<Props, State> implemen
 
     private setActiveConnector = (connector: WalletConnector) => {
         console.log('WithWalletConnection: updating active connector state', { connector, state: this.state });
-        this.setState({ activeConnector: connector, connectorError: '' });
+        this.setState({ activeConnector: connector, activeConnectorError: '' });
     };
 
     setActiveConnection = (connection: WalletConnection | undefined) => {

--- a/examples/wCCD/src/wallet/WithWalletConnection.tsx
+++ b/examples/wCCD/src/wallet/WithWalletConnection.tsx
@@ -151,7 +151,7 @@ export class WithWalletConnection extends React.Component<Props, State> implemen
     connect = () => {
         const { activeConnector } = this.state;
         if (activeConnector) {
-            this.setState({ isActiveConnectorWaitingForUser: true });
+            this.setState({ isActiveConnectorWaitingForUser: true, activeConnectorError: '' });
             activeConnector
                 .connect()
                 .then(this.setActiveConnection)

--- a/examples/wCCD/src/wallet/WithWalletConnection.tsx
+++ b/examples/wCCD/src/wallet/WithWalletConnection.tsx
@@ -120,7 +120,7 @@ export class WithWalletConnection extends React.Component<Props, State> implemen
             window.alert(
                 `Unexpected genesis hash '${genesisHash}'. Expected '${network.genesisHash}' (network '${network.name}').`
             );
-            connection.disconnect().catch(console.error);
+            connection.getConnector().disconnect().catch(console.error);
         }
     };
 

--- a/examples/wCCD/src/wallet/WithWalletConnection.tsx
+++ b/examples/wCCD/src/wallet/WithWalletConnection.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-/* eslint-disable no-alert */
 /* eslint-disable react/sort-comp */
 /* eslint-disable react/no-unused-class-component-methods */
 
@@ -19,7 +18,9 @@ interface State {
     activeConnectorType: string | undefined;
     activeConnector: WalletConnector | undefined;
     activeConnection: WalletConnection | undefined;
+    activeConnectionGenesisHash: string | undefined;
     activeConnectedAccount: string | undefined;
+    connectionError: string;
 }
 
 // TODO React appropriately if 'network' changes.
@@ -30,11 +31,13 @@ interface Props {
 }
 
 export interface WalletConnectionProps extends State {
+    network: Network;
+    activeConnectionGenesisHash: string | undefined;
     setActiveConnectorType: (t: string | undefined) => void;
     setActiveConnection: (c: WalletConnection | undefined) => void;
+    connectionError: string;
 }
 
-// TODO Expose error to child component instead of logging to 'console.error'.
 // eslint-disable-next-line react/prefer-stateless-function
 export class WithWalletConnection extends React.Component<Props, State> implements WalletConnectionDelegate {
     constructor(props: Props) {
@@ -43,9 +46,13 @@ export class WithWalletConnection extends React.Component<Props, State> implemen
             activeConnectorType: undefined,
             activeConnector: undefined,
             activeConnection: undefined,
+            activeConnectionGenesisHash: undefined,
             activeConnectedAccount: undefined,
+            connectionError: '',
         };
     }
+
+    private setConnectionError = (err: unknown) => this.setState({ connectionError: (err as Error).message });
 
     setActiveConnectorType = (type: string | undefined) => {
         const { network } = this.props;
@@ -57,20 +64,22 @@ export class WithWalletConnection extends React.Component<Props, State> implemen
             activeConnectorType: type,
             activeConnector: undefined,
             activeConnection: undefined,
+            activeConnectionGenesisHash: undefined,
             activeConnectedAccount: undefined,
+            connectionError: '',
         });
         if (type) {
-            this.createConnector(type, network).then(this.setActiveConnector).catch(console.error);
+            this.createConnector(type, network).then(this.setActiveConnector).catch(this.setConnectionError);
         }
     };
 
     private setActiveConnector = (connector: WalletConnector) => {
-        console.log('WithWalletConnection: updating connector state', { connector, state: this.state });
-        this.setState({ activeConnector: connector });
+        console.log('WithWalletConnection: updating active connector state', { connector, state: this.state });
+        this.setState({ activeConnector: connector, connectionError: '' });
     };
 
     setActiveConnection = (connection: WalletConnection | undefined) => {
-        console.debug('WithWalletConnection: setActiveConnection called', { connection, state: this.state });
+        console.debug("WithWalletConnection: calling 'setActiveConnection'", { connection, state: this.state });
         // Not setting the active connector to that of the connection
         // as it isn't obvious that one would always want that.
         // The app can just do it explicitly.
@@ -82,12 +91,13 @@ export class WithWalletConnection extends React.Component<Props, State> implemen
             this.setState({
                 activeConnection: connection,
                 activeConnectedAccount: connectedAccount,
+                connectionError: '',
             });
         });
     };
 
     private createConnector = (connectorType: string, network: Network): Promise<WalletConnector> => {
-        console.debug('WithWalletConnection: createConnector called', { connectorType, network, state: this.state });
+        console.debug("WithWalletConnection: calling 'createConnector'", { connectorType, network, state: this.state });
         const { walletConnectOpts } = this.props;
         switch (connectorType) {
             case 'BrowserWallet':
@@ -102,42 +112,38 @@ export class WithWalletConnection extends React.Component<Props, State> implemen
     };
 
     onAccountChanged = (connection: WalletConnection, address: string | undefined) => {
-        console.debug('WithWalletConnection: onAccountChanged called', { connection, address, state: this.state });
+        console.debug("WithWalletConnection: calling 'onAccountChanged'", { connection, address, state: this.state });
         const { activeConnection } = this.state;
         // Ignore event on connections other than the active one.
         if (connection === activeConnection) {
             console.log('WithWalletConnection: updating connected account state', { address });
-            this.setState({ activeConnectedAccount: address });
+            this.setState({ activeConnectedAccount: address, connectionError: '' });
         }
     };
 
     onChainChanged = (connection: WalletConnection, genesisHash: string) => {
-        console.debug('WithWalletConnection: onChainChanged called', { connection, genesisHash, state: this.state });
-        const { network } = this.props;
-        // Check if the user is connected to expected network by checking if the genesis hash matches the expected one.
-        // Emit a warning and disconnect if it's the wrong chain.
-        if (genesisHash !== network.genesisHash) {
-            window.alert(
-                `Unexpected genesis hash '${genesisHash}'. Expected '${network.genesisHash}' (network '${network.name}').`
-            );
-            connection.getConnector().disconnect().catch(console.error);
+        console.debug("WithWalletConnection: calling 'onChainChanged'", { connection, genesisHash, state: this.state });
+        const { activeConnection } = this.state;
+        if (connection === activeConnection) {
+            this.setState({ activeConnectionGenesisHash: genesisHash });
         }
     };
 
     onDisconnect = (connection: WalletConnection) => {
-        console.debug('WithWalletConnection: onDisconnect called', { connection, state: this.state });
+        console.debug("WithWalletConnection: calling 'onDisconnect'", { connection, state: this.state });
         const { activeConnection } = this.state;
         // Ignore event on connections other than the active one.
         if (connection === activeConnection) {
             console.log('WithWalletConnection: clearing wallet connection and connected account state');
-            this.setState({ activeConnection: undefined, activeConnectedAccount: undefined });
+            this.setState({ activeConnection: undefined, activeConnectedAccount: undefined, connectionError: '' });
         }
     };
 
     render() {
-        const { children } = this.props;
+        const { children, network } = this.props;
         return children({
             ...this.state,
+            network,
             setActiveConnectorType: this.setActiveConnectorType,
             setActiveConnection: this.setActiveConnection,
         });


### PR DESCRIPTION
Display error messages in the application instead of logging them to console or showing alert popups. This adds a bunch of error fields to the various components' state.

Error messages got a pass and the connection logic was migrated from the app component into the `WithWalletConnection` library component.

This improves the UX and solves the following issues:

- Browser Wallet:

  - Clean up event handlers when "disconnecting" (i.e. discarding) the connector. This avoids interference between reconnects.
  - Show error message when browser wallet isn't available.

- WalletConnect:

  - Disconnect is now detected properly.
  - Ensure that we no longer get stuck in "waiting for user" state when the modal is closed without connecting.

- RPC errors are improved and displayed in the UI. This makes it as clear as it can be if the connected account belongs to the wrong chain.

The UI now only shows the "transaction status" and "admin instance" fields when the is a connection as there otherwise isn't anything useful to show in them. As part of this the "lean how to make a wrapper like this" link was moved down next to the version.