### PR TITLE
Make account info atom refreshable

### DIFF
--- a/packages/browser-wallet/src/popup/shared/AccountInfoListenerContext/AccountInfoListenerContext.tsx
+++ b/packages/browser-wallet/src/popup/shared/AccountInfoListenerContext/AccountInfoListenerContext.tsx
@@ -1,16 +1,16 @@
-import { AccountAddress, AccountInfo } from '@concordium/web-sdk';
-import { networkConfigurationAtom, jsonRpcClientAtom, cookieAtom } from '@popup/store/settings';
 import { useAtomValue, useSetAtom, useAtom, atom, WritableAtom } from 'jotai';
 import React, { createContext, ReactNode, useContext, useEffect, useMemo, useState } from 'react';
-import { atomWithChromeStorage } from '@popup/store/utils';
-import { ChromeStorageKey, CreationStatus, WalletCredential } from '@shared/storage/types';
-import { noOp, parse, stringify } from 'wallet-common-helpers';
-import { addToastAtom } from '@popup/state';
+import { AccountAddress, AccountInfo } from '@concordium/web-sdk';
 import { useTranslation } from 'react-i18next';
-import { getGenesisHash, sessionAccountInfoCache, useIndexedStorage } from '@shared/storage/access';
-import { accountInfoCacheLock, updateRecord } from '@shared/storage/update';
 import i18next from 'i18next';
 import { atomFamily } from 'jotai/utils';
+import { noOp, parse, stringify } from 'wallet-common-helpers';
+import { networkConfigurationAtom, jsonRpcClientAtom, cookieAtom } from '@popup/store/settings';
+import { atomWithChromeStorage } from '@popup/store/utils';
+import { ChromeStorageKey, CreationStatus, WalletCredential } from '@shared/storage/types';
+import { addToastAtom } from '@popup/state';
+import { getGenesisHash, sessionAccountInfoCache, useIndexedStorage } from '@shared/storage/access';
+import { accountInfoCacheLock, updateRecord } from '@shared/storage/update';
 import { AccountInfoListener } from '../account-info-listener';
 
 const accountInfoBaseAtom = atomWithChromeStorage<Record<string, string>>(ChromeStorageKey.AccountInfoCache, {}, false);
@@ -112,7 +112,7 @@ export function useAccountInfo(account: WalletCredential): AccountInfo | undefin
         if (!accountInfo && account.status === CreationStatus.Confirmed) {
             refreshAccountInfo();
         }
