### PR TITLE
Use gRPCv2 client

### DIFF
--- a/examples/eSealing/package.json
+++ b/examples/eSealing/package.json
@@ -5,7 +5,7 @@
     "license": "Apache-2.0",
     "dependencies": {
         "@concordium/react-components": "^0.2.0",
-        "@concordium/web-sdk": "^3.2.0",
+        "@concordium/web-sdk": "^3.3.1",
         "@thi.ng/leb128": "^2.1.18",
         "@types/sha256": "^0.2.0",
         "@walletconnect/types": "^2.1.4",

--- a/examples/nft-minting/package.json
+++ b/examples/nft-minting/package.json
@@ -3,7 +3,7 @@
     "packageManager": "yarn@3.2.0",
     "dependencies": {
         "@concordium/browser-wallet-api-helpers": "workspace:^",
-        "@concordium/web-sdk": "^3.0.0",
+        "@concordium/web-sdk": "^3.3.1",
         "cors": "^2.8.5",
         "express": "^4.18.1",
         "express-fileupload": "^1.4.0",

--- a/examples/piggybank/package.json
+++ b/examples/piggybank/package.json
@@ -3,7 +3,7 @@
     "packageManager": "yarn@3.2.0",
     "dependencies": {
         "@concordium/browser-wallet-api-helpers": "workspace:^",
-        "@concordium/web-sdk": "^3.0.0",
+        "@concordium/web-sdk": "^3.3.1",
         "react": "^18.1.0",
         "react-dom": "^18.1.0"
     },

--- a/examples/two-step-transfer/package.json
+++ b/examples/two-step-transfer/package.json
@@ -8,6 +8,6 @@
         "start": "live-server ../two-step-transfer/index.html --mount=/sdk.js:./node_modules/@concordium/web-sdk/lib/concordium.min.js --mount=/helpers.js:../../packages/browser-wallet-api-helpers/lib/concordiumHelpers.min.js"
     },
     "dependencies": {
-        "@concordium/web-sdk": "^3.2.0"
+        "@concordium/web-sdk": "^3.3.1"
     }
 }

