### PR TITLE
Add support for SignMessageObject as input to signMessage

### DIFF
--- a/examples/two-step-transfer/index.html
+++ b/examples/two-step-transfer/index.html
@@ -53,6 +53,47 @@
                         .then((sig) => alert(JSON.stringify(sig)))
                         .catch(alert)
                 );
+                document.getElementById('signMessageBinary').addEventListener('click', () => {
+                    const SERIALIZATION_HELPER_SCHEMA =
+                        'FAAFAAAAEAAAAGNvbnRyYWN0X2FkZHJlc3MMCwAAAGVudHJ5X3BvaW50FgEFAAAAbm9uY2UFCQAAAHRpbWVzdGFtcA0HAAAAcGF5bG9hZBUCAAAACAAAAFRyYW5zZmVyAQEAAAAQARQABQAAAAgAAAB0b2tlbl9pZB0ABgAAAGFtb3VudBslAAAABAAAAGZyb20VAgAAAAcAAABBY2NvdW50AQEAAAALCAAAAENvbnRyYWN0AQEAAAAMAgAAAHRvFQIAAAAHAAAAQWNjb3VudAEBAAAACwgAAABDb250cmFjdAECAAAADBYBBAAAAGRhdGEdAQ4AAABVcGRhdGVPcGVyYXRvcgEBAAAAEAEUAAIAAAAGAAAAdXBkYXRlFQIAAAAGAAAAUmVtb3ZlAgMAAABBZGQCCAAAAG9wZXJhdG9yFQIAAAAHAAAAQWNjb3VudAEBAAAACwgAAABDb250cmFjdAEBAAAADA';
+                    const sponsoredMessage = {
+                        contract_address: {
+                            index: 0,
+                            subindex: 0,
+                        },
+                        entry_point: 'contract_transfer',
+                        nonce: 1,
+                        payload: {
+                            Transfer: [
+                                [
+                                    {
+                                        amount: '1',
+                                        data: '',
+                                        from: {
+                                            Account: [currentAccountAddress],
+                                        },
+                                        to: {
+                                            Account: [currentAccountAddress],
+                                        },
+                                        token_id: '11111111',
+                                    },
+                                ],
+                            ],
+                        },
+                        timestamp: '2030-08-08T05:15:00Z',
+                    };
+                    const serializedMessage = concordiumSDK.serializeTypeValue(
+                        sponsoredMessage,
+                        concordiumSDK.toBuffer(SERIALIZATION_HELPER_SCHEMA, 'base64')
+                    );
+                    provider
+                        .signMessage(currentAccountAddress, {
+                            data: serializedMessage.toString('hex'),
+                            schema: SERIALIZATION_HELPER_SCHEMA,
+                        })
+                        .then((sig) => alert(JSON.stringify(sig)))
+                        .catch(alert);
+                });
                 document.getElementById('sendDeposit').addEventListener('click', () =>
                     provider
                         .sendTransaction(currentAccountAddress, concordiumSDK.AccountTransactionType.Update, {
@@ -182,6 +223,7 @@
         <br />
         Message: <input type="text" id="message" value="I believe in miracles" />
         <button id="signMessage">SignMessage</button>
+        <button id="signMessageBinary">SignSponsoredTransactionLikeMessage</button>
         <button id="registerData">Register message (HEX encoded) (must be a hex string)</button>
         <button id="registerDataCBOR">Register message (CBOR encoded)</button>
     </body>

--- a/examples/two-step-transfer/package.json
+++ b/examples/two-step-transfer/package.json
@@ -5,7 +5,7 @@
         "live-server": "^1.2.2"
     },
     "scripts": {
-        "start": "live-server ../two-step-transfer/index.html --mount=/sdk.js:./node_modules/@concordium/web-sdk/lib/concordium.min.js --mount=/helpers.js:../../packages/browser-wallet-api-helpers/lib/concordiumHelpers.min.js"
+        "start": "live-server ../two-step-transfer/index.html --mount=/sdk.js:../../node_modules/@concordium/web-sdk/lib/concordium.min.js --mount=/helpers.js:../../packages/browser-wallet-api-helpers/lib/concordiumHelpers.min.js"
     },
     "dependencies": {
         "@concordium/web-sdk": "^3.2.0"

--- a/packages/browser-wallet-api-helpers/CHANGELOG.md
+++ b/packages/browser-wallet-api-helpers/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.4.0
+
+### Added
+
+-   signMessage is now able to receive a SignMessageObject as the message in addition to a utf8 string.
+
 ## 2.3.0
 
 ### Added

--- a/packages/browser-wallet-api-helpers/README.md
+++ b/packages/browser-wallet-api-helpers/README.md
@@ -142,7 +142,12 @@ It is possible to sign arbitrary messages using the keys for an account stored i
 
 If the wallet is locked, or you have not connected with the wallet (or previously been whitelisted) or if the user rejects signing the meesage, the `Promise` will reject.
 
-The following exemplifies requesting a signature of a message:
+The message should either utf8 string or an object with the following fields:
+
+-   data: A hex string representing the bytes that should be signed.
+-   schema: A base64 string that represents a schema for the data field, and which can be used to deserialize the data into a JSON format.
+
+The following exemplifies requesting a signature of a message, where the message is a utf8 string:
 
 ```typescript
 const provider = await detectConcordiumProvider();
@@ -150,6 +155,31 @@ const signature = await provider.signMessage(
     '4MyVHYbRkAU6fqQsoSDzni6mrVz1KEvhDJoMVmDmrCgPBD8b7S',
     'This is a message to be signed'
 );
+```
+
+The following exemplifies requesting a signature of a message, where the message is an object:
+
+```typescript
+const provider = await detectConcordiumProvider();
+const signature = await provider.signMessage('4MyVHYbRkAU6fqQsoSDzni6mrVz1KEvhDJoMVmDmrCgPBD8b7S', {
+    data: '00000b0000004120676f6f64206974656d00a4fbca84010000',
+    schema: 'FAAEAAAADQAAAGF1Y3Rpb25fc3RhdGUVAgAAAAoAAABOb3RTb2xkWWV0AgQAAABTb2xkAQEAAAALDgAAAGhpZ2hlc3RfYmlkZGVyFQIAAAAEAAAATm9uZQIEAAAAU29tZQEBAAAACwQAAABpdGVtFgIDAAAAZW5kDQ',
+});
+```
+
+In this example the user will be shown:
+
+```JSON
+{
+  "auction_state": {
+    "NotSoldYet": []
+  },
+  "end": "2022-12-01T00:00:00+00:00",
+  "highest_bidder": {
+    "None": []
+  },
+  "item": "A good item"
+}
 ```
 
 ### Add CIS-2 Tokens

--- a/packages/browser-wallet-api-helpers/package.json
+++ b/packages/browser-wallet-api-helpers/package.json
@@ -19,7 +19,7 @@
         "url": "https://concordium.com"
     },
     "dependencies": {
-        "@concordium/web-sdk": "^3.2.0"
+        "@concordium/web-sdk": "^3.4.0"
     },
     "devDependencies": {
         "@babel/core": "^7.17.10",

--- a/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
+++ b/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
@@ -22,6 +22,13 @@ export type SmartContractParameters =
     | string
     | boolean;
 
+export type SignMessageObject = {
+    /** as base64 */
+    schema: string;
+    /** as hex */
+    data: string;
+};
+
 /**
  * An enumeration of the events that can be emitted by the WalletApi.
  */
@@ -91,9 +98,9 @@ interface MainWalletApi {
      * Sends a message to the Concordium Wallet and awaits the users action. If the user signs the message, this will resolve to the signature.
      * Note that if the user rejects signing the message, this will throw an error.
      * @param accountAddress the address of the account that should sign the message
-     * @param message message to be signed. Note that the wallet will prepend some bytes to ensure the message cannot be a transaction
+     * @param message message to be signed. Note that the wallet will prepend some bytes to ensure the message cannot be a transaction. The message should either be a utf8 string or { @link SignMessageObject }.
      */
-    signMessage(accountAddress: string, message: string): Promise<AccountTransactionSignature>;
+    signMessage(accountAddress: string, message: string | SignMessageObject): Promise<AccountTransactionSignature>;
     /**
      * Requests a connection to the Concordium wallet, prompting the user to either accept or reject the request.
      * If a connection has already been accepted for the url once the returned promise will resolve without prompting the user.

--- a/packages/browser-wallet-api/package.json
+++ b/packages/browser-wallet-api/package.json
@@ -7,7 +7,7 @@
     "license": "Apache-2.0",
     "dependencies": {
         "@concordium/browser-wallet-api-helpers": "workspace:^",
-        "@concordium/common-sdk": "^6.2.0",
+        "@concordium/common-sdk": "^6.4.0",
         "buffer": "^6.0.3",
         "json-bigint": "^1.0.0"
     },

--- a/packages/browser-wallet-api/src/wallet-api.ts
+++ b/packages/browser-wallet-api/src/wallet-api.ts
@@ -19,6 +19,7 @@ import {
     EventType,
     SchemaWithContext,
     SchemaType,
+    SignMessageObject,
     SmartContractParameters,
 } from '@concordium/browser-wallet-api-helpers';
 import EventEmitter from 'events';
@@ -66,7 +67,10 @@ class WalletApi extends EventEmitter implements IWalletApi {
     /**
      * Sends a sign request to the Concordium Wallet and awaits the users action
      */
-    public async signMessage(accountAddress: string, message: string): Promise<AccountTransactionSignature> {
+    public async signMessage(
+        accountAddress: string,
+        message: string | SignMessageObject
+    ): Promise<AccountTransactionSignature> {
         const response = await this.messageHandler.sendMessage<MessageStatusWrapper<AccountTransactionSignature>>(
             MessageType.SignMessage,
             {
@@ -76,7 +80,7 @@ class WalletApi extends EventEmitter implements IWalletApi {
         );
 
         if (!response.success) {
-            throw new Error('Signing rejected');
+            throw new Error(response.message);
         }
 
         return response.result;

--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.9.9
+
+### Added
+
+-   Support for signing arbitrary data with signMessage.
+
 ## 0.9.8
 
 ### Fixed

--- a/packages/browser-wallet/package.json
+++ b/packages/browser-wallet/package.json
@@ -17,7 +17,7 @@
     "dependencies": {
         "@concordium/browser-wallet-api": "workspace:^",
         "@concordium/browser-wallet-api-helpers": "workspace:^",
-        "@concordium/web-sdk": "^3.2.0",
+        "@concordium/web-sdk": "^3.4.0",
         "@scure/bip39": "^1.1.0",
         "axios": "^0.27.2",
         "buffer": "^6.0.3",

--- a/packages/browser-wallet/src/background/credential-deployment.ts
+++ b/packages/browser-wallet/src/background/credential-deployment.ts
@@ -3,7 +3,7 @@ import { ExtensionMessageHandler } from '@concordium/browser-wallet-message-hub'
 import {
     HttpProvider,
     createCredentialV1,
-    CredentialInputV1,
+    CredentialInput,
     getAccountAddress,
     getSignedCredentialDeploymentTransactionHash,
     JsonRpcClient,
@@ -14,7 +14,9 @@ import { BackgroundResponseStatus, CredentialDeploymentBackgroundResponse } from
 import { confirmCredential } from './confirmation';
 import { addCredential } from './update';
 
-async function createAndSendCredential(credIn: CredentialInputV1): Promise<CredentialDeploymentBackgroundResponse> {
+async function createAndSendCredential(
+    credIn: CredentialInput & { expiry: number }
+): Promise<CredentialDeploymentBackgroundResponse> {
     let address: string;
     try {
         const network = await storedCurrentNetwork.get();

--- a/packages/browser-wallet/src/background/index.ts
+++ b/packages/browser-wallet/src/background/index.ts
@@ -5,7 +5,7 @@ import {
     ExtensionMessageHandler,
     MessageStatusWrapper,
 } from '@concordium/browser-wallet-message-hub';
-import { HttpProvider } from '@concordium/web-sdk';
+import { deserializeTypeValue, HttpProvider } from '@concordium/web-sdk';
 import {
     storedConnectedSites,
     storedSelectedAccount,
@@ -19,6 +19,7 @@ import JSONBig from 'json-bigint';
 import { ChromeStorageKey, NetworkConfiguration } from '@shared/storage/types';
 import { buildURLwithSearchParameters } from '@shared/utils/url-helpers';
 import { getTermsAndConditionsConfig } from '@shared/utils/network-helpers';
+import { Buffer } from 'buffer/';
 import bgMessageHandler from './message-handler';
 import {
     forwardToPopup,
@@ -218,6 +219,31 @@ const runIfWhitelisted: RunCondition<MessageStatusWrapper<undefined>> = async (m
     return { run: false, response: { success: false, message: NOT_WHITELISTED } };
 };
 
+const INCORRECT_SIGN_MESSAGE_FORMAT = 'The given message does not have correct format.';
+const UNABLE_TO_PARSE_SIGN_MESSAGE_OBJECT =
+    'The given message data could not be deserialized using the provided schema';
+
+/**
+ * Run condition for signMessage, which ensures the message is either a string,
+ * or a messageObject and in that case that the schema can be used to deserialize the message data.
+ */
+const ensureMessageWithSchemaParse: RunCondition<MessageStatusWrapper<undefined>> = async (msg) => {
+    const { message } = msg.payload;
+    if (typeof message === 'string') {
+        return { run: true };
+    }
+
+    if (!message.schema || !message.data) {
+        return { run: false, response: { success: false, message: INCORRECT_SIGN_MESSAGE_FORMAT } };
+    }
+    try {
+        deserializeTypeValue(Buffer.from(message.data, 'hex'), Buffer.from(message.schema, 'base64'));
+        return { run: true };
+    } catch {
+        return { run: false, response: { success: false, message: UNABLE_TO_PARSE_SIGN_MESSAGE_OBJECT } };
+    }
+};
+
 // TODO change this to find most recently selected account
 /**
  * Finds the most prioritized account that is connected to the provided site.
@@ -367,7 +393,7 @@ forwardToPopup(
 forwardToPopup(
     MessageType.SignMessage,
     InternalMessageType.SignMessage,
-    runConditionComposer(runIfWhitelisted, withPromptStart),
+    runConditionComposer(runIfWhitelisted, ensureMessageWithSchemaParse, withPromptStart),
     appendUrlToPayload,
     undefined,
     withPromptEnd

--- a/packages/browser-wallet/src/popup/pages/SignMessage/SignMessage.scss
+++ b/packages/browser-wallet/src/popup/pages/SignMessage/SignMessage.scss
@@ -1,3 +1,27 @@
+$actions-height: rem(26px);
+
 .sign-message {
     display: block;
+
+    &__view-actions {
+        display: grid;
+        width: 100%;
+        grid-template-columns: 1fr 1fr;
+        height: $actions-height;
+        border-top-left-radius: rem(5px);
+        border-top-right-radius: rem(5px);
+    }
+
+    &__binary-text-area textarea {
+        border-top-left-radius: 0;
+        border-top-right-radius: 0;
+        font-family: $font-family-mono;
+        padding: rem(10px);
+    }
+
+    &__link {
+        &:not(.active) {
+            color: rgba($color: $color-off-white, $alpha: 60%);
+        }
+    }
 }

--- a/packages/browser-wallet/src/popup/pages/SignMessage/SignMessage.tsx
+++ b/packages/browser-wallet/src/popup/pages/SignMessage/SignMessage.tsx
@@ -1,9 +1,16 @@
-import React, { useContext, useCallback } from 'react';
+import React, { useContext, useCallback, useState, useMemo } from 'react';
+import { Buffer } from 'buffer/';
 import { fullscreenPromptContext } from '@popup/page-layouts/FullscreenPromptLayout';
 import { useTranslation } from 'react-i18next';
 import { useSetAtom } from 'jotai';
 import { useLocation } from 'react-router-dom';
-import { signMessage, buildBasicAccountSigner, AccountTransactionSignature, AccountAddress } from '@concordium/web-sdk';
+import {
+    signMessage,
+    buildBasicAccountSigner,
+    AccountTransactionSignature,
+    AccountAddress,
+    deserializeTypeValue,
+} from '@concordium/web-sdk';
 import { usePrivateKey } from '@popup/shared/utils/account-helpers';
 import { displayUrl } from '@popup/shared/utils/string-helpers';
 import { TextArea } from '@popup/shared/Form/TextArea';
@@ -11,6 +18,8 @@ import ConnectedBox from '@popup/pages/Account/ConnectedBox';
 import Button from '@popup/shared/Button';
 import { addToastAtom } from '@popup/state';
 import ExternalRequestLayout from '@popup/page-layouts/ExternalRequestLayout';
+import TabBar from '@popup/shared/TabBar';
+import clsx from 'clsx';
 
 type Props = {
     onSubmit(signature: AccountTransactionSignature): void;
@@ -21,10 +30,63 @@ interface Location {
     state: {
         payload: {
             accountAddress: string;
-            message: string;
+            message: string | MessageObject;
             url: string;
         };
     };
+}
+
+type MessageObject = {
+    schema: string;
+    data: string;
+};
+
+function BinaryDisplay({ message, url }: { message: MessageObject; url: string }) {
+    const { t } = useTranslation('signMessage');
+    const [displayDeserialized, setDisplayDeserialized] = useState<boolean>(true);
+
+    const parsedMessage = useMemo(() => {
+        try {
+            return JSON.stringify(
+                deserializeTypeValue(Buffer.from(message.data, 'hex'), Buffer.from(message.schema, 'base64')),
+                undefined,
+                2
+            );
+        } catch (e) {
+            return 'a';
+        }
+    }, []);
+
+    const display = useMemo(() => (displayDeserialized ? parsedMessage : message.data), [displayDeserialized]);
+
+    return (
+        <>
+            <p className="m-t-0 text-center">{t('descriptionWithSchema', { dApp: displayUrl(url) })}</p>
+            <TabBar className="sign-message__view-actions">
+                <TabBar.Item
+                    className={clsx('sign-message__link', displayDeserialized && 'active')}
+                    as={Button}
+                    clear
+                    onClick={() => setDisplayDeserialized(true)}
+                >
+                    {t('deserializedDisplay')}
+                </TabBar.Item>
+                <TabBar.Item
+                    className={clsx('sign-message__link', !displayDeserialized && 'active')}
+                    as={Button}
+                    clear
+                    onClick={() => setDisplayDeserialized(false)}
+                >
+                    {t('rawDisplay')}
+                </TabBar.Item>
+            </TabBar>
+            <TextArea
+                readOnly
+                className={clsx('m-b-20 w-full flex-child-fill sign-message__binary-text-area')}
+                value={display}
+            />
+        </>
+    );
 }
 
 export default function SignMessage({ onSubmit, onReject }: Props) {
@@ -34,12 +96,19 @@ export default function SignMessage({ onSubmit, onReject }: Props) {
     const { accountAddress, url } = state.payload;
     const key = usePrivateKey(accountAddress);
     const addToast = useSetAtom(addToastAtom);
+    const { message } = state.payload;
+    const messageIsAString = typeof message === 'string';
 
     const onClick = useCallback(async () => {
         if (!key) {
             throw new Error('Missing key for the chosen address');
         }
-        return signMessage(new AccountAddress(accountAddress), state.payload.message, buildBasicAccountSigner(key));
+
+        return signMessage(
+            new AccountAddress(accountAddress),
+            messageIsAString ? message : Buffer.from(message.data, 'hex'),
+            buildBasicAccountSigner(key)
+        );
     }, [state.payload.message, state.payload.accountAddress, key]);
 
     return (
@@ -47,7 +116,8 @@ export default function SignMessage({ onSubmit, onReject }: Props) {
             <ConnectedBox accountAddress={accountAddress} url={new URL(url).origin} />
             <div className="h-full flex-column align-center">
                 <h3 className="m-t-0 text-center">{t('description', { dApp: displayUrl(url) })}</h3>
-                <TextArea className="m-v-20 w-full flex-child-fill" value={state.payload.message} />
+                {messageIsAString && <TextArea readOnly className="m-v-20 w-full flex-child-fill" value={message} />}
+                {!messageIsAString && <BinaryDisplay message={message} url={url} />}
                 <div className="flex p-b-10  m-t-auto">
                     <Button width="narrow" className="m-r-10" onClick={withClose(onReject)}>
                         {t('reject')}

--- a/packages/browser-wallet/src/popup/pages/SignMessage/i18n/da.ts
+++ b/packages/browser-wallet/src/popup/pages/SignMessage/i18n/da.ts
@@ -1,7 +1,11 @@
 import type en from './en';
 
 const t: typeof en = {
-    description: 'Signér besked med konto {{address}}',
+    description: '{{ dApp }} anmoder om en signatur på følgende besked',
+    descriptionWithSchema:
+        '{{ dApp }} har sendt en rå besked og et schema til at oversætte den. Vi har oversat beskeden, men du burde kun underskrive hvis du stoler på {{ dApp }}',
+    deserializedDisplay: 'Oversat',
+    rawDisplay: 'Rå',
     sign: 'Signér',
     reject: 'Afvis',
     error: 'Fejl',

--- a/packages/browser-wallet/src/popup/pages/SignMessage/i18n/en.ts
+++ b/packages/browser-wallet/src/popup/pages/SignMessage/i18n/en.ts
@@ -1,5 +1,9 @@
 const t = {
     description: '{{ dApp }} requests a signature on a message',
+    descriptionWithSchema:
+        "{{ dApp }} has provided the raw message and a schema to translate it. We've translated the message but you should only sign it if you trust {{ dApp }}.",
+    deserializedDisplay: 'Translated',
+    rawDisplay: 'Raw',
     sign: 'Sign',
     reject: 'Reject',
     error: 'Error',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1900,7 +1900,7 @@ __metadata:
     "@babel/plugin-transform-modules-commonjs": ^7.12.1
     "@babel/plugin-transform-runtime": ^7.12.1
     "@babel/preset-env": ^7.12.1
-    "@concordium/web-sdk": ^3.2.0
+    "@concordium/web-sdk": ^3.4.0
     typescript: ^4.3.5
     webpack: ^5.72.0
     webpack-cli: ^4.9.2
@@ -1912,7 +1912,7 @@ __metadata:
   resolution: "@concordium/browser-wallet-api@workspace:packages/browser-wallet-api"
   dependencies:
     "@concordium/browser-wallet-api-helpers": "workspace:^"
-    "@concordium/common-sdk": ^6.2.0
+    "@concordium/common-sdk": ^6.4.0
     "@types/json-bigint": ^1.0.1
     buffer: ^6.0.3
     json-bigint: ^1.0.0
@@ -1938,7 +1938,7 @@ __metadata:
     "@babel/core": ^7.18.2
     "@concordium/browser-wallet-api": "workspace:^"
     "@concordium/browser-wallet-api-helpers": "workspace:^"
-    "@concordium/web-sdk": ^3.2.0
+    "@concordium/web-sdk": ^3.4.0
     "@craftamap/esbuild-plugin-html": ^0.4.0
     "@mdx-js/react": ^1.6.22
     "@scure/bip39": ^1.1.0
@@ -2037,6 +2037,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@concordium/common-sdk@npm:6.4.0, @concordium/common-sdk@npm:^6.4.0":
+  version: 6.4.0
+  resolution: "@concordium/common-sdk@npm:6.4.0"
+  dependencies:
+    "@concordium/rust-bindings": 0.11.0
+    "@grpc/grpc-js": ^1.3.4
+    "@noble/ed25519": ^1.7.1
+    "@protobuf-ts/runtime-rpc": ^2.8.2
+    "@scure/bip39": ^1.1.0
+    bs58check: ^2.1.2
+    buffer: ^6.0.3
+    cross-fetch: 3.1.5
+    hash.js: ^1.1.7
+    iso-3166-1: ^2.1.1
+    json-bigint: ^1.0.0
+    uuid: ^8.3.2
+  checksum: d4d8fcd1961cfbe6939958afec90eeff05cc88c83cbb5bd6e1dcf5f887324e15b2c175e4e0dced4cf2860cdc06dcb945b94c88a7790f087028d4f1dcd9b40f86
+  languageName: node
+  linkType: hard
+
 "@concordium/react-components@npm:^0.2.0":
   version: 0.2.0
   resolution: "@concordium/react-components@npm:0.2.0"
@@ -2045,6 +2065,13 @@ __metadata:
   peerDependencies:
     react: ^18
   checksum: b4141037d2f38d289362ca124369d7d61b9ec5260ca895d57bf6d5823027c901e96943f27261b2813ccdfaae9dbeecaf35a1a37492e146ea6d32fc358486f4be
+  languageName: node
+  linkType: hard
+
+"@concordium/rust-bindings@npm:0.11.0":
+  version: 0.11.0
+  resolution: "@concordium/rust-bindings@npm:0.11.0"
+  checksum: a6c437cb782b7b2e9f217215dd4dbed9ffb8b3ef46fa307952aca3ae8f166cb96687de64efd18490aec7e86d58712dccb7d1a8bf63c151e3ed2a0170f066cd6d
   languageName: node
   linkType: hard
 
@@ -2094,6 +2121,20 @@ __metadata:
     buffer: ^6.0.3
     process: ^0.11.10
   checksum: e61bbfcca07e7d63035667324395d1f6bec2a7c17a0a2bab85d12b9ed3bf3203155ba9c0aa3df2fdf0c57e036d9fa1479ffa8399d7b08daf0edb4f14c9a5cb37
+  languageName: node
+  linkType: hard
+
+"@concordium/web-sdk@npm:^3.4.0":
+  version: 3.4.0
+  resolution: "@concordium/web-sdk@npm:3.4.0"
+  dependencies:
+    "@concordium/common-sdk": 6.4.0
+    "@concordium/rust-bindings": 0.11.0
+    "@grpc/grpc-js": ^1.3.4
+    "@protobuf-ts/grpcweb-transport": ^2.8.2
+    buffer: ^6.0.3
+    process: ^0.11.10
+  checksum: 65474ebc30bd846d5848a76732ee6517e644b63ea916b625625e2a9e42e4980eacbcdd21ce286d11e27d09b2a262847a5b42577a28c6950837ddfbc04625590d
   languageName: node
   linkType: hard
 
@@ -2238,6 +2279,31 @@ __metadata:
   version: 1.1.3
   resolution: "@gar/promisify@npm:1.1.3"
   checksum: 4059f790e2d07bf3c3ff3e0fec0daa8144fe35c1f6e0111c9921bd32106adaa97a4ab096ad7dab1e28ee6a9060083c4d1a4ada42a7f5f3f7a96b8812e2b757c1
+  languageName: node
+  linkType: hard
+
+"@grpc/grpc-js@npm:^1.3.4":
+  version: 1.8.12
+  resolution: "@grpc/grpc-js@npm:1.8.12"
+  dependencies:
+    "@grpc/proto-loader": ^0.7.0
+    "@types/node": ">=12.12.47"
+  checksum: bf6135f8c87d6008f42452a7234b9bfa4bb558dd553a77dcd90cd2fbc9c8f01585504788e479a2805e4ab5f0d4e6d3480f7096324b3ab5db9e492e674b8c375a
+  languageName: node
+  linkType: hard
+
+"@grpc/proto-loader@npm:^0.7.0":
+  version: 0.7.5
+  resolution: "@grpc/proto-loader@npm:0.7.5"
+  dependencies:
+    "@types/long": ^4.0.1
+    lodash.camelcase: ^4.3.0
+    long: ^4.0.0
+    protobufjs: ^7.0.0
+    yargs: ^16.2.0
+  bin:
+    proto-loader-gen-types: build/bin/proto-loader-gen-types.js
+  checksum: ca3a16fc18526a835d006802d15dcf21cb3e2a7a803a988bf34397ebeb07ae94062b3f06db3d1a9b8ec3c40bd96354ca69d9e2ac06ef4c3a74a990d9e55ca2fd
   languageName: node
   linkType: hard
 
@@ -2843,6 +2909,105 @@ __metadata:
   version: 2.11.6
   resolution: "@popperjs/core@npm:2.11.6"
   checksum: 47fb328cec1924559d759b48235c78574f2d71a8a6c4c03edb6de5d7074078371633b91e39bbf3f901b32aa8af9b9d8f82834856d2f5737a23475036b16817f0
+  languageName: node
+  linkType: hard
+
+"@protobuf-ts/grpcweb-transport@npm:^2.8.2":
+  version: 2.8.3
+  resolution: "@protobuf-ts/grpcweb-transport@npm:2.8.3"
+  dependencies:
+    "@protobuf-ts/runtime": ^2.8.3
+    "@protobuf-ts/runtime-rpc": ^2.8.3
+  checksum: 22b748e6e4f218bc86023bd9a180279ed7fbccc1169c93ab382a94b22868cbfc823eecb84e38213930206f2e78eb2913d4b7e2fabc479388496db7f00112c602
+  languageName: node
+  linkType: hard
+
+"@protobuf-ts/runtime-rpc@npm:^2.8.2, @protobuf-ts/runtime-rpc@npm:^2.8.3":
+  version: 2.8.3
+  resolution: "@protobuf-ts/runtime-rpc@npm:2.8.3"
+  dependencies:
+    "@protobuf-ts/runtime": ^2.8.3
+  checksum: 9b6124abde33669ba87f15f921d6fcc60d09cfd2ffcbdda257e791edbd5be0c66f682ac207843f5841ba829354ec86664c627a4c2cdce3525f4cf9e3db8fdbdf
+  languageName: node
+  linkType: hard
+
+"@protobuf-ts/runtime@npm:^2.8.3":
+  version: 2.8.3
+  resolution: "@protobuf-ts/runtime@npm:2.8.3"
+  checksum: b5237c5ec4b05f407a8afb51e066a5e27d03da55763e9c83a0d0d32433d95d0b8be0cdf5bcafb5616250c382299dc7c9f9b8a4334813e2cb4615e27a971daada
+  languageName: node
+  linkType: hard
+
+"@protobufjs/aspromise@npm:^1.1.1, @protobufjs/aspromise@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@protobufjs/aspromise@npm:1.1.2"
+  checksum: 011fe7ef0826b0fd1a95935a033a3c0fd08483903e1aa8f8b4e0704e3233406abb9ee25350ec0c20bbecb2aad8da0dcea58b392bbd77d6690736f02c143865d2
+  languageName: node
+  linkType: hard
+
+"@protobufjs/base64@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@protobufjs/base64@npm:1.1.2"
+  checksum: 67173ac34de1e242c55da52c2f5bdc65505d82453893f9b51dc74af9fe4c065cf4a657a4538e91b0d4a1a1e0a0642215e31894c31650ff6e3831471061e1ee9e
+  languageName: node
+  linkType: hard
+
+"@protobufjs/codegen@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "@protobufjs/codegen@npm:2.0.4"
+  checksum: 59240c850b1d3d0b56d8f8098dd04787dcaec5c5bd8de186fa548de86b86076e1c50e80144b90335e705a044edf5bc8b0998548474c2a10a98c7e004a1547e4b
+  languageName: node
+  linkType: hard
+
+"@protobufjs/eventemitter@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/eventemitter@npm:1.1.0"
+  checksum: 0369163a3d226851682f855f81413cbf166cd98f131edb94a0f67f79e75342d86e89df9d7a1df08ac28be2bc77e0a7f0200526bb6c2a407abbfee1f0262d5fd7
+  languageName: node
+  linkType: hard
+
+"@protobufjs/fetch@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/fetch@npm:1.1.0"
+  dependencies:
+    "@protobufjs/aspromise": ^1.1.1
+    "@protobufjs/inquire": ^1.1.0
+  checksum: 3fce7e09eb3f1171dd55a192066450f65324fd5f7cc01a431df01bb00d0a895e6bfb5b0c5561ce157ee1d886349c90703d10a4e11a1a256418ff591b969b3477
+  languageName: node
+  linkType: hard
+
+"@protobufjs/float@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@protobufjs/float@npm:1.0.2"
+  checksum: 5781e1241270b8bd1591d324ca9e3a3128d2f768077a446187a049e36505e91bc4156ed5ac3159c3ce3d2ba3743dbc757b051b2d723eea9cd367bfd54ab29b2f
+  languageName: node
+  linkType: hard
+
+"@protobufjs/inquire@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/inquire@npm:1.1.0"
+  checksum: ca06f02eaf65ca36fb7498fc3492b7fc087bfcc85c702bac5b86fad34b692bdce4990e0ef444c1e2aea8c034227bd1f0484be02810d5d7e931c55445555646f4
+  languageName: node
+  linkType: hard
+
+"@protobufjs/path@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@protobufjs/path@npm:1.1.2"
+  checksum: 856eeb532b16a7aac071cacde5c5620df800db4c80cee6dbc56380524736205aae21e5ae47739114bf669ab5e8ba0e767a282ad894f3b5e124197cb9224445ee
+  languageName: node
+  linkType: hard
+
+"@protobufjs/pool@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/pool@npm:1.1.0"
+  checksum: d6a34fbbd24f729e2a10ee915b74e1d77d52214de626b921b2d77288bd8f2386808da2315080f2905761527cceffe7ec34c7647bd21a5ae41a25e8212ff79451
+  languageName: node
+  linkType: hard
+
+"@protobufjs/utf8@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/utf8@npm:1.1.0"
+  checksum: f9bf3163d13aaa3b6f5e6fbf37a116e094ea021c0e1f2a7ccd0e12a29e2ce08dafba4e8b36e13f8ed7397e1591610ce880ed1289af4d66cf4ace8a36a9557278
   languageName: node
   linkType: hard
 
@@ -5095,6 +5260,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/long@npm:^4.0.1":
+  version: 4.0.2
+  resolution: "@types/long@npm:4.0.2"
+  checksum: d16cde7240d834cf44ba1eaec49e78ae3180e724cd667052b194a372f350d024cba8dd3f37b0864931683dab09ca935d52f0c4c1687178af5ada9fc85b0635f4
+  languageName: node
+  linkType: hard
+
 "@types/mdast@npm:^3.0.0":
   version: 3.0.10
   resolution: "@types/mdast@npm:3.0.10"
@@ -5139,6 +5311,13 @@ __metadata:
   version: 18.0.0
   resolution: "@types/node@npm:18.0.0"
   checksum: aab2b325727a2599f6d25ebe0dedf58c40fb66a51ce4ca9c0226ceb70fcda2d3afccdca29db5942eb48b158ee8585a274a1e3750c718bbd5399d7f41d62dfdcc
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:>=12.12.47, @types/node@npm:>=13.7.0":
+  version: 18.15.5
+  resolution: "@types/node@npm:18.15.5"
+  checksum: 5fbf3453bd5ce1402bb2964e55d928fc8a8a7de5451b1b0fe66587fecb8a3eb86854ca9cefa5076a5971e2cff00e1773ceeb5d872a54f6c6ddfbbc1064b4e91a
   languageName: node
   linkType: hard
 
@@ -14502,6 +14681,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.camelcase@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "lodash.camelcase@npm:4.3.0"
+  checksum: cb9227612f71b83e42de93eccf1232feeb25e705bdb19ba26c04f91e885bfd3dd5c517c4a97137658190581d3493ea3973072ca010aab7e301046d90740393d1
+  languageName: node
+  linkType: hard
+
 "lodash.debounce@npm:^4.0.8":
   version: 4.0.8
   resolution: "lodash.debounce@npm:4.0.8"
@@ -14586,6 +14772,20 @@ __metadata:
     slice-ansi: ^4.0.0
     wrap-ansi: ^6.2.0
   checksum: ae2f85bbabc1906034154fb7d4c4477c79b3e703d22d78adee8b3862fa913942772e7fa11713e3d96fb46de4e3cabefbf5d0a544344f03b58d3c4bff52aa9eb2
+  languageName: node
+  linkType: hard
+
+"long@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "long@npm:4.0.0"
+  checksum: 16afbe8f749c7c849db1f4de4e2e6a31ac6e617cead3bdc4f9605cb703cd20e1e9fc1a7baba674ffcca57d660a6e5b53a9e236d7b25a295d3855cca79cc06744
+  languageName: node
+  linkType: hard
+
+"long@npm:^5.0.0":
+  version: 5.2.1
+  resolution: "long@npm:5.2.1"
+  checksum: 9264da12d1b7df67e5aa6da4498144293caf1ad12e7f092efe4e9a2d32c53f0bbf7334f7cef997080a2a3af061142558ab366efa71698d98b1cdb883477445a7
   languageName: node
   linkType: hard
 
@@ -16967,6 +17167,26 @@ __metadata:
   dependencies:
     xtend: ^4.0.0
   checksum: fcf87c6542e59a8bbe31ca0b3255a4a63ac1059b01b04469680288998bcfa97f341ca989566adbb63975f4d85339030b82320c324a511532d390910d1c583893
+  languageName: node
+  linkType: hard
+
+"protobufjs@npm:^7.0.0":
+  version: 7.2.2
+  resolution: "protobufjs@npm:7.2.2"
+  dependencies:
+    "@protobufjs/aspromise": ^1.1.2
+    "@protobufjs/base64": ^1.1.2
+    "@protobufjs/codegen": ^2.0.4
+    "@protobufjs/eventemitter": ^1.1.0
+    "@protobufjs/fetch": ^1.1.0
+    "@protobufjs/float": ^1.0.2
+    "@protobufjs/inquire": ^1.1.0
+    "@protobufjs/path": ^1.1.2
+    "@protobufjs/pool": ^1.1.0
+    "@protobufjs/utf8": ^1.1.0
+    "@types/node": ">=13.7.0"
+    long: ^5.0.0
+  checksum: 86166e8f3e46789fa4d117ae72c17356db36bf87c0e0710d224be32e543b1c378a94e66dc2b1de5af45edfc25f56acfc7e688c50c956426a3ae97bc474f4445c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Purpose

Extend sign_message wallet API to support signing arbitrary data.

## Changes

- Extend wallet-api so signMessage can receive an object with data/schema instead of only a string.
- Fix signMessage error response, so it doesn't always say "signing was rejected".
- Bump web-sdk version.
- Add an example to the two-step-transfer that uses the new format.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.