### PR TITLE
Fix parsing of metadata URLs if they are accompanied by hashes.

### DIFF
--- a/packages/browser-wallet/src/shared/utils/token-helpers.ts
+++ b/packages/browser-wallet/src/shared/utils/token-helpers.ts
@@ -73,7 +73,12 @@ function deserializeTokenMetadataReturnValue(returnValue: string): string[] {
         const url = Buffer.from(buf.subarray(urlStart, urlEnd)).toString('utf8');
         urls.push(url);
 
-        cursor = urlEnd + 1;
+        if (buf[urlEnd] === 0) {
+            cursor = urlEnd + 1;
+        } else {
+            // Skip the metadata Hash.
+            cursor = urlEnd + 1 + 32;
+        }
     }
 
     return urls;


### PR DESCRIPTION
## Purpose

Fixes #252 

Ideally we'd also check the metadata hash against the file at the link.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.