-    }, [genesisHash, address, accountInfo, account.status]);
+    }, [genesisHash, accountInfo, account.status]);
 
     useEffect(() => {
         if (account.status === CreationStatus.Confirmed && accountInfoEmitter) {

--- a/packages/browser-wallet/src/popup/shared/AccountInfoListenerContext/AccountInfoListenerContext.tsx
+++ b/packages/browser-wallet/src/popup/shared/AccountInfoListenerContext/AccountInfoListenerContext.tsx
@@ -1,6 +1,6 @@
 import { AccountAddress, AccountInfo } from '@concordium/web-sdk';
 import { networkConfigurationAtom, jsonRpcClientAtom, cookieAtom } from '@popup/store/settings';
-import { useAtomValue, useSetAtom, useAtom } from 'jotai';
+import { useAtomValue, useSetAtom, useAtom, atom, WritableAtom } from 'jotai';
 import React, { createContext, ReactNode, useContext, useEffect, useMemo, useState } from 'react';
 import { atomWithChromeStorage } from '@popup/store/utils';
 import { ChromeStorageKey, CreationStatus, WalletCredential } from '@shared/storage/types';
@@ -9,12 +9,60 @@ import { addToastAtom } from '@popup/state';
 import { useTranslation } from 'react-i18next';
 import { getGenesisHash, sessionAccountInfoCache, useIndexedStorage } from '@shared/storage/access';
 import { accountInfoCacheLock, updateRecord } from '@shared/storage/update';
+import i18next from 'i18next';
+import { atomFamily } from 'jotai/utils';
 import { AccountInfoListener } from '../account-info-listener';
 
-export const accountInfoAtom = atomWithChromeStorage<Record<string, string>>(
-    ChromeStorageKey.AccountInfoCache,
-    {},
-    false
+const accountInfoBaseAtom = atomWithChromeStorage<Record<string, string>>(ChromeStorageKey.AccountInfoCache, {}, false);
+
+type RefreshAction = {
+    type: 'refresh';
+    address: string;
+};
+
+type AccountInfoAction = RefreshAction;
+
+export const accountInfoAtom = atom<Record<string, AccountInfo>, AccountInfoAction, Promise<void>>(
+    (get) =>
+        Object.entries(get(accountInfoBaseAtom)).reduce(
+            (acc, [address, info]) => ({
+                ...acc,
+                [address]: info === undefined ? undefined : parse(info),
+            }),
+            {}
+        ),
+    async (get, set, update) => {
+        const client = get(jsonRpcClientAtom);
+        const addToast = (v: string) => set(addToastAtom, v);
+
+        try {
+            const consensusStatus = await client.getConsensusStatus();
+            const newAccountInfo = await client.getAccountInfo(
+                new AccountAddress(update.address),
+                consensusStatus.lastFinalizedBlock
+            );
+
+            if (newAccountInfo) {
+                updateRecord(
+                    accountInfoCacheLock,
+                    useIndexedStorage(sessionAccountInfoCache, getGenesisHash),
+                    newAccountInfo.accountAddress,
+                    stringify(newAccountInfo)
+                );
+            }
+        } catch {
+            addToast(i18next.t('account.error'));
+        }
+    }
+);
+
+export const accountInfoFamily = atomFamily<string, WritableAtom<AccountInfo | undefined, void>>((address) =>
+    atom(
+        (get) => get(accountInfoAtom)[address],
+        (_, set) => {
+            set(accountInfoAtom, { type: 'refresh', address });
+        }
+    )
 );
 export const AccountInfoListenerContext = createContext<AccountInfoListener | undefined>(undefined);
 
@@ -56,42 +104,15 @@ export default function AccountInfoListenerContextProvider({ children }: Props) 
  */
 export function useAccountInfo(account: WalletCredential): AccountInfo | undefined {
     const accountInfoEmitter = useContext<AccountInfoListener | undefined>(AccountInfoListenerContext);
-    const accountInfoCache = useAtomValue(accountInfoAtom);
+    const [accountInfo, refreshAccountInfo] = useAtom(accountInfoFamily(account.address));
     const { genesisHash } = useAtomValue(networkConfigurationAtom);
     const address = useMemo(() => account.address, [account]);
-    const addToast = useSetAtom(addToastAtom);
-    const client = useAtomValue(jsonRpcClientAtom);
-    const { t } = useTranslation();
-    const [accountInfo, setAccountInfo] = useState<AccountInfo>();
 
     useEffect(() => {
-        setAccountInfo(undefined);
-    }, [genesisHash, address]);
-
-    useEffect(() => {
-        if (accountInfoCache[address]) {
-            setAccountInfo(parse(accountInfoCache[address]));
-        } else if (account.status === CreationStatus.Confirmed) {
-            client
-                .getConsensusStatus()
-                .then((consensusStatus) => {
-                    client
-                        .getAccountInfo(new AccountAddress(address), consensusStatus.lastFinalizedBlock)
-                        .then((newAccountInfo) => {
-                            if (newAccountInfo) {
-                                updateRecord(
-                                    accountInfoCacheLock,
-                                    useIndexedStorage(sessionAccountInfoCache, getGenesisHash),
-                                    newAccountInfo.accountAddress,
-                                    stringify(newAccountInfo)
-                                );
-                            }
-                        })
-                        .catch(() => addToast(t('account.error')));
-                })
-                .catch(() => addToast(t('account.error')));
+        if (!accountInfo && account.status === CreationStatus.Confirmed) {
+            refreshAccountInfo();
         }
-    }, [genesisHash, address, accountInfoCache[address], account.status]);
+    }, [genesisHash, address, accountInfo, account.status]);
 
     useEffect(() => {
         if (account.status === CreationStatus.Confirmed && accountInfoEmitter) {

--- a/packages/browser-wallet/src/popup/store/transactions.ts
+++ b/packages/browser-wallet/src/popup/store/transactions.ts
@@ -151,10 +151,3 @@ export const addPendingTransactionAtom = atom<null, BrowserWalletAccountTransact
     null,
     (get, set, transaction) => set(pendingTransactionsAtom, [...get(pendingTransactionsAtom), transaction])
 );
-
-export const removePendingTransactionAtom = atom<null, string, Promise<void>>(null, (get, set, transactionHash) =>
-    set(
-        pendingTransactionsAtom,
-        get(pendingTransactionsAtom).filter((t) => t.transactionHash === transactionHash)
-    )
-);

--- a/packages/browser-wallet/src/popup/store/transactions.ts
+++ b/packages/browser-wallet/src/popup/store/transactions.ts
@@ -7,7 +7,8 @@ import { loop } from '@shared/utils/function-helpers';
 import { getTransactionStatus } from '@popup/shared/utils/wallet-proxy';
 import { ACCOUNT_INFO_RETRIEVAL_INTERVAL_MS } from '@popup/shared/account-info-listener';
 import { sessionPendingTransactions, useIndexedStorage } from '@shared/storage/access';
-import { selectedAccountAtom } from './account';
+import { accountInfoFamily } from '@popup/shared/AccountInfoListenerContext/AccountInfoListenerContext';
+import { accountsAtom, selectedAccountAtom } from './account';
 import { atomWithChromeStorage } from './utils';
 import { networkConfigurationAtom } from './settings';
 
@@ -80,7 +81,7 @@ const pendingTransactionsAtom = (() => {
 
             pending
                 .filter((p) => p.status === TransactionStatus.Pending)
-                .forEach(async ({ transactionHash }) => {
+                .forEach(async ({ transactionHash, toAddress, fromAddress }) => {
                     const result = await monitor(transactionHash);
                     const currentNetwork = get(networkConfigurationAtom);
 
@@ -96,6 +97,16 @@ const pendingTransactionsAtom = (() => {
                     if (!networkChanged) {
                         const next = get(parsedAtom).map(mapIfMatch);
                         await set(parsedAtom, next);
+
+                        const addresses = get(accountsAtom);
+
+                        const refreshAccountInfo = (address: string | undefined) =>
+                            address !== undefined && addresses.includes(address) && set(accountInfoFamily(address)); // Refresh account info for the selected account.
+
+                        refreshAccountInfo(fromAddress);
+                        if (result.status === TransactionStatus.Finalized) {
+                            refreshAccountInfo(toAddress);
+                        }
                     } else {
                         const spt = useIndexedStorage(sessionPendingTransactions, async () => network.genesisHash);
                         const next = (await spt.get())?.map(parse).map(mapIfMatch);
@@ -139,4 +150,11 @@ export const selectedPendingTransactionsAtom = atom<BrowserWalletAccountTransact
 export const addPendingTransactionAtom = atom<null, BrowserWalletAccountTransaction, Promise<void>>(
     null,
     (get, set, transaction) => set(pendingTransactionsAtom, [...get(pendingTransactionsAtom), transaction])
+);
+
+export const removePendingTransactionAtom = atom<null, string, Promise<void>>(null, (get, set, transactionHash) =>
+    set(
+        pendingTransactionsAtom,
+        get(pendingTransactionsAtom).filter((t) => t.transactionHash === transactionHash)
+    )
 );


### PR DESCRIPTION
## Purpose

Make it possible to refresh account info from atom. Also update account info when pending transactions are confirmed.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