--- a/examples/voting/package.json
+++ b/examples/voting/package.json
@@ -4,7 +4,7 @@
     "packageManager": "yarn@3.2.0",
     "dependencies": {
         "@concordium/browser-wallet-api-helpers": "^2.0.0",
-        "@concordium/web-sdk": "^3.0.0",
+        "@concordium/web-sdk": "^3.3.1",
         "bootstrap": "^5.2.1",
         "cross-env": "^7.0.3",
         "moment": "^2.29.4",

--- a/examples/wCCD/package.json
+++ b/examples/wCCD/package.json
@@ -5,7 +5,7 @@
     "license": "Apache-2.0",
     "dependencies": {
         "@concordium/react-components": "^0.2.0",
-        "@concordium/web-sdk": "^3.2.0",
+        "@concordium/web-sdk": "^3.3.1",
         "@thi.ng/leb128": "^2.1.18",
         "@walletconnect/types": "^2.1.4",
         "mathjs": "^11.4.0",

--- a/packages/browser-wallet-api-helpers/CHANGELOG.md
+++ b/packages/browser-wallet-api-helpers/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.4.0
+
+### Added
+
+-   Added `getGrpcClient` entrypoint to access grpc-web client.
+
+### Deprecated
+
+-   `getJsonRpcClient` in favor of the new `getGrpcClient`.
+
 ## 2.3.0
 
 ### Added

--- a/packages/browser-wallet-api-helpers/package.json
+++ b/packages/browser-wallet-api-helpers/package.json
@@ -19,7 +19,7 @@
         "url": "https://concordium.com"
     },
     "dependencies": {
-        "@concordium/web-sdk": "^3.2.0"
+        "@concordium/web-sdk": "^3.3.1"
     },
     "devDependencies": {
         "@babel/core": "^7.17.10",

--- a/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
+++ b/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
@@ -8,6 +8,7 @@ import type {
     UpdateContractPayload,
     IdStatement,
     IdProofOutput,
+    ConcordiumGRPCClient,
 } from '@concordium/web-sdk';
 
 export type SendTransactionPayload =
@@ -107,7 +108,16 @@ interface MainWalletApi {
 
     removeAllListeners(event?: EventType | string | undefined): this;
 
+    /**
+     * @deprecated use { @link getGrpcClient} instead
+     */
     getJsonRpcClient(): JsonRpcClient;
+
+    /**
+     * Returns a gRPC client that is connected to the node that the wallet is.
+     * Note that any calls will throw an error, if the site is not connected with the wallet.
+     */
+    getGrpcClient(): ConcordiumGRPCClient;
 
     /**
      * Request that the user adds the specified tokens for a given contract to the wallet.

--- a/packages/browser-wallet-api/package.json
+++ b/packages/browser-wallet-api/package.json
@@ -7,7 +7,7 @@
     "license": "Apache-2.0",
     "dependencies": {
         "@concordium/browser-wallet-api-helpers": "workspace:^",
-        "@concordium/common-sdk": "^6.2.0",
+        "@concordium/common-sdk": "^6.3.0",
         "@protobuf-ts/grpcweb-transport": "^2.8.2",
         "@protobuf-ts/runtime-rpc": "^2.8.2",
         "buffer": "^6.0.3",

--- a/packages/browser-wallet-api/package.json
+++ b/packages/browser-wallet-api/package.json
@@ -8,6 +8,8 @@
     "dependencies": {
         "@concordium/browser-wallet-api-helpers": "workspace:^",
         "@concordium/common-sdk": "^6.2.0",
+        "@protobuf-ts/grpcweb-transport": "^2.8.2",
+        "@protobuf-ts/runtime-rpc": "^2.8.2",
         "buffer": "^6.0.3",
         "json-bigint": "^1.0.0"
     },

--- a/packages/browser-wallet-api/package.json
+++ b/packages/browser-wallet-api/package.json
@@ -8,6 +8,8 @@
     "dependencies": {
         "@concordium/browser-wallet-api-helpers": "workspace:^",
         "@concordium/common-sdk": "^6.3.0",
+        "@protobuf-ts/grpcweb-transport": "^2.8.2",
+        "@protobuf-ts/runtime-rpc": "^2.8.2",
         "buffer": "^6.0.3",
         "json-bigint": "^1.0.0"
     },

--- a/packages/browser-wallet-api/package.json
+++ b/packages/browser-wallet-api/package.json
@@ -8,8 +8,6 @@
     "dependencies": {
         "@concordium/browser-wallet-api-helpers": "workspace:^",
         "@concordium/common-sdk": "^6.3.0",
-        "@protobuf-ts/grpcweb-transport": "^2.8.2",
-        "@protobuf-ts/runtime-rpc": "^2.8.2",
         "buffer": "^6.0.3",
         "json-bigint": "^1.0.0"
     },

--- a/packages/browser-wallet-api/src/gRPC-transport.ts
+++ b/packages/browser-wallet-api/src/gRPC-transport.ts
@@ -17,6 +17,8 @@ import {
 
 /**
  * A transport that retrieves the location of the server from the wallet each time a request is made.
+ * The purpose of this custom transport is to defer providing the baseUrl a request is called, instead of when the transport is created,
+ * but other than that it is just forwards the inputs to the internal GrpcWebFetchTransport and forwards the outputs to the returned UnaryCall / ServerStreamingCall.
  * TODO: Move the actual fetch to the background / or content script to make this more robust / not leak the URL into this context.
  */
 export class BWGRPCTransport implements RpcTransport {
@@ -32,30 +34,38 @@ export class BWGRPCTransport implements RpcTransport {
         return this.transport?.mergeOptions(options) || { ...options };
     }
 
+    /**
+     * UnaryCalls expects a single response from the server.
+     */
     unary<I extends object, O extends object>(
         method: MethodInfo<I, O>,
         input: I,
         options: RpcOptions
     ): UnaryCall<I, O> {
+        // Prepare the 4 outputs:
         const defHeader = new Deferred<RpcMetadata>();
         const defMessage = new Deferred<O>();
         const defStatus = new Deferred<RpcStatus>();
         const defTrailer = new Deferred<RpcMetadata>();
 
+        // Retrieve the baseUrl from the background script:
         this.messageHandler
             .sendMessage<MessageStatusWrapper<string>>(MessageType.GrpcRequest)
             .then((response) => {
                 if (!response.success) {
                     throw new Error(response.message);
                 }
+                // Perform the actual gRPC request:
                 this.transport = new GrpcWebFetchTransport({ baseUrl: response.result });
                 const unary = this.transport.unary(method, input, options);
+                // Forward results for all the 4 outputs:
                 unary.headers.then(defHeader.resolve.bind(defHeader)).catch(defHeader.reject.bind(defHeader));
                 unary.response.then(defMessage.resolve.bind(defMessage)).catch(defMessage.reject.bind(defMessage));
                 unary.status.then(defStatus.resolve.bind(defStatus)).catch(defStatus.reject.bind(defStatus));
                 unary.trailers.then(defTrailer.resolve.bind(defTrailer)).catch(defTrailer.reject.bind(defTrailer));
             })
             .catch((error) => {
+                // Forward the error to all the 4 outputs if the background scripts returns a negative result:
                 defHeader.rejectPending(error);
                 defMessage.rejectPending(error);
                 defStatus.rejectPending(error);
@@ -73,30 +83,38 @@ export class BWGRPCTransport implements RpcTransport {
         );
     }
 
+    /**
+     * serverStreaming expects any number of responses from the server, until it is closed with the status/trailers.
+     */
     serverStreaming<I extends object, O extends object>(
         method: MethodInfo<I, O>,
         input: I,
         options: RpcOptions
     ): ServerStreamingCall<I, O> {
+        // Prepare the 4 outputs:
         const defHeader = new Deferred<RpcMetadata>();
         const defStatus = new Deferred<RpcStatus>();
         const defTrailer = new Deferred<RpcMetadata>();
         const responseStream = new RpcOutputStreamController<O>();
 
+        // Retrieve the baseUrl from the background script:
         this.messageHandler
             .sendMessage<MessageStatusWrapper<string>>(MessageType.GrpcRequest)
             .then((response) => {
                 if (!response.success) {
                     throw new Error(response.message);
                 }
+                // Perform the actual gRPC request:
                 this.transport = new GrpcWebFetchTransport({ baseUrl: response.result });
                 const stream = this.transport.serverStreaming(method, input, options);
+                // Forward results for all the 4 outputs:
                 stream.headers.then(defHeader.resolve.bind(defHeader)).catch(defHeader.reject.bind(defHeader));
                 stream.responses.onNext(responseStream.notifyNext.bind(responseStream));
                 stream.status.then(defStatus.resolve.bind(defStatus)).catch(defStatus.reject.bind(defStatus));
                 stream.trailers.then(defTrailer.resolve.bind(defTrailer)).catch(defTrailer.reject.bind(defTrailer));
             })
             .catch((error) => {
+                // Forward the error to all the 4 outputs if the background scripts returns a negative result:
                 defHeader.rejectPending(error);
                 responseStream.notifyError(error);
                 defStatus.rejectPending(error);

--- a/packages/browser-wallet-api/src/gRPC-transport.ts
+++ b/packages/browser-wallet-api/src/gRPC-transport.ts
@@ -1,0 +1,136 @@
+import { InjectedMessageHandler, MessageStatusWrapper, MessageType } from '@concordium/browser-wallet-message-hub';
+import { GrpcStatusCode, GrpcWebFetchTransport } from '@protobuf-ts/grpcweb-transport';
+import {
+    ClientStreamingCall,
+    Deferred,
+    DuplexStreamingCall,
+    MethodInfo,
+    RpcError,
+    RpcMetadata,
+    RpcOptions,
+    RpcOutputStreamController,
+    RpcStatus,
+    RpcTransport,
+    ServerStreamingCall,
+    UnaryCall,
+} from '@protobuf-ts/runtime-rpc';
+
+/**
+ * A transport that retrieves the location of the server from the wallet each time a request is made.
+ * TODO: Move the actual fetch to the background / or content script to make this more robust / not leak the URL into this context.
+ */
+export class BWGRPCTransport implements RpcTransport {
+    messageHandler: InjectedMessageHandler;
+
+    transport: RpcTransport | undefined;
+
+    constructor(messageHandler: InjectedMessageHandler) {
+        this.messageHandler = messageHandler;
+    }
+
+    mergeOptions(options: RpcOptions) {
+        return this.transport?.mergeOptions(options) || { ...options };
+    }
+
+    unary<I extends object, O extends object>(
+        method: MethodInfo<I, O>,
+        input: I,
+        options: RpcOptions
+    ): UnaryCall<I, O> {
+        const defHeader = new Deferred<RpcMetadata>();
+        const defMessage = new Deferred<O>();
+        const defStatus = new Deferred<RpcStatus>();
+        const defTrailer = new Deferred<RpcMetadata>();
+
+        this.messageHandler
+            .sendMessage<MessageStatusWrapper<string>>(MessageType.GrpcRequest)
+            .then((response) => {
+                if (!response.success) {
+                    throw new Error(response.message);
+                }
+                this.transport = new GrpcWebFetchTransport({ baseUrl: response.result });
+                const unary = this.transport.unary(method, input, options);
+                unary.headers.then(defHeader.resolve.bind(defHeader)).catch(defHeader.reject.bind(defHeader));
+                unary.response.then(defMessage.resolve.bind(defMessage)).catch(defMessage.reject.bind(defMessage));
+                unary.status.then(defStatus.resolve.bind(defStatus)).catch(defStatus.reject.bind(defStatus));
+                unary.trailers.then(defTrailer.resolve.bind(defTrailer)).catch(defTrailer.reject.bind(defTrailer));
+            })
+            .catch((error) => {
+                defHeader.rejectPending(error);
+                defMessage.rejectPending(error);
+                defStatus.rejectPending(error);
+                defTrailer.rejectPending(error);
+            });
+
+        return new UnaryCall(
+            method,
+            options?.meta || {},
+            input,
+            defHeader.promise,
+            defMessage.promise,
+            defStatus.promise,
+            defTrailer.promise
+        );
+    }
+
+    serverStreaming<I extends object, O extends object>(
+        method: MethodInfo<I, O>,
+        input: I,
+        options: RpcOptions
+    ): ServerStreamingCall<I, O> {
+        const defHeader = new Deferred<RpcMetadata>();
+        const defStatus = new Deferred<RpcStatus>();
+        const defTrailer = new Deferred<RpcMetadata>();
+        const responseStream = new RpcOutputStreamController<O>();
+
+        this.messageHandler
+            .sendMessage<MessageStatusWrapper<string>>(MessageType.GrpcRequest)
+            .then((response) => {
+                if (!response.success) {
+                    throw new Error(response.message);
+                }
+                this.transport = new GrpcWebFetchTransport({ baseUrl: response.result });
+                const stream = this.transport.serverStreaming(method, input, options);
+                stream.headers.then(defHeader.resolve.bind(defHeader)).catch(defHeader.reject.bind(defHeader));
+                stream.responses.onNext(responseStream.notifyNext.bind(responseStream));
+                stream.status.then(defStatus.resolve.bind(defStatus)).catch(defStatus.reject.bind(defStatus));
+                stream.trailers.then(defTrailer.resolve.bind(defTrailer)).catch(defTrailer.reject.bind(defTrailer));
+            })
+            .catch((error) => {
+                defHeader.rejectPending(error);
+                responseStream.notifyError(error);
+                defStatus.rejectPending(error);
+                defTrailer.rejectPending(error);
+            });
+
+        return new ServerStreamingCall(
+            method,
+            options?.meta || {},
+            input,
+            defHeader.promise,
+            responseStream,
+            defStatus.promise,
+            defTrailer.promise
+        );
+    }
+
+    clientStreaming<I extends object, O extends object>(method: MethodInfo<I, O>): ClientStreamingCall<I, O> {
+        const e = new RpcError(
+            'Client streaming is not supported by grpc-web',
+            GrpcStatusCode[GrpcStatusCode.UNIMPLEMENTED]
+        );
+        e.methodName = method.name;
+        e.serviceName = method.service.typeName;
+        throw e;
+    }
+
+    duplex<I extends object, O extends object>(method: MethodInfo<I, O>): DuplexStreamingCall<I, O> {
+        const e = new RpcError(
+            'Duplex streaming is not supported by grpc-web',
+            GrpcStatusCode[GrpcStatusCode.UNIMPLEMENTED]
+        );
+        e.methodName = method.name;
+        e.serviceName = method.service.typeName;
+        throw e;
+    }
+}

--- a/packages/browser-wallet-api/src/wallet-api.ts
+++ b/packages/browser-wallet-api/src/wallet-api.ts
@@ -24,40 +24,34 @@ import {
 import EventEmitter from 'events';
 import type { JsonRpcRequest } from '@concordium/common-sdk/lib/providers/provider';
 import JSONBig from 'json-bigint';
-import { IdProofOutput, IdStatement } from '@concordium/common-sdk';
+import { ConcordiumGRPCClient, IdProofOutput, IdStatement } from '@concordium/common-sdk';
 import { stringify } from './util';
-
-type JsonRpcCallResponse =
-    | {
-          success: true;
-          response: string;
-      }
-    | {
-          success: false;
-          error: string;
-      };
+import { BWGRPCTransport } from './gRPC-transport';
 
 class WalletApi extends EventEmitter implements IWalletApi {
     private messageHandler = new InjectedMessageHandler();
 
     private jsonRpcClient: JsonRpcClient;
 
+    private grpcClient: ConcordiumGRPCClient;
+
     constructor() {
         super();
         // We pre-serialize the parameters before sending to the background script.
         const request = (...input: Parameters<JsonRpcRequest>) =>
             this.messageHandler
-                .sendMessage<JsonRpcCallResponse>(MessageType.JsonRpcRequest, {
+                .sendMessage<MessageStatusWrapper<string>>(MessageType.JsonRpcRequest, {
                     method: input[0],
                     params: JSONBig.stringify(input[1]),
                 })
                 .then((result) => {
                     if (!result.success) {
-                        throw new Error(result.error);
+                        throw new Error(result.message);
                     }
-                    return result.response;
+                    return result.result;
                 });
         this.jsonRpcClient = new JsonRpcClient({ request });
+        this.grpcClient = new ConcordiumGRPCClient(new BWGRPCTransport(this.messageHandler));
 
         // Set up message handlers to emit events.
         Object.values(EventType).forEach((eventType) => this.handleEvent(eventType));
@@ -177,6 +171,10 @@ class WalletApi extends EventEmitter implements IWalletApi {
 
     public getJsonRpcClient(): JsonRpcClient {
         return this.jsonRpcClient;
+    }
+
+    public getGrpcClient(): ConcordiumGRPCClient {
+        return this.grpcClient;
     }
 
     public async addCIS2Tokens(

--- a/packages/browser-wallet-message-hub/src/message.ts
+++ b/packages/browser-wallet-message-hub/src/message.ts
@@ -12,6 +12,7 @@ export enum MessageType {
     GetSelectedAccount = 'M_GetSelectedAccount',
     Connect = 'M_Connect',
     JsonRpcRequest = 'M_JsonRpcRequest',
+    GrpcRequest = 'M_GrpcRequest',
     AddTokens = 'M_AddTokens',
     IdProof = 'M_IdProof',
 }

--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.0
+
+### Changed
+
+-   Use gRPC-web instead of json-RPC.
+
 ## 0.9.8
 
 ### Fixed

--- a/packages/browser-wallet/package.json
+++ b/packages/browser-wallet/package.json
@@ -17,7 +17,7 @@
     "dependencies": {
         "@concordium/browser-wallet-api": "workspace:^",
         "@concordium/browser-wallet-api-helpers": "workspace:^",
-        "@concordium/web-sdk": "^3.2.0",
+        "@concordium/web-sdk": "^3.3.1",
         "@scure/bip39": "^1.1.0",
         "axios": "^0.27.2",
         "buffer": "^6.0.3",
@@ -43,7 +43,7 @@
         "react-window-infinite-loader": "^1.0.8",
         "readable-stream": "^4.2.0",
         "uuid": "^8.3.2",
-        "wallet-common-helpers": "https://github.com/Concordium/concordium-wallet-common-helpers.git#cde2bfb682cae08c9f0338d4a0567abecaeb2a26"
+        "wallet-common-helpers": "https://github.com/Concordium/concordium-wallet-common-helpers.git#280339fa6c51922944094bc631d097d245e1e08f"
     },
     "devDependencies": {
         "@babel/core": "^7.18.2",

--- a/packages/browser-wallet/src/background/confirmation.ts
+++ b/packages/browser-wallet/src/background/confirmation.ts
@@ -29,7 +29,7 @@ const isMonitoringCred = (genesisHash: string, id: PendingWalletCredential): boo
 
 async function monitorCredentialStatus(initialNetwork: NetworkConfiguration, cred: PendingWalletCredential) {
     const { genesisHash } = initialNetwork;
-    const client = createConcordiumClient(initialNetwork.grpcUrl, initialNetwork.grpcPort, GRPCTIMEOUT);
+    const client = createConcordiumClient(initialNetwork.grpcUrl, initialNetwork.grpcPort, { timeout: GRPCTIMEOUT });
     if (isMonitoringCred(genesisHash, cred)) {
         return;
     }

--- a/packages/browser-wallet/src/background/credential-deployment.ts
+++ b/packages/browser-wallet/src/background/credential-deployment.ts
@@ -1,51 +1,64 @@
 import { ExtensionMessageHandler } from '@concordium/browser-wallet-message-hub';
 
 import {
-    HttpProvider,
-    createCredentialV1,
-    CredentialInputV1,
+    CredentialInput,
     getAccountAddress,
-    getSignedCredentialDeploymentTransactionHash,
-    JsonRpcClient,
+    createConcordiumClient,
+    createCredentialTransaction,
+    signCredentialTransaction,
+    ConcordiumHdWallet,
+    TransactionExpiry,
+    getCredentialDeploymentTransactionHash,
 } from '@concordium/web-sdk';
+import { GRPCTIMEOUT } from '@shared/constants/networkConfiguration';
 import { sessionCreatingCredential, storedCurrentNetwork, storedSelectedAccount } from '@shared/storage/access';
 import { CreationStatus, PendingWalletCredential } from '@shared/storage/types';
 import { BackgroundResponseStatus, CredentialDeploymentBackgroundResponse } from '@shared/utils/types';
 import { confirmCredential } from './confirmation';
 import { addCredential } from './update';
 
-async function createAndSendCredential(credIn: CredentialInputV1): Promise<CredentialDeploymentBackgroundResponse> {
+async function createAndSendCredential(credIn: CredentialInput): Promise<CredentialDeploymentBackgroundResponse> {
     let address: string;
     try {
         const network = await storedCurrentNetwork.get();
-        const url = network?.jsonRpcUrl;
-        if (!url) {
-            throw new Error('No JSON RPC url available');
+        if (!network) {
+            throw new Error('No network available');
         }
 
-        const request = createCredentialV1(credIn);
-        const { credId } = request.cdi;
-        const deploymentHash = getSignedCredentialDeploymentTransactionHash(request);
+        const { identityIndex, credNumber } = credIn;
+        const providerIndex = credIn.ipInfo.ipIdentity;
+
+        const request = createCredentialTransaction(credIn, new TransactionExpiry(new Date(Date.now() + 720000)));
+        const signingKey = ConcordiumHdWallet.fromHex(credIn.seedAsHex, credIn.net)
+            .getAccountSigningKey(providerIndex, identityIndex, credNumber)
+            .toString('hex');
+        const signature = await signCredentialTransaction(request, signingKey);
+        const { credId } = request.unsignedCdi;
+        const deploymentHash = getCredentialDeploymentTransactionHash(request, [signature]);
         address = getAccountAddress(credId).address;
         const newCred: PendingWalletCredential = {
             address,
-            identityIndex: credIn.identityIndex,
-            providerIndex: credIn.ipInfo.ipIdentity,
+            identityIndex,
+            providerIndex,
             credId,
-            credNumber: credIn.credNumber,
+            credNumber,
             status: CreationStatus.Pending,
             deploymentHash,
         };
 
         // Send Request
-        const successful = await new JsonRpcClient(new HttpProvider(url, fetch)).sendCredentialDeployment(request);
+        const successful = createConcordiumClient(
+            network.grpcUrl,
+            network.grpcPort,
+            GRPCTIMEOUT
+        ).sendCredentialDeploymentTransaction(request, [signature]);
         if (!successful) {
             throw new Error('Credential deployment was rejected');
         }
 
         // Add Pending
         await addCredential(newCred, network.genesisHash);
-        confirmCredential(newCred, url, network.genesisHash);
+        confirmCredential(newCred, network);
         // Set Selected to new account
         await storedSelectedAccount.set(address);
     } finally {

--- a/packages/browser-wallet/src/background/credential-deployment.ts
+++ b/packages/browser-wallet/src/background/credential-deployment.ts
@@ -28,7 +28,8 @@ async function createAndSendCredential(credIn: CredentialInput): Promise<Credent
         const { identityIndex, credNumber } = credIn;
         const providerIndex = credIn.ipInfo.ipIdentity;
 
-        const request = createCredentialTransaction(credIn, new TransactionExpiry(new Date(Date.now() + 720000)));
+        const expiry = new TransactionExpiry(new Date(Date.now() + 720000));
+        const request = createCredentialTransaction(credIn, expiry);
         const signingKey = ConcordiumHdWallet.fromHex(credIn.seedAsHex, credIn.net)
             .getAccountSigningKey(providerIndex, identityIndex, credNumber)
             .toString('hex');
@@ -47,11 +48,9 @@ async function createAndSendCredential(credIn: CredentialInput): Promise<Credent
         };
 
         // Send Request
-        const successful = createConcordiumClient(
-            network.grpcUrl,
-            network.grpcPort,
-            GRPCTIMEOUT
-        ).sendCredentialDeploymentTransaction(request, [signature]);
+        const successful = createConcordiumClient(network.grpcUrl, network.grpcPort, {
+            timeout: GRPCTIMEOUT,
+        }).sendCredentialDeploymentTransaction(request, [signature]);
         if (!successful) {
             throw new Error('Credential deployment was rejected');
         }

--- a/packages/browser-wallet/src/background/credential-deployment.ts
+++ b/packages/browser-wallet/src/background/credential-deployment.ts
@@ -11,6 +11,7 @@ import {
     getCredentialDeploymentTransactionHash,
 } from '@concordium/web-sdk';
 import { GRPCTIMEOUT } from '@shared/constants/networkConfiguration';
+import { DEFAULT_TRANSACTION_EXPIRY } from '@shared/constants/time';
 import { sessionCreatingCredential, storedCurrentNetwork, storedSelectedAccount } from '@shared/storage/access';
 import { CreationStatus, PendingWalletCredential } from '@shared/storage/types';
 import { BackgroundResponseStatus, CredentialDeploymentBackgroundResponse } from '@shared/utils/types';
@@ -28,7 +29,7 @@ async function createAndSendCredential(credIn: CredentialInput): Promise<Credent
         const { identityIndex, credNumber } = credIn;
         const providerIndex = credIn.ipInfo.ipIdentity;
 
-        const expiry = new TransactionExpiry(new Date(Date.now() + 720000));
+        const expiry = new TransactionExpiry(new Date(Date.now() + DEFAULT_TRANSACTION_EXPIRY));
         const request = createCredentialTransaction(credIn, expiry);
         const signingKey = ConcordiumHdWallet.fromHex(credIn.seedAsHex, credIn.net)
             .getAccountSigningKey(providerIndex, identityIndex, credNumber)

--- a/packages/browser-wallet/src/background/index.ts
+++ b/packages/browser-wallet/src/background/index.ts
@@ -19,6 +19,7 @@ import JSONBig from 'json-bigint';
 import { ChromeStorageKey, NetworkConfiguration } from '@shared/storage/types';
 import { buildURLwithSearchParameters } from '@shared/utils/url-helpers';
 import { getTermsAndConditionsConfig } from '@shared/utils/network-helpers';
+import { mainnet, testnet } from '@shared/constants/networkConfiguration';
 import bgMessageHandler from './message-handler';
 import {
     forwardToPopup,
@@ -134,9 +135,16 @@ async function checkForNewTermsAndConditions() {
     }
 }
 
+async function migrateNetwork(network: NetworkConfiguration) {
+    if (network.genesisHash && (!network.grpcUrl || !network.grpcPort)) {
+        await storedCurrentNetwork.set(network.genesisHash === mainnet.genesisHash ? mainnet : testnet);
+    }
+}
+
 const startupHandler = async () => {
     const network = await storedCurrentNetwork.get();
     if (network) {
+        await migrateNetwork(network);
         await startMonitoringPendingStatus(network);
     }
     checkForNewTermsAndConditions();

--- a/packages/browser-wallet/src/background/recovery.ts
+++ b/packages/browser-wallet/src/background/recovery.ts
@@ -132,7 +132,7 @@ async function performRecovery() {
         const identities = await storedIdentities.get(network.genesisHash);
         const credentials = await storedCredentials.get(network.genesisHash);
 
-        const client = createConcordiumClient(network.grpcUrl, network.grpcPort, GRPCTIMEOUT);
+        const client = createConcordiumClient(network.grpcUrl, network.grpcPort, { timeout: GRPCTIMEOUT });
         const getAccountInfo = (credId: string) => client.getAccountInfo(new CredentialRegistrationId(credId));
 
         let initialGap: number | undefined = status.identityGap || 0;

--- a/packages/browser-wallet/src/background/recovery.ts
+++ b/packages/browser-wallet/src/background/recovery.ts
@@ -3,9 +3,8 @@ import {
     ConcordiumHdWallet,
     createIdentityRecoveryRequest,
     CredentialRegistrationId,
-    HttpProvider,
     IdentityRecoveryRequestInput,
-    JsonRpcClient,
+    createConcordiumClient,
 } from '@concordium/web-sdk';
 import { InternalMessageType } from '@concordium/browser-wallet-message-hub';
 import { BackgroundResponseStatus, RecoveryBackgroundResponse } from '@shared/utils/types';
@@ -31,6 +30,7 @@ import { partition } from 'wallet-common-helpers';
 import { mnemonicToSeedSync } from '@scure/bip39';
 import { decrypt } from '@shared/utils/crypto';
 import { Buffer } from 'buffer/';
+import { GRPCTIMEOUT } from '@shared/constants/networkConfiguration';
 import { addCredential, addIdentity, updateCredentials } from './update';
 import bgMessageHandler from './message-handler';
 import { openWindow } from './window-management';
@@ -132,10 +132,8 @@ async function performRecovery() {
         const identities = await storedIdentities.get(network.genesisHash);
         const credentials = await storedCredentials.get(network.genesisHash);
 
-        const client = new JsonRpcClient(new HttpProvider(network.jsonRpcUrl, fetch));
-        const blockHash = (await client.getConsensusStatus()).lastFinalizedBlock;
-        const getAccountInfo = (credId: string) =>
-            client.getAccountInfo(new CredentialRegistrationId(credId), blockHash);
+        const client = createConcordiumClient(network.grpcUrl, network.grpcPort, GRPCTIMEOUT);
+        const getAccountInfo = (credId: string) => client.getAccountInfo(new CredentialRegistrationId(credId));
 
         let initialGap: number | undefined = status.identityGap || 0;
         let initialIndex: number | undefined = status.identityIndex || 0;

--- a/packages/browser-wallet/src/background/recovery.ts
+++ b/packages/browser-wallet/src/background/recovery.ts
@@ -133,7 +133,10 @@ async function performRecovery() {
         const credentials = await storedCredentials.get(network.genesisHash);
 
         const client = createConcordiumClient(network.grpcUrl, network.grpcPort, { timeout: GRPCTIMEOUT });
-        const getAccountInfo = (credId: string) => client.getAccountInfo(new CredentialRegistrationId(credId));
+        const getAccountInfo = (credId: string) =>
+            client.getAccountInfo(new CredentialRegistrationId(credId)).catch(() => {
+                return undefined;
+            });
 
         let initialGap: number | undefined = status.identityGap || 0;
         let initialIndex: number | undefined = status.identityIndex || 0;

--- a/packages/browser-wallet/src/popup/page-layouts/ExternalRequestLayout/ExternalRequestLayout.tsx
+++ b/packages/browser-wallet/src/popup/page-layouts/ExternalRequestLayout/ExternalRequestLayout.tsx
@@ -7,8 +7,6 @@ import Toast from '@popup/shared/Toast/Toast';
 
 import { useCredential } from '@popup/shared/utils/account-helpers';
 import AccountDetails from '@popup/pages/Account/AccountDetails';
-import AccountInfoListenerContext from '@popup/shared/AccountInfoListenerContext';
-import BlockChainParametersContext from '@popup/shared/BlockChainParametersProvider';
 
 function Header() {
     const { t } = useTranslation('mainLayout');
@@ -61,13 +59,9 @@ export default function ExternalRequestLayout({ children }: Props) {
         <>
             <Header />
             <div className="external-request-layout">
-                <AccountInfoListenerContext>
-                    <BlockChainParametersContext>
-                        {account && <AccountDetails expanded={false} account={account} />}
-                        <main className="external-request-layout__main">{children}</main>
-                        <Toast />
-                    </BlockChainParametersContext>
-                </AccountInfoListenerContext>
+                {account && <AccountDetails expanded={false} account={account} />}
+                <main className="external-request-layout__main">{children}</main>
+                <Toast />
             </div>
         </>
     );

--- a/packages/browser-wallet/src/popup/page-layouts/ExternalRequestLayout/ExternalRequestLayout.tsx
+++ b/packages/browser-wallet/src/popup/page-layouts/ExternalRequestLayout/ExternalRequestLayout.tsx
@@ -8,6 +8,7 @@ import Toast from '@popup/shared/Toast/Toast';
 import { useCredential } from '@popup/shared/utils/account-helpers';
 import AccountDetails from '@popup/pages/Account/AccountDetails';
 import AccountInfoListenerContext from '@popup/shared/AccountInfoListenerContext';
+import BlockChainParametersContext from '@popup/shared/BlockChainParametersProvider';
 
 function Header() {
     const { t } = useTranslation('mainLayout');
@@ -61,9 +62,11 @@ export default function ExternalRequestLayout({ children }: Props) {
             <Header />
             <div className="external-request-layout">
                 <AccountInfoListenerContext>
-                    {account && <AccountDetails expanded={false} account={account} />}
-                    <main className="external-request-layout__main">{children}</main>
-                    <Toast />
+                    <BlockChainParametersContext>
+                        {account && <AccountDetails expanded={false} account={account} />}
+                        <main className="external-request-layout__main">{children}</main>
+                        <Toast />
+                    </BlockChainParametersContext>
                 </AccountInfoListenerContext>
             </div>
         </>

--- a/packages/browser-wallet/src/popup/page-layouts/MainLayout/MainLayout.tsx
+++ b/packages/browser-wallet/src/popup/page-layouts/MainLayout/MainLayout.tsx
@@ -13,6 +13,7 @@ import {
 import { isRecoveringAtom } from '@popup/store/identity';
 import Toast from '@popup/shared/Toast/Toast';
 import AccountInfoListenerContext from '@popup/shared/AccountInfoListenerContext';
+import BlockChainParametersContext from '@popup/shared/BlockChainParametersProvider';
 import Header from './Header';
 
 export default function MainLayout() {
@@ -57,10 +58,12 @@ export default function MainLayout() {
     return (
         <div className="main-layout">
             <AccountInfoListenerContext>
-                <Header onToggle={setHeaderOpen} />
-                <main className={clsx('main-layout__main', headerOpen && 'main-layout__main--blur')}>
-                    <Outlet />
-                </main>
+                <BlockChainParametersContext>
+                    <Header onToggle={setHeaderOpen} />
+                    <main className={clsx('main-layout__main', headerOpen && 'main-layout__main--blur')}>
+                        <Outlet />
+                    </main>
+                </BlockChainParametersContext>
             </AccountInfoListenerContext>
             <Toast />
         </div>

--- a/packages/browser-wallet/src/popup/page-layouts/MainLayout/MainLayout.tsx
+++ b/packages/browser-wallet/src/popup/page-layouts/MainLayout/MainLayout.tsx
@@ -12,8 +12,6 @@ import {
 } from '@popup/store/settings';
 import { isRecoveringAtom } from '@popup/store/identity';
 import Toast from '@popup/shared/Toast/Toast';
-import AccountInfoListenerContext from '@popup/shared/AccountInfoListenerContext';
-import BlockChainParametersContext from '@popup/shared/BlockChainParametersProvider';
 import Header from './Header';
 
 export default function MainLayout() {
@@ -57,14 +55,10 @@ export default function MainLayout() {
 
     return (
         <div className="main-layout">
-            <AccountInfoListenerContext>
-                <BlockChainParametersContext>
-                    <Header onToggle={setHeaderOpen} />
-                    <main className={clsx('main-layout__main', headerOpen && 'main-layout__main--blur')}>
-                        <Outlet />
-                    </main>
-                </BlockChainParametersContext>
-            </AccountInfoListenerContext>
+            <Header onToggle={setHeaderOpen} />
+            <main className={clsx('main-layout__main', headerOpen && 'main-layout__main--blur')}>
+                <Outlet />
+            </main>
             <Toast />
         </div>
     );

--- a/packages/browser-wallet/src/popup/pages/Account/Account.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/Account.tsx
@@ -83,6 +83,7 @@ function Account() {
 
 export default function AccountRoutes() {
     const [detailsExpanded, setDetailsExpanded] = useState(true);
+
     const contextValue: AccountPageContext = useMemo(
         () => ({ detailsExpanded, setDetailsExpanded }),
         [setDetailsExpanded, detailsExpanded]

--- a/packages/browser-wallet/src/popup/pages/Account/ManageTokens/ManageTokens.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/ManageTokens/ManageTokens.tsx
@@ -8,7 +8,7 @@ import { useUpdateEffect } from 'wallet-common-helpers';
 import Form from '@popup/shared/Form';
 import FormInput from '@popup/shared/Form/Input';
 import Submit from '@popup/shared/Form/Submit';
-import { jsonRpcClientAtom } from '@popup/store/settings';
+import { grpcClientAtom } from '@popup/store/settings';
 import { confirmCIS2Contract, ContractDetails, ContractTokenDetails } from '@shared/utils/token-helpers';
 import TokenDetails from '@popup/shared/TokenDetails';
 import { selectedAccountAtom } from '@popup/store/account';
@@ -44,7 +44,7 @@ function ChooseContract() {
         defaultValues: { contractIndex: contractDetails?.index?.toString() },
     });
     const contractIndexValue = form.watch('contractIndex');
-    const client = useAtomValue(jsonRpcClientAtom);
+    const client = useAtomValue(grpcClientAtom);
     const nav = useNavigate();
     const validContract = useRef<{ details: ContractDetails; tokens: FetchTokensResponse } | undefined>();
     const account = ensureDefined(useAtomValue(selectedAccountAtom), 'No account has been selected');

--- a/packages/browser-wallet/src/popup/pages/Account/ManageTokens/TokenList.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/ManageTokens/TokenList.tsx
@@ -2,7 +2,7 @@ import React, { CSSProperties, forwardRef, ReactNode, useCallback, useEffect, us
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { isHex, isDefined, noOp, useUpdateEffect } from 'wallet-common-helpers';
-import { JsonRpcClient } from '@concordium/web-sdk';
+import { ConcordiumGRPCClient } from '@concordium/web-sdk';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import debounce from 'lodash.debounce';
 import InfiniteLoader from 'react-window-infinite-loader';
@@ -16,7 +16,7 @@ import Button from '@popup/shared/Button';
 import { Input } from '@popup/shared/Form/Input';
 import { addToastAtom } from '@popup/state';
 import { selectedAccountAtom } from '@popup/store/account';
-import { jsonRpcClientAtom } from '@popup/store/settings';
+import { grpcClientAtom } from '@popup/store/settings';
 import { currentAccountTokensAtom } from '@popup/store/token';
 import { ensureDefined } from '@shared/utils/basic-helpers';
 import ContractTokenLine, { ChoiceStatus } from '@popup/shared/ContractTokenLine';
@@ -88,7 +88,7 @@ const InfiniteTokenList = forwardRef<HTMLDivElement, InfiniteTokenListProps>(
  * Sets result.value to empty list on error, list with 1 token on successful lookup, and undefined while loading.
  * Invoking with empty searchQuery param aborts previous invocations.
  */
-const lookupTokenIdConfigure = (contractDetails: ContractDetails, client: JsonRpcClient, account: string) => {
+const lookupTokenIdConfigure = (contractDetails: ContractDetails, client: ConcordiumGRPCClient, account: string) => {
     let ac: AbortController;
 
     return debounce(
@@ -133,7 +133,7 @@ const validateId = (id: string | undefined, message: string) => {
 
 function useLookupTokenId() {
     const contractDetails = ensureDefined(useAtomValue(contractDetailsAtom), 'Assumed contract details to be defined');
-    const client = useAtomValue(jsonRpcClientAtom);
+    const client = useAtomValue(grpcClientAtom);
     const account = ensureDefined(useAtomValue(selectedAccountAtom), 'No account selected');
 
     const lookupTokenId = useCallback(lookupTokenIdConfigure(contractDetails, client, account), [

--- a/packages/browser-wallet/src/popup/pages/Account/ManageTokens/state.ts
+++ b/packages/browser-wallet/src/popup/pages/Account/ManageTokens/state.ts
@@ -2,7 +2,7 @@ import { atom } from 'jotai';
 import { MakeOptional } from 'wallet-common-helpers';
 
 import { selectedAccountAtom } from '@popup/store/account';
-import { jsonRpcClientAtom } from '@popup/store/settings';
+import { grpcClientAtom } from '@popup/store/settings';
 import { ensureDefined } from '@shared/utils/basic-helpers';
 import { ContractDetails, ContractTokenDetails } from '@shared/utils/token-helpers';
 import { AsyncWrapper, resetOnUnmountAtom } from '@popup/store/utils';
@@ -59,7 +59,7 @@ export const contractTokensAtom = (() => {
                 case 'next': {
                     const contractDetails = ensureDefined(get(contractDetailsAtom), 'Needs contract details');
                     const account = ensureDefined(get(selectedAccountAtom), 'No account has been selected');
-                    const client = get(jsonRpcClientAtom);
+                    const client = get(grpcClientAtom);
                     const fetchTokens = fetchTokensConfigure(contractDetails, client, account);
 
                     set(loadingAtom, true);

--- a/packages/browser-wallet/src/popup/pages/Account/ManageTokens/utils.ts
+++ b/packages/browser-wallet/src/popup/pages/Account/ManageTokens/utils.ts
@@ -1,4 +1,4 @@
-import { JsonRpcClient } from '@concordium/web-sdk';
+import { ConcordiumGRPCClient } from '@concordium/web-sdk';
 import { getCis2Tokens } from '@popup/shared/utils/wallet-proxy';
 import { TokenIdAndMetadata } from '@shared/storage/types';
 import { ContractDetails, ContractTokenDetails, getTokens } from '@shared/utils/token-helpers';
@@ -27,7 +27,12 @@ export const manageTokensRoutes = {
 };
 
 export const fetchTokensConfigure =
-    (contractDetails: ContractDetails, client: JsonRpcClient, account: string, onError?: (error: string) => void) =>
+    (
+        contractDetails: ContractDetails,
+        client: ConcordiumGRPCClient,
+        account: string,
+        onError?: (error: string) => void
+    ) =>
     async (from?: number): Promise<FetchTokensResponse> => {
         const {
             tokens: cts,

--- a/packages/browser-wallet/src/popup/pages/Account/SendCcd/ConfirmTokenTransfer.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/SendCcd/ConfirmTokenTransfer.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useSetAtom, useAtomValue } from 'jotai';
 import { selectedAccountAtom } from '@popup/store/account';
 import { AccountTransactionType, SimpleTransferPayload, UpdateContractPayload } from '@concordium/web-sdk';
-import { jsonRpcClientAtom } from '@popup/store/settings';
+import { grpcClientAtom } from '@popup/store/settings';
 import { addToastAtom } from '@popup/state';
 import { useLocation } from 'react-router-dom';
 import { useAsyncMemo } from 'wallet-common-helpers';
@@ -28,7 +28,7 @@ export default function ConfirmTokenTransfer({ setDetailsExpanded, cost }: Props
     const { state } = useLocation();
     const { toAddress, amount, contractIndex, tokenId, executionEnergy, metadata } = state as State;
     const selectedAddress = useAtomValue(selectedAccountAtom);
-    const client = useAtomValue(jsonRpcClientAtom);
+    const client = useAtomValue(grpcClientAtom);
     const addToast = useSetAtom(addToastAtom);
     const contractName = useAsyncMemo(() => fetchContractName(client, BigInt(contractIndex)), undefined, []);
 

--- a/packages/browser-wallet/src/popup/pages/Account/SendCcd/ConfirmTransfer.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/SendCcd/ConfirmTransfer.tsx
@@ -14,7 +14,7 @@ import {
     createPendingTransactionFromAccountTransaction,
     sendTransaction,
 } from '@popup/shared/utils/transaction-helpers';
-import { jsonRpcClientAtom } from '@popup/store/settings';
+import { grpcClientAtom } from '@popup/store/settings';
 import { addToastAtom } from '@popup/state';
 import { usePrivateKey } from '@popup/shared/utils/account-helpers';
 import Button from '@popup/shared/Button';
@@ -63,7 +63,7 @@ export default function ConfirmTransfer(props: Props) {
     const selectedAddress = useAtomValue(selectedAccountAtom);
     const address = useMemo(() => selectedAddress, []);
     const key = usePrivateKey(address);
-    const client = useAtomValue(jsonRpcClientAtom);
+    const client = useAtomValue(grpcClientAtom);
     const nav = useNavigate();
     const addToast = useSetAtom(addToastAtom);
     const addPendingTransaction = useUpdateAtom(addPendingTransactionAtom);

--- a/packages/browser-wallet/src/popup/pages/Account/SendCcd/CreateTransfer.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/SendCcd/CreateTransfer.tsx
@@ -35,7 +35,7 @@ import {
     TokenIdentifier,
     trunctateSymbol,
 } from '@shared/utils/token-helpers';
-import { jsonRpcClientAtom } from '@popup/store/settings';
+import { grpcClientAtom } from '@popup/store/settings';
 import CcdIcon from '@assets/svg/concordium.svg';
 import { addToastAtom } from '@popup/state';
 import TokenBalance from '@popup/shared/TokenBalance';
@@ -96,7 +96,7 @@ function CreateTransaction({ exchangeRate, tokens, setCost, setDetailsExpanded, 
     const form = useForm<FormValues>({
         defaultValues: createDefaultValues(state as State, accountTokens),
     });
-    const client = useAtomValue(jsonRpcClientAtom);
+    const client = useAtomValue(grpcClientAtom);
     const chosenToken = form.watch('token');
     const recipient = form.watch('recipient');
     const tokenMetadata = useMemo(() => chosenToken?.metadata || CCD_METADATA, [chosenToken?.metadata]);

--- a/packages/browser-wallet/src/popup/pages/Account/SendCcd/CreateTransfer.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/SendCcd/CreateTransfer.tsx
@@ -197,11 +197,12 @@ function CreateTransaction({ tokens, setCost, setDetailsExpanded, cost }: Props 
         if (validateAddress) {
             return validateAddress;
         }
-        const info = await client.getAccountInfo(new AccountAddress(recipientAddress));
-        if (!info) {
+        try {
+            await client.getAccountInfo(new AccountAddress(recipientAddress));
+            return undefined;
+        } catch {
             return t('sendCcd.nonexistingAccount');
         }
-        return undefined;
     }, []);
 
     const displayAmount = integerToFractional(getMetadataDecimals(tokenMetadata));

--- a/packages/browser-wallet/src/popup/pages/Account/SendCcd/CreateTransfer.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/SendCcd/CreateTransfer.tsx
@@ -41,8 +41,9 @@ import { addToastAtom } from '@popup/state';
 import TokenBalance from '@popup/shared/TokenBalance';
 import Button from '@popup/shared/Button';
 import SearchIcon from '@assets/svg/search.svg';
-import { SIMPLE_TRANSFER_ENERGY_TOTAL_COST } from '@shared/utils/energy-helpers';
+import { convertEnergyToMicroCcd, SIMPLE_TRANSFER_ENERGY_TOTAL_COST } from '@shared/utils/energy-helpers';
 import Img from '@popup/shared/Img';
+import { useBlockChainParameters } from '@popup/shared/BlockChainParametersProvider';
 import { routes } from './routes';
 import PickToken from './PickToken';
 
@@ -55,7 +56,6 @@ export type FormValues = {
 };
 
 interface Props {
-    exchangeRate?: number;
     cost: bigint;
     setCost: (cost: bigint) => void;
     setDetailsExpanded: (expanded: boolean) => void;
@@ -85,7 +85,7 @@ function createDefaultValues(defaultPayload: State, accountTokens?: AccountToken
     };
 }
 
-function CreateTransaction({ exchangeRate, tokens, setCost, setDetailsExpanded, cost }: Props & { tokens: Tokens }) {
+function CreateTransaction({ tokens, setCost, setDetailsExpanded, cost }: Props & { tokens: Tokens }) {
     const { t } = useTranslation('account');
     const { t: tShared } = useTranslation('shared');
     const { state } = useLocation();
@@ -102,6 +102,7 @@ function CreateTransaction({ exchangeRate, tokens, setCost, setDetailsExpanded, 
     const tokenMetadata = useMemo(() => chosenToken?.metadata || CCD_METADATA, [chosenToken?.metadata]);
     const [pickingToken, setPickingToken] = useState<boolean>(false);
     const addToast = useSetAtom(addToastAtom);
+    const chainParameters = useBlockChainParameters();
 
     if (!address || !selectedCred) {
         throw new Error('Missing selected accoount');
@@ -137,8 +138,8 @@ function CreateTransaction({ exchangeRate, tokens, setCost, setDetailsExpanded, 
     );
 
     useEffect(() => {
-        setCost(exchangeRate && fee?.success ? BigInt(Math.ceil(exchangeRate * Number(fee.value))) : 0n);
-    }, [fee, exchangeRate]);
+        setCost(chainParameters && fee?.success ? convertEnergyToMicroCcd(fee.value, chainParameters) : 0n);
+    }, [fee, chainParameters]);
 
     const accountInfo = useAccountInfo(selectedCred);
 

--- a/packages/browser-wallet/src/popup/pages/Account/SendCcd/SendCcd.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/SendCcd/SendCcd.tsx
@@ -1,7 +1,5 @@
 import React, { useContext, useState } from 'react';
 import { Route, Routes } from 'react-router-dom';
-import { getEnergyPerCCD } from '@popup/shared/utils/wallet-proxy';
-import { noOp, useAsyncMemo } from 'wallet-common-helpers';
 import CreateTransfer from './CreateTransfer';
 import ConfirmSimpleTransfer from './ConfirmSimpleTransfer';
 import { routes } from './routes';
@@ -9,7 +7,6 @@ import ConfirmTokenTransfer from './ConfirmTokenTransfer';
 import { accountPageContext } from '../utils';
 
 export default function SendCcd() {
-    const exchangeRate = useAsyncMemo(getEnergyPerCCD, noOp, []);
     const [cost, setCost] = useState(0n);
     const { setDetailsExpanded } = useContext(accountPageContext);
 
@@ -25,14 +22,7 @@ export default function SendCcd() {
             />
             <Route
                 index
-                element={
-                    <CreateTransfer
-                        exchangeRate={exchangeRate}
-                        setCost={setCost}
-                        cost={cost}
-                        setDetailsExpanded={setDetailsExpanded}
-                    />
-                }
+                element={<CreateTransfer setCost={setCost} cost={cost} setDetailsExpanded={setDetailsExpanded} />}
             />
         </Routes>
     );

--- a/packages/browser-wallet/src/popup/pages/AddAccount/Confirm.tsx
+++ b/packages/browser-wallet/src/popup/pages/AddAccount/Confirm.tsx
@@ -5,7 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import IdCard from '@popup/shared/IdCard';
 import { identityProvidersAtom, selectedIdentityAtom } from '@popup/store/identity';
 import { credentialsAtom, creatingCredentialRequestAtom } from '@popup/store/account';
-import { jsonRpcClientAtom, networkConfigurationAtom } from '@popup/store/settings';
+import { grpcClientAtom, networkConfigurationAtom } from '@popup/store/settings';
 import { CreationStatus, WalletCredential } from '@shared/storage/types';
 import Button from '@popup/shared/Button';
 import ArrowIcon from '@assets/svg/arrow.svg';
@@ -28,7 +28,7 @@ export default function Confirm() {
     const selectedIdentity = useAtomValue(selectedIdentityAtom);
     const credentials = useAtomValue(credentialsAtom);
     const network = useAtomValue(networkConfigurationAtom);
-    const client = useAtomValue(jsonRpcClientAtom);
+    const client = useAtomValue(grpcClientAtom);
     const providers = useAtomValue(identityProvidersAtom);
     const addToast = useSetAtom(addToastAtom);
     const seedPhrase = useDecryptedSeedPhrase((e) => addToast(e.message));

--- a/packages/browser-wallet/src/popup/pages/AddAccount/Confirm.tsx
+++ b/packages/browser-wallet/src/popup/pages/AddAccount/Confirm.tsx
@@ -58,8 +58,6 @@ export default function Confirm() {
             const global = await getGlobal(client);
 
             // Make request
-            const expiry = Math.floor(Date.now() / 1000) + 720;
-
             const credsOfCurrentIdentity = credentials.filter(isIdentityOfCredential(selectedIdentity));
             const credNumber = getNextEmptyCredNumber(credsOfCurrentIdentity);
 
@@ -75,7 +73,6 @@ export default function Confirm() {
                     revealedAttributes: [],
                     identityIndex: selectedIdentity.index,
                     credNumber,
-                    expiry,
                 }
             );
             if (response.status === BackgroundResponseStatus.Success) {

--- a/packages/browser-wallet/src/popup/pages/ExternalAddTokens/ExternalAddTokens.tsx
+++ b/packages/browser-wallet/src/popup/pages/ExternalAddTokens/ExternalAddTokens.tsx
@@ -10,7 +10,7 @@ import { currentAccountTokensAtom } from '@popup/store/token';
 import { useAsyncMemo } from 'wallet-common-helpers';
 import { TokenIdAndMetadata } from '@shared/storage/types';
 import { ContractTokenDetails, fetchContractName, getTokens } from '@shared/utils/token-helpers';
-import { jsonRpcClientAtom } from '@popup/store/settings';
+import { grpcClientAtom } from '@popup/store/settings';
 import { selectedAccountAtom } from '@popup/store/account';
 import { fullscreenPromptContext } from '@popup/page-layouts/FullscreenPromptLayout';
 import { Input as UncontrolledInput } from '@popup/shared/Form/Input';
@@ -44,7 +44,7 @@ export default function SignMessage({ respond }: Props) {
     const { withClose, onClose } = useContext(fullscreenPromptContext);
     const { contractIndex, contractSubindex, tokenIds, url } = state.payload;
     const addToast = useSetAtom(addToastAtom);
-    const client = useAtomValue(jsonRpcClientAtom);
+    const client = useAtomValue(grpcClientAtom);
     const account = useAtomValue(selectedAccountAtom);
     const [accountTokens, setAccountTokens] = useAtom(currentAccountTokensAtom);
     const [addingTokens, setAddingTokens] = useState<TokenWithChoice[]>();

--- a/packages/browser-wallet/src/popup/pages/IdProofRequest/IdProofRequest.tsx
+++ b/packages/browser-wallet/src/popup/pages/IdProofRequest/IdProofRequest.tsx
@@ -8,7 +8,7 @@ import { InternalMessageType } from '@concordium/browser-wallet-message-hub';
 import { popupMessageHandler } from '@popup/shared/message-handler';
 import { identityByAddressAtomFamily } from '@popup/store/identity';
 import { useCredential } from '@popup/shared/utils/account-helpers';
-import { jsonRpcClientAtom, networkConfigurationAtom } from '@popup/store/settings';
+import { grpcClientAtom, networkConfigurationAtom } from '@popup/store/settings';
 import { addToastAtom } from '@popup/state';
 import { useDecryptedSeedPhrase } from '@popup/shared/utils/seed-phrase-helpers';
 import { getGlobal, getNet } from '@shared/utils/network-helpers';
@@ -46,7 +46,7 @@ export default function IdProofRequest({ onReject, onSubmit }: Props) {
     const { loading: identityLoading, value: identity } = useAtomValue(identityByAddressAtomFamily(account));
     const credential = useCredential(account);
     const network = useAtomValue(networkConfigurationAtom);
-    const client = useAtomValue(jsonRpcClientAtom);
+    const client = useAtomValue(grpcClientAtom);
     const addToast = useSetAtom(addToastAtom);
     const recoveryPhrase = useDecryptedSeedPhrase((e) => addToast(e.message));
     const dappName = displayUrl(url);

--- a/packages/browser-wallet/src/popup/pages/IdentityIssuance/IdentityIssuanceStart.tsx
+++ b/packages/browser-wallet/src/popup/pages/IdentityIssuance/IdentityIssuanceStart.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useAtomValue, useAtom, useSetAtom } from 'jotai';
 import { useTranslation } from 'react-i18next';
-import { jsonRpcClientAtom, networkConfigurationAtom } from '@popup/store/settings';
+import { grpcClientAtom, networkConfigurationAtom } from '@popup/store/settings';
 import { pendingIdentityAtom, identitiesAtom, identityProvidersAtom } from '@popup/store/identity';
 import { popupMessageHandler } from '@popup/shared/message-handler';
 import { getIdentityProviders } from '@popup/shared/utils/wallet-proxy';
@@ -23,7 +23,7 @@ function IdentityIssuanceStart({ onStart, onError }: InnerProps) {
     const { t } = useTranslation('identityIssuance');
     const [providers, setProviders] = useAtom(identityProvidersAtom);
     const network = useAtomValue(networkConfigurationAtom);
-    const client = useAtomValue(jsonRpcClientAtom);
+    const client = useAtomValue(grpcClientAtom);
     const updatePendingIdentity = useSetAtom(pendingIdentityAtom);
     const identities = useAtomValue(identitiesAtom);
     const [buttonDisabled, setButtonDisabled] = useState(false);

--- a/packages/browser-wallet/src/popup/pages/Recovery/RecoveryMain.tsx
+++ b/packages/browser-wallet/src/popup/pages/Recovery/RecoveryMain.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { useTranslation } from 'react-i18next';
-import { jsonRpcClientAtom, networkConfigurationAtom } from '@popup/store/settings';
+import { grpcClientAtom, networkConfigurationAtom } from '@popup/store/settings';
 import { identityProvidersAtom, isRecoveringAtom, setRecoveryPayloadAtom } from '@popup/store/identity';
 import PendingArrows from '@assets/svg/pending-arrows.svg';
 import { BackgroundResponseStatus } from '@shared/utils/types';
@@ -14,7 +14,7 @@ import { absoluteRoutes } from '@popup/constants/routes';
 export default function RecoveryMain() {
     const { t } = useTranslation('recovery');
     const network = useAtomValue(networkConfigurationAtom);
-    const client = useAtomValue(jsonRpcClientAtom);
+    const client = useAtomValue(grpcClientAtom);
     const [providers, setProviders] = useAtom(identityProvidersAtom);
     const [isRecovering, setIsRecovering] = useAtom(isRecoveringAtom);
     const setRecoveryStatus = useSetAtom(setRecoveryPayloadAtom);

--- a/packages/browser-wallet/src/popup/pages/SendTransaction/SendTransaction.tsx
+++ b/packages/browser-wallet/src/popup/pages/SendTransaction/SendTransaction.tsx
@@ -10,7 +10,7 @@ import {
     getDefaultExpiry,
     createPendingTransactionFromAccountTransaction,
 } from '@popup/shared/utils/transaction-helpers';
-import { jsonRpcClientAtom } from '@popup/store/settings';
+import { grpcClientAtom } from '@popup/store/settings';
 import TransactionReceipt from '@popup/shared/TransactionReceipt/TransactionReceipt';
 import Button from '@popup/shared/Button';
 import { displayUrl } from '@popup/shared/utils/string-helpers';
@@ -53,7 +53,7 @@ export default function SendTransaction({ onSubmit, onReject }: Props) {
     const { state } = useLocation() as Location;
     const { t } = useTranslation('sendTransaction');
     const addToast = useSetAtom(addToastAtom);
-    const client = useAtomValue(jsonRpcClientAtom);
+    const client = useAtomValue(grpcClientAtom);
     const { withClose, onClose } = useContext(fullscreenPromptContext);
     const addPendingTransaction = useUpdateAtom(addPendingTransactionAtom);
 

--- a/packages/browser-wallet/src/popup/shared/AccountInfoListenerContext/AccountInfoListenerContext.tsx
+++ b/packages/browser-wallet/src/popup/shared/AccountInfoListenerContext/AccountInfoListenerContext.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import i18next from 'i18next';
 import { atomFamily } from 'jotai/utils';
 import { noOp, parse, stringify } from 'wallet-common-helpers';
-import { networkConfigurationAtom, grpcClientAtom, cookieAtom } from '@popup/store/settings';
+import { networkConfigurationAtom, grpcClientAtom } from '@popup/store/settings';
 import { atomWithChromeStorage } from '@popup/store/utils';
 import { ChromeStorageKey, CreationStatus, WalletCredential } from '@shared/storage/types';
 import { addToastAtom } from '@popup/state';
@@ -69,12 +69,11 @@ interface Props {
 export default function AccountInfoListenerContextProvider({ children }: Props) {
     const network = useAtomValue(networkConfigurationAtom);
     const addToast = useSetAtom(addToastAtom);
-    const [cookie, setCookie] = useAtom(cookieAtom);
     const [accountInfoListener, setAccountInfoListener] = useState<AccountInfoListener>();
     const { t } = useTranslation();
 
     useEffect(() => {
-        const listener = new AccountInfoListener(network, setCookie, cookie);
+        const listener = new AccountInfoListener(network);
         listener.listen();
         setAccountInfoListener(listener);
         const errorListener = () => addToast(t('account.error'));

--- a/packages/browser-wallet/src/popup/shared/AccountInfoListenerContext/AccountInfoListenerContext.tsx
+++ b/packages/browser-wallet/src/popup/shared/AccountInfoListenerContext/AccountInfoListenerContext.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import i18next from 'i18next';
 import { atomFamily } from 'jotai/utils';
 import { noOp, parse, stringify } from 'wallet-common-helpers';
-import { networkConfigurationAtom, jsonRpcClientAtom, cookieAtom } from '@popup/store/settings';
+import { networkConfigurationAtom, grpcClientAtom, cookieAtom } from '@popup/store/settings';
 import { atomWithChromeStorage } from '@popup/store/utils';
 import { ChromeStorageKey, CreationStatus, WalletCredential } from '@shared/storage/types';
 import { addToastAtom } from '@popup/state';
@@ -32,7 +32,7 @@ export const accountInfoAtom = atom<Record<string, AccountInfo>, AccountInfoActi
             {}
         ),
     async (get, set, update) => {
-        const client = get(jsonRpcClientAtom);
+        const client = get(grpcClientAtom);
         const addToast = (v: string) => set(addToastAtom, v);
 
         try {

--- a/packages/browser-wallet/src/popup/shared/AccountInfoListenerContext/AccountInfoListenerContext.tsx
+++ b/packages/browser-wallet/src/popup/shared/AccountInfoListenerContext/AccountInfoListenerContext.tsx
@@ -36,11 +36,7 @@ export const accountInfoAtom = atom<Record<string, AccountInfo>, AccountInfoActi
         const addToast = (v: string) => set(addToastAtom, v);
 
         try {
-            const consensusStatus = await client.getConsensusStatus();
-            const newAccountInfo = await client.getAccountInfo(
-                new AccountAddress(update.address),
-                consensusStatus.lastFinalizedBlock
-            );
+            const newAccountInfo = await client.getAccountInfo(new AccountAddress(update.address));
 
             if (newAccountInfo) {
                 updateRecord(

--- a/packages/browser-wallet/src/popup/shared/BlockChainParametersProvider.tsx
+++ b/packages/browser-wallet/src/popup/shared/BlockChainParametersProvider.tsx
@@ -10,15 +10,19 @@ interface Props {
     children: ReactNode;
 }
 
+/**
+ * Context for enabling the useBlockChainParameters hook.
+ * Caches the parameter values to avoid unnecessary calls to the node.
+ */
 export default function BlockChainParametersContext({ children }: Props) {
-    const chainParameters = useRef<ChainParameters | undefined>(undefined);
+    const chainParameters = useRef<Promise<ChainParameters> | undefined>(undefined);
     const client = useAtomValue(grpcClientAtom);
 
-    const getBlockChainParameters = useCallback(async () => {
+    const getBlockChainParameters = useCallback(() => {
         if (chainParameters.current) {
             return chainParameters.current;
         }
-        const params = await client.getBlockChainParameters();
+        const params = client.getBlockChainParameters();
         chainParameters.current = params;
         return params;
     }, []);
@@ -30,6 +34,9 @@ export default function BlockChainParametersContext({ children }: Props) {
     );
 }
 
+/**
+ * Hook for getting the blockchain parameters.
+ */
 export function useBlockChainParameters() {
     const getBlockChainParameters = useContext(blockChainParametersContext);
     return useAsyncMemo(getBlockChainParameters, undefined, []);

--- a/packages/browser-wallet/src/popup/shared/BlockChainParametersProvider.tsx
+++ b/packages/browser-wallet/src/popup/shared/BlockChainParametersProvider.tsx
@@ -4,7 +4,7 @@ import { useAtomValue } from 'jotai';
 import React, { createContext, ReactNode, useCallback, useContext, useEffect, useRef } from 'react';
 import { useAsyncMemo } from 'wallet-common-helpers';
 
-export const blockChainParametersContext = createContext<() => Promise<ChainParameters>>(() => Promise.reject());
+const blockChainParametersContext = createContext<() => Promise<ChainParameters>>(() => Promise.reject());
 
 interface Props {
     children: ReactNode;

--- a/packages/browser-wallet/src/popup/shared/BlockChainParametersProvider.tsx
+++ b/packages/browser-wallet/src/popup/shared/BlockChainParametersProvider.tsx
@@ -1,7 +1,7 @@
 import { ChainParameters } from '@concordium/web-sdk';
-import { grpcClientAtom } from '@popup/store/settings';
+import { grpcClientAtom, networkConfigurationAtom } from '@popup/store/settings';
 import { useAtomValue } from 'jotai';
-import React, { createContext, ReactNode, useCallback, useContext, useRef } from 'react';
+import React, { createContext, ReactNode, useCallback, useContext, useEffect, useRef } from 'react';
 import { useAsyncMemo } from 'wallet-common-helpers';
 
 export const blockChainParametersContext = createContext<() => Promise<ChainParameters>>(() => Promise.reject());
@@ -16,7 +16,12 @@ interface Props {
  */
 export default function BlockChainParametersContext({ children }: Props) {
     const chainParameters = useRef<Promise<ChainParameters> | undefined>(undefined);
+    const currentNetwork = useAtomValue(networkConfigurationAtom);
     const client = useAtomValue(grpcClientAtom);
+
+    useEffect(() => {
+        chainParameters.current = undefined;
+    }, [currentNetwork.genesisHash]);
 
     const getBlockChainParameters = useCallback(() => {
         if (chainParameters.current) {
@@ -25,7 +30,7 @@ export default function BlockChainParametersContext({ children }: Props) {
         const params = client.getBlockChainParameters();
         chainParameters.current = params;
         return params;
-    }, []);
+    }, [client]);
 
     return (
         <blockChainParametersContext.Provider value={getBlockChainParameters}>

--- a/packages/browser-wallet/src/popup/shared/BlockChainParametersProvider.tsx
+++ b/packages/browser-wallet/src/popup/shared/BlockChainParametersProvider.tsx
@@ -1,0 +1,36 @@
+import { ChainParameters } from '@concordium/web-sdk';
+import { grpcClientAtom } from '@popup/store/settings';
+import { useAtomValue } from 'jotai';
+import React, { createContext, ReactNode, useCallback, useContext, useRef } from 'react';
+import { useAsyncMemo } from 'wallet-common-helpers';
+
+export const blockChainParametersContext = createContext<() => Promise<ChainParameters>>(() => Promise.reject());
+
+interface Props {
+    children: ReactNode;
+}
+
+export default function BlockChainParametersContext({ children }: Props) {
+    const chainParameters = useRef<ChainParameters | undefined>(undefined);
+    const client = useAtomValue(grpcClientAtom);
+
+    const getBlockChainParameters = useCallback(async () => {
+        if (chainParameters.current) {
+            return chainParameters.current;
+        }
+        const params = await client.getBlockChainParameters();
+        chainParameters.current = params;
+        return params;
+    }, []);
+
+    return (
+        <blockChainParametersContext.Provider value={getBlockChainParameters}>
+            {children}
+        </blockChainParametersContext.Provider>
+    );
+}
+
+export function useBlockChainParameters() {
+    const getBlockChainParameters = useContext(blockChainParametersContext);
+    return useAsyncMemo(getBlockChainParameters, undefined, []);
+}

--- a/packages/browser-wallet/src/popup/shared/account-info-listener.ts
+++ b/packages/browser-wallet/src/popup/shared/account-info-listener.ts
@@ -21,7 +21,7 @@ export class AccountInfoListener extends EventEmitter {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     constructor(network: NetworkConfiguration, _onSetCookie: (cookie: string) => void, _cookie?: string) {
         super();
-        this.client = createConcordiumClient(network.grpcUrl, network.grpcPort, GRPCTIMEOUT); // TODO cookie?
+        this.client = createConcordiumClient(network.grpcUrl, network.grpcPort, { timeout: GRPCTIMEOUT });
         this.genesisHash = network.genesisHash;
     }
 

--- a/packages/browser-wallet/src/popup/shared/account-info-listener.ts
+++ b/packages/browser-wallet/src/popup/shared/account-info-listener.ts
@@ -18,8 +18,7 @@ export class AccountInfoListener extends EventEmitter {
 
     private accountsMap: Map<string, number> = new Map();
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    constructor(network: NetworkConfiguration, _onSetCookie: (cookie: string) => void, _cookie?: string) {
+    constructor(network: NetworkConfiguration) {
         super();
         this.client = createConcordiumClient(network.grpcUrl, network.grpcPort, { timeout: GRPCTIMEOUT });
         this.genesisHash = network.genesisHash;

--- a/packages/browser-wallet/src/popup/shared/account-info-listener.ts
+++ b/packages/browser-wallet/src/popup/shared/account-info-listener.ts
@@ -1,4 +1,5 @@
-import { AccountAddress, HttpProvider, JsonRpcClient } from '@concordium/web-sdk';
+import { AccountAddress, ConcordiumGRPCClient, createConcordiumClient } from '@concordium/web-sdk';
+import { GRPCTIMEOUT } from '@shared/constants/networkConfiguration';
 import { sessionAccountInfoCache, useIndexedStorage } from '@shared/storage/access';
 import { NetworkConfiguration } from '@shared/storage/types';
 import { accountInfoCacheLock, updateRecord } from '@shared/storage/update';
@@ -9,7 +10,7 @@ import { stringify } from 'wallet-common-helpers';
 export const ACCOUNT_INFO_RETRIEVAL_INTERVAL_MS = 15000;
 
 export class AccountInfoListener extends EventEmitter {
-    private client: JsonRpcClient;
+    private client: ConcordiumGRPCClient;
 
     private genesisHash: string;
 
@@ -17,9 +18,10 @@ export class AccountInfoListener extends EventEmitter {
 
     private accountsMap: Map<string, number> = new Map();
 
-    constructor(network: NetworkConfiguration, onSetCookie: (cookie: string) => void, cookie?: string) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    constructor(network: NetworkConfiguration, _onSetCookie: (cookie: string) => void, _cookie?: string) {
         super();
-        this.client = new JsonRpcClient(new HttpProvider(network.jsonRpcUrl, undefined, onSetCookie, cookie));
+        this.client = createConcordiumClient(network.grpcUrl, network.grpcPort, GRPCTIMEOUT); // TODO cookie?
         this.genesisHash = network.genesisHash;
     }
 
@@ -47,10 +49,9 @@ export class AccountInfoListener extends EventEmitter {
         this.interval = setInterval(async () => {
             try {
                 if (this.accountsMap.size > 0) {
-                    const lfBlockHash = (await this.client.getConsensusStatus()).lastFinalizedBlock;
                     for (const accountAddress of this.accountsMap.keys()) {
                         const address = new AccountAddress(accountAddress);
-                        const accountInfo = await this.client.getAccountInfo(address, lfBlockHash);
+                        const accountInfo = await this.client.getAccountInfo(address);
                         if (accountInfo) {
                             updateRecord(
                                 accountInfoCacheLock,

--- a/packages/browser-wallet/src/popup/shared/utils/transaction-helpers.ts
+++ b/packages/browser-wallet/src/popup/shared/utils/transaction-helpers.ts
@@ -13,6 +13,7 @@ import {
 import { fractionalToInteger, isValidCcdString } from 'wallet-common-helpers';
 
 import i18n from '@popup/shell/i18n';
+import { DEFAULT_TRANSACTION_EXPIRY } from '@shared/constants/time';
 import { BrowserWalletAccountTransaction, TransactionStatus } from './transaction-history-types';
 
 export function buildSimpleTransferPayload(recipient: string, amount: bigint): SimpleTransferPayload {
@@ -72,8 +73,7 @@ export function validateAccountAddress(cand: string): string | undefined {
 }
 
 export function getDefaultExpiry(): TransactionExpiry {
-    // TODO: add better default?
-    return new TransactionExpiry(new Date(Date.now() + 3600000));
+    return new TransactionExpiry(new Date(Date.now() + DEFAULT_TRANSACTION_EXPIRY));
 }
 
 export function getTransactionTypeName(type: AccountTransactionType): string {

--- a/packages/browser-wallet/src/popup/shared/utils/transaction-helpers.ts
+++ b/packages/browser-wallet/src/popup/shared/utils/transaction-helpers.ts
@@ -5,7 +5,7 @@ import {
     buildBasicAccountSigner,
     getAccountTransactionHash,
     CcdAmount,
-    JsonRpcClient,
+    ConcordiumGRPCClient,
     signTransaction,
     SimpleTransferPayload,
     TransactionExpiry,
@@ -23,7 +23,7 @@ export function buildSimpleTransferPayload(recipient: string, amount: bigint): S
 }
 
 export async function sendTransaction(
-    client: JsonRpcClient,
+    client: ConcordiumGRPCClient,
     transaction: AccountTransaction,
     signingKey: string
 ): Promise<string> {

--- a/packages/browser-wallet/src/popup/shared/utils/wallet-proxy.ts
+++ b/packages/browser-wallet/src/popup/shared/utils/wallet-proxy.ts
@@ -262,21 +262,6 @@ export async function getIdentityProviders(): Promise<IdentityProvider[]> {
     return response.data;
 }
 
-export async function getSimpleTransferCost(): Promise<bigint> {
-    const proxyPath = `/v0/transactionCost?type=simpleTransfer`;
-    const response = await (await getWalletProxy()).get(proxyPath);
-    return BigInt(response.data.cost);
-}
-
-// TODO: get from node directly
-export async function getEnergyPerCCD(): Promise<number> {
-    const proxyPath = `/v0/transactionCost?type=simpleTransfer`;
-    const response = await (await getWalletProxy()).get(proxyPath);
-    const ccdPrice = Number(response.data.cost);
-    const nrgPrice = Number(response.data.energy);
-    return ccdPrice / nrgPrice;
-}
-
 export async function getCcdDrop(accountAddress: string): Promise<BrowserWalletAccountTransaction> {
     const response = await (await getWalletProxy()).put(`/v0/testnetGTUDrop/${accountAddress}`);
 

--- a/packages/browser-wallet/src/popup/shell/Root.tsx
+++ b/packages/browser-wallet/src/popup/shell/Root.tsx
@@ -10,6 +10,8 @@ import { isSpawnedWindow } from '@popup/shared/window-helpers';
 import { networkConfigurationAtom, themeAtom } from '@popup/store/settings';
 import { Theme as ThemeType } from '@shared/storage/types';
 import { absoluteRoutes } from '@popup/constants/routes';
+import BlockChainParametersContext from '@popup/shared/BlockChainParametersProvider';
+import AccountInfoListenerContext from '@popup/shared/AccountInfoListenerContext';
 
 import './i18n';
 
@@ -85,7 +87,11 @@ export default function Root() {
             <MemoryRouter initialEntries={[absoluteRoutes.home.account.path]}>
                 <Network>
                     <Theme>
-                        <Routes />
+                        <AccountInfoListenerContext>
+                            <BlockChainParametersContext>
+                                <Routes />
+                            </BlockChainParametersContext>
+                        </AccountInfoListenerContext>
                     </Theme>
                 </Network>
             </MemoryRouter>

--- a/packages/browser-wallet/src/popup/store/settings.ts
+++ b/packages/browser-wallet/src/popup/store/settings.ts
@@ -56,7 +56,7 @@ export const jsonRpcClientAtom = atom<JsonRpcClient>((get) => {
 export const grpcClientAtom = atom<ConcordiumGRPCClient>((get) => {
     const network = get(storedNetworkConfigurationAtom);
 
-    return createConcordiumClient(network.grpcUrl, network.grpcPort, GRPCTIMEOUT); // TODO cookies?
+    return createConcordiumClient(network.grpcUrl, network.grpcPort, { timeout: GRPCTIMEOUT });
 });
 
 export const acceptedTermsAtom = atomWithChromeStorage<AcceptedTermsState | undefined>(

--- a/packages/browser-wallet/src/popup/store/settings.ts
+++ b/packages/browser-wallet/src/popup/store/settings.ts
@@ -8,9 +8,9 @@ import {
 import { atom } from 'jotai';
 import { EventType } from '@concordium/browser-wallet-api-helpers';
 import { popupMessageHandler } from '@popup/shared/message-handler';
-import { HttpProvider, JsonRpcClient } from '@concordium/web-sdk';
+import { HttpProvider, JsonRpcClient, ConcordiumGRPCClient, createConcordiumClient } from '@concordium/web-sdk';
 import { sessionCookie, storedCredentials } from '@shared/storage/access';
-import { mainnet } from '@shared/constants/networkConfiguration';
+import { GRPCTIMEOUT, mainnet } from '@shared/constants/networkConfiguration';
 import { atomWithChromeStorage } from './utils';
 import { selectedAccountAtom } from './account';
 import { selectedIdentityIndexAtom } from './identity';
@@ -51,6 +51,12 @@ export const jsonRpcClientAtom = atom<JsonRpcClient>((get) => {
             cookie
         )
     );
+});
+
+export const grpcClientAtom = atom<ConcordiumGRPCClient>((get) => {
+    const network = get(storedNetworkConfigurationAtom);
+
+    return createConcordiumClient(network.grpcUrl, network.grpcPort, GRPCTIMEOUT); // TODO cookies?
 });
 
 export const acceptedTermsAtom = atomWithChromeStorage<AcceptedTermsState | undefined>(

--- a/packages/browser-wallet/src/popup/store/settings.ts
+++ b/packages/browser-wallet/src/popup/store/settings.ts
@@ -39,7 +39,7 @@ export const networkConfigurationAtom = atom<NetworkConfiguration, NetworkConfig
     }
 );
 
-export const cookieAtom = atomWithChromeStorage<string | undefined>(ChromeStorageKey.Cookie, undefined);
+const cookieAtom = atomWithChromeStorage<string | undefined>(ChromeStorageKey.Cookie, undefined);
 export const jsonRpcClientAtom = atom<JsonRpcClient>((get) => {
     const network = get(storedNetworkConfigurationAtom);
     const cookie = get(cookieAtom);

--- a/packages/browser-wallet/src/popup/store/token.ts
+++ b/packages/browser-wallet/src/popup/store/token.ts
@@ -6,7 +6,7 @@ import { ChromeStorageKey, TokenIdAndMetadata, TokenMetadata, TokenStorage } fro
 import { ContractBalances, getContractBalances } from '@shared/utils/token-helpers';
 import { addToastAtom } from '@popup/state';
 import { AsyncWrapper, atomWithChromeStorage } from './utils';
-import { jsonRpcClientAtom } from './settings';
+import { grpcClientAtom } from './settings';
 import { selectedAccountAtom } from './account';
 
 export const storedTokensAtom = atomWithChromeStorage<Record<string, Record<string, TokenStorage[]>>>(
@@ -122,7 +122,7 @@ const cbf = atomFamily<string, Atom<ContractBalances>>((identifier: string) => {
     const derivedAtom = atom<ContractBalances, void, Promise<void>>(
         (get) => get(baseAtom),
         async (get, set) => {
-            const client = get(jsonRpcClientAtom);
+            const client = get(grpcClientAtom);
             const tokens = get(accountTokensFamily(accountAddress));
 
             const tokenIds = tokens.value[contractIndex]?.map((t) => t.id) ?? [];

--- a/packages/browser-wallet/src/shared/constants/networkConfiguration.ts
+++ b/packages/browser-wallet/src/shared/constants/networkConfiguration.ts
@@ -6,7 +6,7 @@ export const mainnet: NetworkConfiguration = {
     jsonRpcUrl: 'https://json-rpc.mainnet.concordium.software/',
     explorerUrl: 'https://wallet-proxy.mainnet.concordium.software',
     grpcPort: 20000,
-    grpcUrl: 'https://grpc.mainnet.concordium.com',
+    grpcUrl: 'https://grpc.mainnet.concordium.software',
 };
 
 export const testnet: NetworkConfiguration = {

--- a/packages/browser-wallet/src/shared/constants/networkConfiguration.ts
+++ b/packages/browser-wallet/src/shared/constants/networkConfiguration.ts
@@ -5,6 +5,8 @@ export const mainnet: NetworkConfiguration = {
     name: 'Concordium Mainnet',
     jsonRpcUrl: 'https://json-rpc.mainnet.concordium.software/',
     explorerUrl: 'https://wallet-proxy.mainnet.concordium.software',
+    grpcPort: 20000,
+    grpcUrl: 'concordiumwalletnode.com',
 };
 
 export const testnet: NetworkConfiguration = {
@@ -12,4 +14,8 @@ export const testnet: NetworkConfiguration = {
     name: 'Concordium Testnet',
     jsonRpcUrl: 'https://json-rpc.testnet.concordium.com/',
     explorerUrl: 'https://wallet-proxy.testnet.concordium.com',
+    grpcPort: 20000,
+    grpcUrl: 'service.internal.testnet.concordium.com',
 };
+
+export const GRPCTIMEOUT = 15000;

--- a/packages/browser-wallet/src/shared/constants/networkConfiguration.ts
+++ b/packages/browser-wallet/src/shared/constants/networkConfiguration.ts
@@ -6,7 +6,7 @@ export const mainnet: NetworkConfiguration = {
     jsonRpcUrl: 'https://json-rpc.mainnet.concordium.software/',
     explorerUrl: 'https://wallet-proxy.mainnet.concordium.software',
     grpcPort: 20000,
-    grpcUrl: 'concordiumwalletnode.com',
+    grpcUrl: 'https://grpc.mainnet.concordium.com',
 };
 
 export const testnet: NetworkConfiguration = {
@@ -15,7 +15,7 @@ export const testnet: NetworkConfiguration = {
     jsonRpcUrl: 'https://json-rpc.testnet.concordium.com/',
     explorerUrl: 'https://wallet-proxy.testnet.concordium.com',
     grpcPort: 20000,
-    grpcUrl: 'service.internal.testnet.concordium.com',
+    grpcUrl: 'https://grpc.testnet.concordium.com',
 };
 
 export const GRPCTIMEOUT = 15000;

--- a/packages/browser-wallet/src/shared/constants/time.ts
+++ b/packages/browser-wallet/src/shared/constants/time.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_TRANSACTION_EXPIRY = 3600000; // milliSeconds

--- a/packages/browser-wallet/src/shared/storage/types.ts
+++ b/packages/browser-wallet/src/shared/storage/types.ts
@@ -166,6 +166,8 @@ export interface EncryptedData {
 }
 
 export interface NetworkConfiguration {
+    grpcUrl: string;
+    grpcPort: number;
     genesisHash: string;
     name: string;
     jsonRpcUrl: string;

--- a/packages/browser-wallet/src/shared/utils/energy-helpers.ts
+++ b/packages/browser-wallet/src/shared/utils/energy-helpers.ts
@@ -15,11 +15,6 @@ export function determineUpdatePayloadSize(parameterSize: number, receiveName: s
     return 8n + 8n + 8n + 2n + BigInt(parameterSize) + 2n + BigInt(receiveName.length);
 }
 
-// TODO: replace this with helpers from SDK
-export function determineInitPayloadSize(parameterSize: number, contractName: string) {
-    return 8n + 64n + 2n + BigInt(parameterSize) + 2n + BigInt(contractName.length + 5);
-}
-
 /**
  * Given a transaction type and the payload of that transaction type, return the corresponding energy cost.
  */

--- a/packages/browser-wallet/src/shared/utils/energy-helpers.ts
+++ b/packages/browser-wallet/src/shared/utils/energy-helpers.ts
@@ -1,3 +1,13 @@
+import {
+    AccountTransactionPayload,
+    AccountTransactionType,
+    calculateEnergyCost,
+    ChainParameters,
+    getAccountTransactionHandler,
+    Ratio,
+} from '@concordium/web-sdk';
+import { collapseRatio, multiplyFraction } from './number-helpers';
+
 export const SIMPLE_TRANSFER_ENERGY_TOTAL_COST = 501n;
 
 // TODO: replace this with helpers from SDK
@@ -8,4 +18,24 @@ export function determineUpdatePayloadSize(parameterSize: number, receiveName: s
 // TODO: replace this with helpers from SDK
 export function determineInitPayloadSize(parameterSize: number, contractName: string) {
     return 8n + 64n + 2n + BigInt(parameterSize) + 2n + BigInt(contractName.length + 5);
+}
+
+export function getEnergyCost(transactionType: AccountTransactionType, payload: AccountTransactionPayload): bigint {
+    const handler = getAccountTransactionHandler(transactionType);
+    const size = handler.serialize(payload).length;
+    return calculateEnergyCost(1n, BigInt(size), handler.getBaseEnergyCost(payload));
+}
+
+export function getExchangeRate({ euroPerEnergy, microGTUPerEuro }: ChainParameters): Ratio {
+    const denominator = BigInt(euroPerEnergy.denominator * microGTUPerEuro.denominator);
+    const numerator = BigInt(euroPerEnergy.numerator * microGTUPerEuro.numerator);
+    return { numerator, denominator };
+}
+
+/**
+ * Given an NRG amount and the current blockchain parameters, this returns the corresponding amount in microCcd.
+ */
+export function convertEnergyToMicroCcd(cost: bigint, chainParameters: ChainParameters): bigint {
+    const rate = getExchangeRate(chainParameters);
+    return collapseRatio(multiplyFraction(rate, cost));
 }

--- a/packages/browser-wallet/src/shared/utils/energy-helpers.ts
+++ b/packages/browser-wallet/src/shared/utils/energy-helpers.ts
@@ -6,7 +6,7 @@ import {
     getAccountTransactionHandler,
     Ratio,
 } from '@concordium/web-sdk';
-import { collapseRatio, multiplyFraction } from './number-helpers';
+import { collapseRatio, multiplyRatio } from './number-helpers';
 
 export const SIMPLE_TRANSFER_ENERGY_TOTAL_COST = 501n;
 
@@ -20,12 +20,19 @@ export function determineInitPayloadSize(parameterSize: number, contractName: st
     return 8n + 64n + 2n + BigInt(parameterSize) + 2n + BigInt(contractName.length + 5);
 }
 
+/**
+ * Given a transaction type and the payload of that transaction type, return the corresponding energy cost.
+ */
 export function getEnergyCost(transactionType: AccountTransactionType, payload: AccountTransactionPayload): bigint {
     const handler = getAccountTransactionHandler(transactionType);
     const size = handler.serialize(payload).length;
     return calculateEnergyCost(1n, BigInt(size), handler.getBaseEnergyCost(payload));
 }
 
+/**
+ * Given the current blockchain parameters, return the microCCD per NRG exchange rate of the chain.
+ * @returns the microCCD per NRG exchange rate as a ratio.
+ */
 export function getExchangeRate({ euroPerEnergy, microGTUPerEuro }: ChainParameters): Ratio {
     const denominator = BigInt(euroPerEnergy.denominator * microGTUPerEuro.denominator);
     const numerator = BigInt(euroPerEnergy.numerator * microGTUPerEuro.numerator);
@@ -37,5 +44,5 @@ export function getExchangeRate({ euroPerEnergy, microGTUPerEuro }: ChainParamet
  */
 export function convertEnergyToMicroCcd(cost: bigint, chainParameters: ChainParameters): bigint {
     const rate = getExchangeRate(chainParameters);
-    return collapseRatio(multiplyFraction(rate, cost));
+    return collapseRatio(multiplyRatio(rate, cost));
 }

--- a/packages/browser-wallet/src/shared/utils/energy-helpers.ts
+++ b/packages/browser-wallet/src/shared/utils/energy-helpers.ts
@@ -15,6 +15,7 @@ export function determineUpdatePayloadSize(parameterSize: number, receiveName: s
     return 8n + 8n + 8n + 2n + BigInt(parameterSize) + 2n + BigInt(receiveName.length);
 }
 
+// TODO: Replace this with helpers from SDK
 /**
  * Given a transaction type and the payload of that transaction type, return the corresponding energy cost.
  */
@@ -24,6 +25,7 @@ export function getEnergyCost(transactionType: AccountTransactionType, payload: 
     return calculateEnergyCost(1n, BigInt(size), handler.getBaseEnergyCost(payload));
 }
 
+// TODO: Replace this with helpers from SDK
 /**
  * Given the current blockchain parameters, return the microCCD per NRG exchange rate of the chain.
  * @returns the microCCD per NRG exchange rate as a ratio.
@@ -34,6 +36,7 @@ export function getExchangeRate({ euroPerEnergy, microGTUPerEuro }: ChainParamet
     return { numerator, denominator };
 }
 
+// TODO: Replace this with helpers from SDK
 /**
  * Given an NRG amount and the current blockchain parameters, this returns the corresponding amount in microCcd.
  */

--- a/packages/browser-wallet/src/shared/utils/network-helpers.ts
+++ b/packages/browser-wallet/src/shared/utils/network-helpers.ts
@@ -1,4 +1,4 @@
-import { Network, JsonRpcClient, CryptographicParameters } from '@concordium/web-sdk';
+import { Network, CryptographicParameters, ConcordiumGRPCClient } from '@concordium/web-sdk';
 import { NetworkConfiguration } from '@shared/storage/types';
 import { mainnet } from '@shared/constants/networkConfiguration';
 
@@ -10,12 +10,12 @@ export function getNet(network: NetworkConfiguration): Network {
     return isMainnet(network) ? 'Mainnet' : 'Testnet';
 }
 
-export async function getGlobal(client: JsonRpcClient): Promise<CryptographicParameters> {
+export async function getGlobal(client: ConcordiumGRPCClient): Promise<CryptographicParameters> {
     const global = await client.getCryptographicParameters();
     if (!global) {
         throw new Error('no global fetched');
     }
-    return global.value;
+    return global;
 }
 
 /**

--- a/packages/browser-wallet/src/shared/utils/number-helpers.ts
+++ b/packages/browser-wallet/src/shared/utils/number-helpers.ts
@@ -1,3 +1,5 @@
+import { Ratio } from '@concordium/web-sdk';
+
 /**
  * Given a list of numbers return the smallest unused non-negative integer.
  */
@@ -17,4 +19,23 @@ export function getNextUnused(used: number[]) {
     }
     // Use the next credNumber
     return sorted[i] + 1;
+}
+
+/**
+ * Collapses the Fraction into a single number.
+ * If the denominator does not divide the numerator, the function rounds up;
+ */
+export function collapseRatio({ numerator, denominator }: Ratio): bigint {
+    const quotient = numerator / denominator;
+    if (numerator % denominator === 0n) {
+        return quotient;
+    }
+    return 1n + quotient;
+}
+
+export function multiplyFraction({ numerator, denominator }: Ratio, factor: bigint | string): Ratio {
+    return {
+        numerator: numerator * BigInt(factor),
+        denominator,
+    };
 }

--- a/packages/browser-wallet/src/shared/utils/number-helpers.ts
+++ b/packages/browser-wallet/src/shared/utils/number-helpers.ts
@@ -33,7 +33,12 @@ export function collapseRatio({ numerator, denominator }: Ratio): bigint {
     return 1n + quotient;
 }
 
-export function multiplyFraction({ numerator, denominator }: Ratio, factor: bigint | string): Ratio {
+/**
+ * Multiply a ratio with a bigint.
+ * @param factor a number which should be multiplied with the ratio. If given a string, it will attempt to parse it to a bigint.
+ * @returns the product as a ratio.
+ */
+export function multiplyRatio({ numerator, denominator }: Ratio, factor: bigint | string): Ratio {
     return {
         numerator: numerator * BigInt(factor),
         denominator,

--- a/packages/browser-wallet/src/shared/utils/token-helpers.ts
+++ b/packages/browser-wallet/src/shared/utils/token-helpers.ts
@@ -4,7 +4,7 @@ import {
     AccountAddress,
     CcdAmount,
     InstanceInfo,
-    JsonRpcClient,
+    ConcordiumGRPCClient,
     serializeUpdateContractParameters,
     UpdateContractPayload,
     sha256,
@@ -95,7 +95,7 @@ function deserializeTokenMetadataReturnValue(returnValue: string): MetadataUrl[]
  * Confirms that the given smart contract instance is CIS-2 compliant
  */
 export async function confirmCIS2Contract(
-    client: JsonRpcClient,
+    client: ConcordiumGRPCClient,
     { contractName, index, subindex }: ContractDetails
 ): Promise<string | undefined> {
     const supports = await client.invokeContract({
@@ -121,7 +121,7 @@ export async function confirmCIS2Contract(
  * Determines the metadata url for the given token.
  */
 export function getTokenUrl(
-    client: JsonRpcClient,
+    client: ConcordiumGRPCClient,
     ids: string[],
     { contractName, index, subindex }: ContractDetails
 ): Promise<MetadataUrl[]> {
@@ -239,7 +239,7 @@ const deserializeBalanceAmounts = (value: string): bigint[] => {
 export type ContractBalances = Record<string, bigint | undefined>;
 
 export const getContractBalances = async (
-    client: JsonRpcClient,
+    client: ConcordiumGRPCClient,
     index: bigint,
     subindex: bigint,
     tokenIds: string[],
@@ -324,7 +324,7 @@ export function getTokenTransferPayload(
 }
 
 async function getTokenTransferExecutionEnergyEstimate(
-    client: JsonRpcClient,
+    client: ConcordiumGRPCClient,
     parameter: Buffer,
     invoker: AccountAddress,
     contractName: string,
@@ -349,7 +349,7 @@ function getContractName(instanceInfo: InstanceInfo): string | undefined {
     return instanceInfo.name.substring(5);
 }
 
-export async function fetchContractName(client: JsonRpcClient, index: bigint, subindex = 0n) {
+export async function fetchContractName(client: ConcordiumGRPCClient, index: bigint, subindex = 0n) {
     const instanceInfo = await client.getInstanceInfo({ index, subindex });
     if (!instanceInfo) {
         return undefined;
@@ -367,7 +367,7 @@ export function calculateEnergyCost(
 }
 
 export async function getTokenTransferEnergy(
-    client: JsonRpcClient,
+    client: ConcordiumGRPCClient,
     address: string,
     recipient: string,
     tokenId: string,
@@ -400,7 +400,7 @@ type GetTokensResult = {
 
 export async function getTokens(
     contractDetails: ContractDetails,
-    client: JsonRpcClient,
+    client: ConcordiumGRPCClient,
     account: string,
     ids: string[],
     onError?: (error: string) => void

--- a/yarn.lock
+++ b/yarn.lock
@@ -1900,7 +1900,7 @@ __metadata:
     "@babel/plugin-transform-modules-commonjs": ^7.12.1
     "@babel/plugin-transform-runtime": ^7.12.1
     "@babel/preset-env": ^7.12.1
-    "@concordium/web-sdk": ^3.2.0
+    "@concordium/web-sdk": ^3.3.1
     typescript: ^4.3.5
     webpack: ^5.72.0
     webpack-cli: ^4.9.2
@@ -1912,7 +1912,7 @@ __metadata:
   resolution: "@concordium/browser-wallet-api@workspace:packages/browser-wallet-api"
   dependencies:
     "@concordium/browser-wallet-api-helpers": "workspace:^"
-    "@concordium/common-sdk": ^6.2.0
+    "@concordium/common-sdk": ^6.3.0
     "@protobuf-ts/grpcweb-transport": ^2.8.2
     "@protobuf-ts/runtime-rpc": ^2.8.2
     "@types/json-bigint": ^1.0.1
@@ -1940,7 +1940,7 @@ __metadata:
     "@babel/core": ^7.18.2
     "@concordium/browser-wallet-api": "workspace:^"
     "@concordium/browser-wallet-api-helpers": "workspace:^"
-    "@concordium/web-sdk": ^3.2.0
+    "@concordium/web-sdk": ^3.3.1
     "@craftamap/esbuild-plugin-html": ^0.4.0
     "@mdx-js/react": ^1.6.22
     "@scure/bip39": ^1.1.0
@@ -2000,33 +2000,18 @@ __metadata:
     tsconfig-paths-webpack-plugin: ^3.5.2
     typescript: ^4.3.5
     uuid: ^8.3.2
-    wallet-common-helpers: "https://github.com/Concordium/concordium-wallet-common-helpers.git#cde2bfb682cae08c9f0338d4a0567abecaeb2a26"
+    wallet-common-helpers: "https://github.com/Concordium/concordium-wallet-common-helpers.git#280339fa6c51922944094bc631d097d245e1e08f"
   languageName: unknown
   linkType: soft
 
-"@concordium/common-sdk@npm:6.0.0":
-  version: 6.0.0
-  resolution: "@concordium/common-sdk@npm:6.0.0"
+"@concordium/common-sdk@npm:6.3.0, @concordium/common-sdk@npm:^6.3.0":
+  version: 6.3.0
+  resolution: "@concordium/common-sdk@npm:6.3.0"
   dependencies:
-    "@concordium/rust-bindings": 0.7.0
+    "@concordium/rust-bindings": 0.10.0
+    "@grpc/grpc-js": ^1.3.4
     "@noble/ed25519": ^1.7.1
-    "@scure/bip39": ^1.1.0
-    bs58check: ^2.1.2
-    buffer: ^6.0.3
-    cross-fetch: 3.1.5
-    hash.js: ^1.1.7
-    json-bigint: ^1.0.0
-    uuid: ^8.3.2
-  checksum: 7d3d02d7713e6f4673994cb7ef1ba0cce5ab8d06ed86454b0f684fc53c69326e2aa89c0755aba3ef4289e7f2bf438752fa9697eeb70e680af78e0b1999eace20
-  languageName: node
-  linkType: hard
-
-"@concordium/common-sdk@npm:6.2.0, @concordium/common-sdk@npm:^6.2.0":
-  version: 6.2.0
-  resolution: "@concordium/common-sdk@npm:6.2.0"
-  dependencies:
-    "@concordium/rust-bindings": 0.9.0
-    "@noble/ed25519": ^1.7.1
+    "@protobuf-ts/runtime-rpc": ^2.8.2
     "@scure/bip39": ^1.1.0
     bs58check: ^2.1.2
     buffer: ^6.0.3
@@ -2035,7 +2020,7 @@ __metadata:
     iso-3166-1: ^2.1.1
     json-bigint: ^1.0.0
     uuid: ^8.3.2
-  checksum: be2b3b10d05349dd0df1ab78e19addd9da8b2e0bfaa482beaaa54eafab8e656c9cc393cd2f52eaba7aa4c53d21b48332ef6fa4625acb411111cfb59a5c515832
+  checksum: 6ce6e130bce8f3011b00a37e7429a5e19d4b21c21918e3ba8fb0438af841ec9a78d9de5eb9aa277d42154d6784dd182aed9198f92826b3b124fc59dbf5d30078
   languageName: node
   linkType: hard
 
@@ -2050,17 +2035,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@concordium/rust-bindings@npm:0.7.0":
-  version: 0.7.0
-  resolution: "@concordium/rust-bindings@npm:0.7.0"
-  checksum: b9d7bc1557673f276e002b1bcd6651e77262f496a641ff4ba16eceb0d637df631c2b73ea5de412c42d3ae4c92325f71e9030352bf1cbb7c4412a14f93d2b358d
-  languageName: node
-  linkType: hard
-
-"@concordium/rust-bindings@npm:0.9.0":
-  version: 0.9.0
-  resolution: "@concordium/rust-bindings@npm:0.9.0"
-  checksum: d69b264819a718e7073961a1c68da6a766e2360cfb7ea3b988cf7e854f79a3cda4fda70ceed2e4651ed1af127bc817a345f6d7397d648278930eb95f6309626a
+"@concordium/rust-bindings@npm:0.10.0":
+  version: 0.10.0
+  resolution: "@concordium/rust-bindings@npm:0.10.0"
+  checksum: f09c754080fe7e026308342e0139e18de72e68ced8228d80c34d873c065a93e2774015da33ee3f970f33f97916526a43f54a410e42451137cffa3ccbe7e660a3
   languageName: node
   linkType: hard
 
@@ -2075,27 +2053,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@concordium/web-sdk@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@concordium/web-sdk@npm:3.0.0"
+"@concordium/web-sdk@npm:^3.3.1":
+  version: 3.3.1
+  resolution: "@concordium/web-sdk@npm:3.3.1"
   dependencies:
-    "@concordium/common-sdk": 6.0.0
-    "@concordium/rust-bindings": 0.7.0
+    "@concordium/common-sdk": 6.3.0
+    "@concordium/rust-bindings": 0.10.0
+    "@grpc/grpc-js": ^1.3.4
+    "@protobuf-ts/grpcweb-transport": ^2.8.2
     buffer: ^6.0.3
     process: ^0.11.10
-  checksum: 3495bc3d4d10a84c8209902643dd45558a3a6847e26b19948a4401b6186fa38503699e4940dfae3fa88c7e0a2cce2137aa60797d21db4aff8378d195bbfc39a8
-  languageName: node
-  linkType: hard
-
-"@concordium/web-sdk@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "@concordium/web-sdk@npm:3.2.0"
-  dependencies:
-    "@concordium/common-sdk": 6.2.0
-    "@concordium/rust-bindings": 0.9.0
-    buffer: ^6.0.3
-    process: ^0.11.10
-  checksum: e61bbfcca07e7d63035667324395d1f6bec2a7c17a0a2bab85d12b9ed3bf3203155ba9c0aa3df2fdf0c57e036d9fa1479ffa8399d7b08daf0edb4f14c9a5cb37
+  checksum: a7be99af72d605ecbb874a7098b5cea2b5bd42b51899bc9a02ef6c95c4fd184898a19ed6b4745a8ea92deea41b998e529a0e1e83ade7c290fd697e4f7dc618b6
   languageName: node
   linkType: hard
 
@@ -2240,6 +2208,31 @@ __metadata:
   version: 1.1.3
   resolution: "@gar/promisify@npm:1.1.3"
   checksum: 4059f790e2d07bf3c3ff3e0fec0daa8144fe35c1f6e0111c9921bd32106adaa97a4ab096ad7dab1e28ee6a9060083c4d1a4ada42a7f5f3f7a96b8812e2b757c1
+  languageName: node
+  linkType: hard
+
+"@grpc/grpc-js@npm:^1.3.4":
+  version: 1.8.11
+  resolution: "@grpc/grpc-js@npm:1.8.11"
+  dependencies:
+    "@grpc/proto-loader": ^0.7.0
+    "@types/node": ">=12.12.47"
+  checksum: b2ff645ac3a10f8f6ae380945dff2ef2faf2be118b3e7870efecaf2b9a601ab8a4f00d297c3e3f83665a4c5584a9948da336a9df81debb73e5172683bc674c3c
+  languageName: node
+  linkType: hard
+
+"@grpc/proto-loader@npm:^0.7.0":
+  version: 0.7.5
+  resolution: "@grpc/proto-loader@npm:0.7.5"
+  dependencies:
+    "@types/long": ^4.0.1
+    lodash.camelcase: ^4.3.0
+    long: ^4.0.0
+    protobufjs: ^7.0.0
+    yargs: ^16.2.0
+  bin:
+    proto-loader-gen-types: build/bin/proto-loader-gen-types.js
+  checksum: ca3a16fc18526a835d006802d15dcf21cb3e2a7a803a988bf34397ebeb07ae94062b3f06db3d1a9b8ec3c40bd96354ca69d9e2ac06ef4c3a74a990d9e55ca2fd
   languageName: node
   linkType: hard
 
@@ -2871,6 +2864,79 @@ __metadata:
   version: 2.8.2
   resolution: "@protobuf-ts/runtime@npm:2.8.2"
   checksum: ab322e832bfb347b271a8862b8ef3db27ffa380f9c49f94acb410534586a282ebd8af96d4459f959ad0fe5fbf34183f3f4fe512e50c9a4331b742a7445b16c92
+  languageName: node
+  linkType: hard
+
+"@protobufjs/aspromise@npm:^1.1.1, @protobufjs/aspromise@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@protobufjs/aspromise@npm:1.1.2"
+  checksum: 011fe7ef0826b0fd1a95935a033a3c0fd08483903e1aa8f8b4e0704e3233406abb9ee25350ec0c20bbecb2aad8da0dcea58b392bbd77d6690736f02c143865d2
+  languageName: node
+  linkType: hard
+
+"@protobufjs/base64@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@protobufjs/base64@npm:1.1.2"
+  checksum: 67173ac34de1e242c55da52c2f5bdc65505d82453893f9b51dc74af9fe4c065cf4a657a4538e91b0d4a1a1e0a0642215e31894c31650ff6e3831471061e1ee9e
+  languageName: node
+  linkType: hard
+
+"@protobufjs/codegen@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "@protobufjs/codegen@npm:2.0.4"
+  checksum: 59240c850b1d3d0b56d8f8098dd04787dcaec5c5bd8de186fa548de86b86076e1c50e80144b90335e705a044edf5bc8b0998548474c2a10a98c7e004a1547e4b
+  languageName: node
+  linkType: hard
+
+"@protobufjs/eventemitter@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/eventemitter@npm:1.1.0"
+  checksum: 0369163a3d226851682f855f81413cbf166cd98f131edb94a0f67f79e75342d86e89df9d7a1df08ac28be2bc77e0a7f0200526bb6c2a407abbfee1f0262d5fd7
+  languageName: node
+  linkType: hard
+
+"@protobufjs/fetch@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/fetch@npm:1.1.0"
+  dependencies:
+    "@protobufjs/aspromise": ^1.1.1
+    "@protobufjs/inquire": ^1.1.0
+  checksum: 3fce7e09eb3f1171dd55a192066450f65324fd5f7cc01a431df01bb00d0a895e6bfb5b0c5561ce157ee1d886349c90703d10a4e11a1a256418ff591b969b3477
+  languageName: node
+  linkType: hard
+
+"@protobufjs/float@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@protobufjs/float@npm:1.0.2"
+  checksum: 5781e1241270b8bd1591d324ca9e3a3128d2f768077a446187a049e36505e91bc4156ed5ac3159c3ce3d2ba3743dbc757b051b2d723eea9cd367bfd54ab29b2f
+  languageName: node
+  linkType: hard
+
+"@protobufjs/inquire@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/inquire@npm:1.1.0"
+  checksum: ca06f02eaf65ca36fb7498fc3492b7fc087bfcc85c702bac5b86fad34b692bdce4990e0ef444c1e2aea8c034227bd1f0484be02810d5d7e931c55445555646f4
+  languageName: node
+  linkType: hard
+
+"@protobufjs/path@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@protobufjs/path@npm:1.1.2"
+  checksum: 856eeb532b16a7aac071cacde5c5620df800db4c80cee6dbc56380524736205aae21e5ae47739114bf669ab5e8ba0e767a282ad894f3b5e124197cb9224445ee
+  languageName: node
+  linkType: hard
+
+"@protobufjs/pool@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/pool@npm:1.1.0"
+  checksum: d6a34fbbd24f729e2a10ee915b74e1d77d52214de626b921b2d77288bd8f2386808da2315080f2905761527cceffe7ec34c7647bd21a5ae41a25e8212ff79451
+  languageName: node
+  linkType: hard
+
+"@protobufjs/utf8@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/utf8@npm:1.1.0"
+  checksum: f9bf3163d13aaa3b6f5e6fbf37a116e094ea021c0e1f2a7ccd0e12a29e2ce08dafba4e8b36e13f8ed7397e1591610ce880ed1289af4d66cf4ace8a36a9557278
   languageName: node
   linkType: hard
 
@@ -5123,6 +5189,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/long@npm:^4.0.1":
+  version: 4.0.2
+  resolution: "@types/long@npm:4.0.2"
+  checksum: d16cde7240d834cf44ba1eaec49e78ae3180e724cd667052b194a372f350d024cba8dd3f37b0864931683dab09ca935d52f0c4c1687178af5ada9fc85b0635f4
+  languageName: node
+  linkType: hard
+
 "@types/mdast@npm:^3.0.0":
   version: 3.0.10
   resolution: "@types/mdast@npm:3.0.10"
@@ -5167,6 +5240,13 @@ __metadata:
   version: 18.0.0
   resolution: "@types/node@npm:18.0.0"
   checksum: aab2b325727a2599f6d25ebe0dedf58c40fb66a51ce4ca9c0226ceb70fcda2d3afccdca29db5942eb48b158ee8585a274a1e3750c718bbd5399d7f41d62dfdcc
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:>=12.12.47, @types/node@npm:>=13.7.0":
+  version: 18.14.2
+  resolution: "@types/node@npm:18.14.2"
+  checksum: 53c07e721f6ae33de71306f6a0b75dae6066a4f55bd5484c93bd59ff25f0c5f004ceafeef509a4d0cb9e24a247efc34d50489bcc1b05a53ecc68e2fc088e65cb
   languageName: node
   linkType: hard
 
@@ -6284,7 +6364,7 @@ __metadata:
   resolution: "NFT-Minting@workspace:examples/nft-minting"
   dependencies:
     "@concordium/browser-wallet-api-helpers": "workspace:^"
-    "@concordium/web-sdk": ^3.0.0
+    "@concordium/web-sdk": ^3.3.1
     "@craftamap/esbuild-plugin-html": ^0.4.0
     "@types/react": ^18.0.9
     "@types/react-dom": ^18.0.5
@@ -9643,7 +9723,7 @@ __metadata:
   resolution: "e_sealing@workspace:examples/eSealing"
   dependencies:
     "@concordium/react-components": ^0.2.0
-    "@concordium/web-sdk": ^3.2.0
+    "@concordium/web-sdk": ^3.3.1
     "@craftamap/esbuild-plugin-html": ^0.4.0
     "@thi.ng/leb128": ^2.1.18
     "@types/node": ^18.7.23
@@ -14530,6 +14610,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.camelcase@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "lodash.camelcase@npm:4.3.0"
+  checksum: cb9227612f71b83e42de93eccf1232feeb25e705bdb19ba26c04f91e885bfd3dd5c517c4a97137658190581d3493ea3973072ca010aab7e301046d90740393d1
+  languageName: node
+  linkType: hard
+
 "lodash.debounce@npm:^4.0.8":
   version: 4.0.8
   resolution: "lodash.debounce@npm:4.0.8"
@@ -14614,6 +14701,20 @@ __metadata:
     slice-ansi: ^4.0.0
     wrap-ansi: ^6.2.0
   checksum: ae2f85bbabc1906034154fb7d4c4477c79b3e703d22d78adee8b3862fa913942772e7fa11713e3d96fb46de4e3cabefbf5d0a544344f03b58d3c4bff52aa9eb2
+  languageName: node
+  linkType: hard
+
+"long@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "long@npm:4.0.0"
+  checksum: 16afbe8f749c7c849db1f4de4e2e6a31ac6e617cead3bdc4f9605cb703cd20e1e9fc1a7baba674ffcca57d660a6e5b53a9e236d7b25a295d3855cca79cc06744
+  languageName: node
+  linkType: hard
+
+"long@npm:^5.0.0":
+  version: 5.2.1
+  resolution: "long@npm:5.2.1"
+  checksum: 9264da12d1b7df67e5aa6da4498144293caf1ad12e7f092efe4e9a2d32c53f0bbf7334f7cef997080a2a3af061142558ab366efa71698d98b1cdb883477445a7
   languageName: node
   linkType: hard
 
@@ -16433,7 +16534,7 @@ __metadata:
   resolution: "piggybank@workspace:examples/piggybank"
   dependencies:
     "@concordium/browser-wallet-api-helpers": "workspace:^"
-    "@concordium/web-sdk": ^3.0.0
+    "@concordium/web-sdk": ^3.3.1
     "@craftamap/esbuild-plugin-html": ^0.4.0
     "@types/react": ^18.0.9
     "@types/react-dom": ^18.0.5
@@ -16995,6 +17096,26 @@ __metadata:
   dependencies:
     xtend: ^4.0.0
   checksum: fcf87c6542e59a8bbe31ca0b3255a4a63ac1059b01b04469680288998bcfa97f341ca989566adbb63975f4d85339030b82320c324a511532d390910d1c583893
+  languageName: node
+  linkType: hard
+
+"protobufjs@npm:^7.0.0":
+  version: 7.2.2
+  resolution: "protobufjs@npm:7.2.2"
+  dependencies:
+    "@protobufjs/aspromise": ^1.1.2
+    "@protobufjs/base64": ^1.1.2
+    "@protobufjs/codegen": ^2.0.4
+    "@protobufjs/eventemitter": ^1.1.0
+    "@protobufjs/fetch": ^1.1.0
+    "@protobufjs/float": ^1.0.2
+    "@protobufjs/inquire": ^1.1.0
+    "@protobufjs/path": ^1.1.2
+    "@protobufjs/pool": ^1.1.0
+    "@protobufjs/utf8": ^1.1.0
+    "@types/node": ">=13.7.0"
+    long: ^5.0.0
+  checksum: 86166e8f3e46789fa4d117ae72c17356db36bf87c0e0710d224be32e543b1c378a94e66dc2b1de5af45edfc25f56acfc7e688c50c956426a3ae97bc474f4445c
   languageName: node
   linkType: hard
 
@@ -20270,7 +20391,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "two-step-transfer@workspace:examples/two-step-transfer"
   dependencies:
-    "@concordium/web-sdk": ^3.2.0
+    "@concordium/web-sdk": ^3.3.1
     live-server: ^1.2.2
   languageName: unknown
   linkType: soft
@@ -20951,7 +21072,7 @@ __metadata:
   resolution: "voting@workspace:examples/voting"
   dependencies:
     "@concordium/browser-wallet-api-helpers": ^2.0.0
-    "@concordium/web-sdk": ^3.0.0
+    "@concordium/web-sdk": ^3.3.1
     "@types/node": ^18.7.23
     "@types/react": ^18.0.9
     "@types/react-dom": ^18.0.5
@@ -21000,11 +21121,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wallet-common-helpers@https://github.com/Concordium/concordium-wallet-common-helpers.git#cde2bfb682cae08c9f0338d4a0567abecaeb2a26":
+"wallet-common-helpers@https://github.com/Concordium/concordium-wallet-common-helpers.git#280339fa6c51922944094bc631d097d245e1e08f":
   version: 1.5.0
-  resolution: "wallet-common-helpers@https://github.com/Concordium/concordium-wallet-common-helpers.git#commit=cde2bfb682cae08c9f0338d4a0567abecaeb2a26"
+  resolution: "wallet-common-helpers@https://github.com/Concordium/concordium-wallet-common-helpers.git#commit=280339fa6c51922944094bc631d097d245e1e08f"
   dependencies:
-    "@concordium/common-sdk": ^6.2.0
+    "@concordium/common-sdk": ^6.3.0
     buffer: ^6.0.3
     cbor: ^8.0.0
     clsx: ^1.1.1
@@ -21013,7 +21134,7 @@ __metadata:
   peerDependencies:
     react: ">=16"
     react-dom: ">=16"
-  checksum: 6690dce1ea8e4a3923ba9cfed0ac5b7522df85617cc1789312fc956e39c1d08a62e3a437797a255ada458b9b42de0f066ef2ff62384dfcb2d3f5b5a866bf4551
+  checksum: 5b98444c5190d1be50ba4df55c16c9e6559e482830d92044afb3d0a93bf7830bc856710634b681f42d2a4ca62e0030a3a3ab465721e7eca66b005bdc80f93cbb
   languageName: node
   linkType: hard
 
@@ -21067,7 +21188,7 @@ __metadata:
   resolution: "wccd@workspace:examples/wCCD"
   dependencies:
     "@concordium/react-components": ^0.2.0
-    "@concordium/web-sdk": ^3.2.0
+    "@concordium/web-sdk": ^3.3.1
     "@craftamap/esbuild-plugin-html": ^0.4.0
     "@thi.ng/leb128": ^2.1.18
     "@types/node": ^18.7.23

--- a/yarn.lock
+++ b/yarn.lock
@@ -1913,8 +1913,6 @@ __metadata:
   dependencies:
     "@concordium/browser-wallet-api-helpers": "workspace:^"
     "@concordium/common-sdk": ^6.3.0
-    "@protobuf-ts/grpcweb-transport": ^2.8.2
-    "@protobuf-ts/runtime-rpc": ^2.8.2
     "@types/json-bigint": ^1.0.1
     buffer: ^6.0.3
     json-bigint: ^1.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -1913,6 +1913,8 @@ __metadata:
   dependencies:
     "@concordium/browser-wallet-api-helpers": "workspace:^"
     "@concordium/common-sdk": ^6.2.0
+    "@protobuf-ts/grpcweb-transport": ^2.8.2
+    "@protobuf-ts/runtime-rpc": ^2.8.2
     "@types/json-bigint": ^1.0.1
     buffer: ^6.0.3
     json-bigint: ^1.0.0
@@ -2843,6 +2845,32 @@ __metadata:
   version: 2.11.6
   resolution: "@popperjs/core@npm:2.11.6"
   checksum: 47fb328cec1924559d759b48235c78574f2d71a8a6c4c03edb6de5d7074078371633b91e39bbf3f901b32aa8af9b9d8f82834856d2f5737a23475036b16817f0
+  languageName: node
+  linkType: hard
+
+"@protobuf-ts/grpcweb-transport@npm:^2.8.2":
+  version: 2.8.2
+  resolution: "@protobuf-ts/grpcweb-transport@npm:2.8.2"
+  dependencies:
+    "@protobuf-ts/runtime": ^2.8.2
+    "@protobuf-ts/runtime-rpc": ^2.8.2
+  checksum: c579ab87c5d20ae815fcd8ad59326fd36337cd35118dbecdfada8951efa9eeffffbc54052d4132b98615dd9c23c860b90f210ad538ab7b228b484645f7121ee9
+  languageName: node
+  linkType: hard
+
+"@protobuf-ts/runtime-rpc@npm:^2.8.2":
+  version: 2.8.2
+  resolution: "@protobuf-ts/runtime-rpc@npm:2.8.2"
+  dependencies:
+    "@protobuf-ts/runtime": ^2.8.2
+  checksum: a75847f34e93f3d3d17558797a3cfa7b3aa96207f88b00943fdf3e661c5c3b67f112f307b2b0c3e4bb3d40d435fdb41458dde492436befa738677e1e3d8d369d
+  languageName: node
+  linkType: hard
+
+"@protobuf-ts/runtime@npm:^2.8.2":
+  version: 2.8.2
+  resolution: "@protobuf-ts/runtime@npm:2.8.2"
+  checksum: ab322e832bfb347b271a8862b8ef3db27ffa380f9c49f94acb410534586a282ebd8af96d4459f959ad0fe5fbf34183f3f4fe512e50c9a4331b742a7445b16c92
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1913,6 +1913,8 @@ __metadata:
   dependencies:
     "@concordium/browser-wallet-api-helpers": "workspace:^"
     "@concordium/common-sdk": ^6.3.0
+    "@protobuf-ts/grpcweb-transport": ^2.8.2
+    "@protobuf-ts/runtime-rpc": ^2.8.2
     "@types/json-bigint": ^1.0.1
     buffer: ^6.0.3
     json-bigint: ^1.0.0


### PR DESCRIPTION
## Purpose

Use gRPC-web with the v2 API instead of json-RPC.

## Changes

- Use gRPC-web instead of json-RPC.
- add `getGrpcClient` to wallet-api.
- Added context for getting blockchain parameters.
- No longer use wallet-proxy to get current exchangeRate.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
