### PR TITLE
Wccd receiver address

### DIFF
--- a/examples/wCCD/src/utils.ts
+++ b/examples/wCCD/src/utils.ts
@@ -6,7 +6,14 @@ import { WalletConnection } from './wallet/WalletConnection';
 /**
  * Action for wrapping some CCD to WCCD in the WCCD smart contract instance
  */
-export async function wrap(connection: WalletConnection, account: string, index: bigint, subindex = 0n, amount = 0) {
+export async function wrap(
+    connection: WalletConnection,
+    account: string,
+    index: bigint,
+    subindex = 0n,
+    amount = 0,
+    receiver = account
+) {
     if (!Number.isInteger(amount) || amount <= 0) {
         throw new Error('invalid amount');
     }
@@ -26,7 +33,7 @@ export async function wrap(connection: WalletConnection, account: string, index:
         {
             data: '',
             to: {
-                Account: [account],
+                Account: [receiver],
             },
         },
         WRAP_FUNCTION_RAW_SCHEMA
@@ -36,7 +43,14 @@ export async function wrap(connection: WalletConnection, account: string, index:
 /**
  * Action for unwrapping some WCCD to CCD in the WCCD smart contract instance
  */
-export async function unwrap(connection: WalletConnection, account: string, index: bigint, subindex = 0n, amount = 0) {
+export async function unwrap(
+    connection: WalletConnection,
+    account: string,
+    index: bigint,
+    subindex = 0n,
+    amount = 0,
+    receiver = account
+) {
     if (!Number.isInteger(amount) || amount <= 0) {
         throw new Error('invalid amount');
     }
@@ -60,7 +74,7 @@ export async function unwrap(connection: WalletConnection, account: string, inde
                 Account: [account],
             },
             receiver: {
-                Account: [account],
+                Account: [receiver],
             },
         },
         UNWRAP_FUNCTION_RAW_SCHEMA

--- a/examples/wCCD/src/wCCD.tsx
+++ b/examples/wCCD/src/wCCD.tsx
@@ -158,6 +158,14 @@ export default function wCCD(props: WalletConnectionProps) {
     const [isFlipped, setIsFlipped] = useState<boolean>(false);
     const [amountAccount, setAmountAccount] = useState<bigint>();
     const inputValue = useRef<HTMLInputElement | null>(null);
+    const [receiver, setReceiver] = useState(activeConnectedAccount);
+
+    // Sync connected account to receiver input
+    useEffect(() => {
+        if (activeConnectedAccount !== undefined) {
+            setReceiver(activeConnectedAccount);
+        }
+    }, [activeConnectedAccount]);
 
     useEffect(() => {
         if (activeConnection && activeConnectedAccount) {
@@ -276,6 +284,14 @@ export default function wCCD(props: WalletConnectionProps) {
                         placeholder="0.000000"
                         ref={inputValue}
                     />
+                    <input
+                        className="input"
+                        style={InputFieldStyle}
+                        type="text"
+                        placeholder="Receiving account address"
+                        value={receiver}
+                        onChange={(e) => setReceiver(e.target.value)}
+                    />
                     {isWaitingForUser || !activeConnection ? (
                         <button style={ButtonStyleDisabled} type="button" disabled>
                             Waiting for user
@@ -309,7 +325,8 @@ export default function wCCD(props: WalletConnectionProps) {
                                         activeConnectedAccount,
                                         WCCD_CONTRACT_INDEX,
                                         CONTRACT_SUB_INDEX,
-                                        amount
+                                        amount,
+                                        receiver
                                     );
                                     tx.then(setHash)
                                         .catch((err) => setError((err as Error).message))


### PR DESCRIPTION
## Purpose

Make it possible to specify receiving address of wrap/unwrap. This is to accomodate the need for testing transactions made from smart contract udpates, initiated by other accounts than than the receiving address itself.

This change should be deployed to the public wccd testnet app, so critique/change requests are welcome.

## Changes

- Add field to specify receiving address.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
