### PR TITLE
Fix mismatch in string identifier for UpdateCredentialsKeys from wallet-proxy

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Use gRPC-web instead of json-RPC.
 
+### Fixed
+
+-   Handling of UpdateAccountKey transactions from wallet-proxy.
+
 ## 0.9.8
 
 ### Fixed

--- a/packages/browser-wallet/src/popup/pages/Account/TransactionLog/TransactionElement.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/TransactionLog/TransactionElement.tsx
@@ -125,7 +125,7 @@ function mapTypeToText(type: AccountTransactionType | RewardType | SpecialTransa
         case AccountTransactionType.UpdateBakerKeys:
             return 'Baker keys update';
         case AccountTransactionType.UpdateCredentialKeys:
-            return 'Credential keys update';
+            return 'Account keys update';
         case RewardType.BakingReward:
             return 'Baking reward';
         case RewardType.BlockReward:

--- a/packages/browser-wallet/src/popup/shared/utils/wallet-proxy.ts
+++ b/packages/browser-wallet/src/popup/shared/utils/wallet-proxy.ts
@@ -31,7 +31,7 @@ export enum TransactionKindString {
     UpdateBakerStake = 'updateBakerStake',
     UpdateBakerRestakeEarnings = 'updateBakerRestakeEarnings',
     UpdateBakerKeys = 'updateBakerKeys',
-    UpdateCredentialKeys = 'updateCredentialKeys',
+    UpdateCredentialKeys = 'updateAccountKeys',
     BakingReward = 'bakingReward',
     BlockReward = 'blockReward',
     FinalizationReward = 'finalizationReward',


### PR DESCRIPTION
## Purpose

Fix bug that caused transaction history to not load when account has a `updateCredentialsKeys` transaction.

## Changes

- Fix expected key from wallet proxy for `updateCredentialsKeys`.
- Change name for `updateCredentialsKeys` in list to `Account keys update`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.