### PR TITLE
Fix opening portals causing blank screen 

### DIFF
--- a/examples/two-step-transfer/index.html
+++ b/examples/two-step-transfer/index.html
@@ -123,7 +123,7 @@
                                 maxContractExecutionEnergy: 30000n,
                             },
                             {
-                                RequestTransfer: ['1000', '1', '3Y1RLgi5pW3x96xZ7CiDiKsTL9huU92qn6mfxpebwmtkeku8ry'],
+                                RequestTransfer: [1000, '1', '3Y1RLgi5pW3x96xZ7CiDiKsTL9huU92qn6mfxpebwmtkeku8ry'],
                             },
                             getSchema(
                                 twoStepTransferSchema,

--- a/packages/browser-wallet-api/src/constants.ts
+++ b/packages/browser-wallet-api/src/constants.ts
@@ -1,0 +1,8 @@
+export const serializationTypes = {
+    BigInt: 'bigint',
+    Date: 'date',
+    CcdAmount: 'ccdAmount',
+    AccountAddress: 'accountAddress',
+    ModuleReference: 'moduleReference',
+    DataBlob: 'dataBlob',
+};

--- a/packages/browser-wallet-api/src/util.ts
+++ b/packages/browser-wallet-api/src/util.ts
@@ -3,16 +3,8 @@ import { Buffer } from 'buffer/';
 import { CcdAmount } from '@concordium/common-sdk/lib/types/ccdAmount';
 import { AccountAddress } from '@concordium/common-sdk/lib/types/accountAddress';
 import { ModuleReference } from '@concordium/common-sdk/lib/types/moduleReference';
-import { DataBlob } from '@concordium/common-sdk';
-
-const types = {
-    BigInt: 'bigint',
-    Date: 'date',
-    CcdAmount: 'ccdAmount',
-    AccountAddress: 'accountAddress',
-    ModuleReference: 'moduleReference',
-    DataBlob: 'dataBlob',
-};
+import { DataBlob } from '@concordium/common-sdk/lib/types/DataBlob';
+import { serializationTypes } from './constants';
 
 function isGtuAmount(cand: any): cand is { microGtuAmount: bigint } {
     return cand && typeof cand.microGtuAmount === 'bigint';
@@ -35,59 +27,35 @@ function isDataBlob(cand: any): cand is DataBlob {
 }
 
 function replacer(this: any, k: string, value: any) {
-    if (typeof value === types.BigInt) {
-        return { '@type': types.BigInt, value: value.toString() };
+    if (typeof value === serializationTypes.BigInt) {
+        return { '@type': serializationTypes.BigInt, value: value.toString() };
     }
     const rawValue = this[k];
     if (rawValue instanceof Date) {
-        return { '@type': types.Date, value };
+        return { '@type': serializationTypes.Date, value };
     }
     // Support older versions of the SDK
     if (isGtuAmount(rawValue)) {
-        return { '@type': types.CcdAmount, value: rawValue.microGtuAmount.toString() };
+        return { '@type': serializationTypes.CcdAmount, value: rawValue.microGtuAmount.toString() };
     }
     if (isCcdAmount(rawValue)) {
-        return { '@type': types.CcdAmount, value: rawValue.microCcdAmount.toString() };
+        return { '@type': serializationTypes.CcdAmount, value: rawValue.microCcdAmount.toString() };
     }
     if (isAccountAddress(rawValue)) {
-        return { '@type': types.AccountAddress, value: rawValue.address };
+        return { '@type': serializationTypes.AccountAddress, value: rawValue.address };
     }
     if (isModuleReference(rawValue)) {
-        return { '@type': types.ModuleReference, value: rawValue.moduleRef };
+        return { '@type': serializationTypes.ModuleReference, value: rawValue.moduleRef };
     }
     if (isDataBlob(rawValue)) {
-        return { '@type': types.DataBlob, value: rawValue.data.toString('hex') };
+        return { '@type': serializationTypes.DataBlob, value: rawValue.data.toString('hex') };
     }
     return value;
 }
 
+/**
+ * Stringify that acts as an inverse for parse from browser-wallet @shared/utils/payload-helpers
+ */
 export function stringify(input: any) {
     return JSON.stringify(input, replacer);
-}
-
-export function parse(input: string | undefined) {
-    if (!input) {
-        return undefined;
-    }
-    return JSON.parse(input, (_, v) => {
-        if (v) {
-            switch (v['@type']) {
-                case types.BigInt:
-                    return BigInt(v.value);
-                case types.Date:
-                    return new Date(v.value);
-                case types.CcdAmount:
-                    return new CcdAmount(BigInt(v.value));
-                case types.AccountAddress:
-                    return new AccountAddress(v.value);
-                case types.ModuleReference:
-                    return new ModuleReference(v.value);
-                case types.DataBlob:
-                    return new DataBlob(Buffer.from(v.value, 'hex'));
-                default:
-                    return v;
-            }
-        }
-        return v;
-    });
 }

--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+-   Wallet crashing if sendTransaction contained parameters that could not be serialized. (The request is rejected instead)
 -   No longer crashes when opening modals (Like token raw metadata)
 
 ## 0.9.10

--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.9.11
+
+### Fixed
+
+-   No longer crashes when opening modals (Like token raw metadata)
+
 ## 0.9.10
 
 ### Changed

--- a/packages/browser-wallet/jest.config.ts
+++ b/packages/browser-wallet/jest.config.ts
@@ -9,7 +9,6 @@ const config: Config.InitialOptions = {
         ...pathsToModuleNameMapper(tsconfig.compilerOptions.paths, { prefix: '<rootDir>/' }),
         '@concordium/web-sdk': '@concordium/common-sdk',
         '^uuid$': 'uuid',
-        'wallet-common-helpers': '<rootDir>/../../node_modules/wallet-common-helpers/lib/index.js',
     },
     transformIgnorePatterns: ['/node_modules/(?!@concordium/common-sdk)'],
     modulePaths: ['<rootDir>/../../node_modules', '<rootDir>/node_modules'],

--- a/packages/browser-wallet/package.json
+++ b/packages/browser-wallet/package.json
@@ -43,7 +43,7 @@
         "react-window-infinite-loader": "^1.0.8",
         "readable-stream": "^4.2.0",
         "uuid": "^8.3.2",
-        "wallet-common-helpers": "https://github.com/Concordium/concordium-wallet-common-helpers.git#33f65c96e30baf165dd005bc58d261cfbf71118e"
+        "wallet-common-helpers": "https://github.com/Concordium/concordium-wallet-common-helpers.git#744f6914608b61b884b84203de774111ff0178e1"
     },
     "devDependencies": {
         "@babel/core": "^7.18.2",

--- a/packages/browser-wallet/package.json
+++ b/packages/browser-wallet/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/browser-wallet",
-    "version": "0.9.10",
+    "version": "0.9.11",
     "description": "Browser extension wallet for the Concordium blockchain",
     "author": "Concordium Software",
     "license": "Apache-2.0",

--- a/packages/browser-wallet/src/background/confirmation.ts
+++ b/packages/browser-wallet/src/background/confirmation.ts
@@ -12,7 +12,7 @@ import {
 } from '@shared/storage/types';
 import { loop, not } from '@shared/utils/function-helpers';
 import { identityMatch } from '@shared/utils/identity-helpers';
-import { IdentityTokenContainer, IdentityProviderIdentityStatus } from 'wallet-common-helpers/lib/utils/identity/types';
+import { IdentityTokenContainer, IdentityProviderIdentityStatus } from 'wallet-common-helpers';
 import { updateCredentials, updateIdentities } from './update';
 
 const isPendingCred = (cred: WalletCredential): cred is PendingWalletCredential =>

--- a/packages/browser-wallet/src/background/index.ts
+++ b/packages/browser-wallet/src/background/index.ts
@@ -20,6 +20,8 @@ import { ChromeStorageKey, NetworkConfiguration } from '@shared/storage/types';
 import { buildURLwithSearchParameters } from '@shared/utils/url-helpers';
 import { getTermsAndConditionsConfig } from '@shared/utils/network-helpers';
 import { Buffer } from 'buffer/';
+import { BackgroundSendTransactionPayload } from '@shared/utils/types';
+import { parsePayload } from '@shared/utils/payload-helpers';
 import bgMessageHandler from './message-handler';
 import {
     forwardToPopup,
@@ -244,6 +246,21 @@ const ensureMessageWithSchemaParse: RunCondition<MessageStatusWrapper<undefined>
     }
 };
 
+/**
+ * Run condition for signMessage, which ensures the message is either a string,
+ * or a messageObject and in that case that the schema can be used to deserialize the message data.
+ */
+const ensureTransactionPayloadParse: RunCondition<MessageStatusWrapper<undefined>> = async (msg) => {
+    const payload = msg.payload as BackgroundSendTransactionPayload;
+
+    try {
+        parsePayload(payload.type, payload.payload, payload.parameters, payload.schema, payload.schemaVersion);
+    } catch (e) {
+        return { run: false, response: { success: false, message: `The given transaction is not valid due to: ${e}` } };
+    }
+    return { run: true };
+};
+
 // TODO change this to find most recently selected account
 /**
  * Finds the most prioritized account that is connected to the provided site.
@@ -385,7 +402,7 @@ forwardToPopup(
 forwardToPopup(
     MessageType.SendTransaction,
     InternalMessageType.SendTransaction,
-    runConditionComposer(runIfWhitelisted, withPromptStart),
+    runConditionComposer(runIfWhitelisted, ensureTransactionPayloadParse, withPromptStart),
     appendUrlToPayload,
     undefined,
     withPromptEnd

--- a/packages/browser-wallet/src/background/index.ts
+++ b/packages/browser-wallet/src/background/index.ts
@@ -247,8 +247,7 @@ const ensureMessageWithSchemaParse: RunCondition<MessageStatusWrapper<undefined>
 };
 
 /**
- * Run condition for signMessage, which ensures the message is either a string,
- * or a messageObject and in that case that the schema can be used to deserialize the message data.
+ * Run condition for sendTransaction, which ensures that the transaction can be parsed (including that parameters can be serialized).
  */
 const ensureTransactionPayloadParse: RunCondition<MessageStatusWrapper<undefined>> = async (msg) => {
     const payload = msg.payload as BackgroundSendTransactionPayload;

--- a/packages/browser-wallet/src/popup/pages/Account/DisplayAddress/DisplayAddress.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/DisplayAddress/DisplayAddress.tsx
@@ -1,8 +1,7 @@
 import CopyButton from '@popup/shared/CopyButton';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import DisplayAsQR from 'wallet-common-helpers/src/components/DisplayAsQR';
-import DisplayAccountAddress, { AddressDisplayFormat } from 'wallet-common-helpers/src/components/DisplayAddress';
+import { DisplayAsQR, DisplayAddress as DisplayAccountAddress, AddressDisplayFormat } from 'wallet-common-helpers';
 import { useAtomValue } from 'jotai';
 import { selectedAccountAtom } from '@popup/store/account';
 

--- a/packages/browser-wallet/src/popup/pages/Account/TransactionLog/TransactionElement.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/TransactionLog/TransactionElement.tsx
@@ -3,7 +3,7 @@ import React, { CSSProperties } from 'react';
 import DoubleCheckmarkIcon from '@assets/svg/double-grey-checkmark.svg';
 import PendingIcon from '@assets/svg/clock.svg';
 import Warning from '@assets/svg/warning.svg';
-import { displayAsCcd } from 'wallet-common-helpers/lib/utils/ccd';
+import { displayAsCcd, dateFromTimestamp, TimeStampUnit } from 'wallet-common-helpers';
 import {
     BrowserWalletTransaction,
     isAccountTransaction,
@@ -11,7 +11,6 @@ import {
     SpecialTransactionType,
     TransactionStatus,
 } from '@popup/shared/utils/transaction-history-types';
-import { dateFromTimestamp, TimeStampUnit } from 'wallet-common-helpers';
 import clsx from 'clsx';
 import { AccountTransactionType } from '@concordium/web-sdk';
 

--- a/packages/browser-wallet/src/popup/pages/SendTransaction/SendTransaction.tsx
+++ b/packages/browser-wallet/src/popup/pages/SendTransaction/SendTransaction.tsx
@@ -28,7 +28,7 @@ import {
 } from '@shared/utils/energy-helpers';
 import { calculateEnergyCost } from '@shared/utils/token-helpers';
 import { SmartContractParameters, SchemaWithContext } from '@concordium/browser-wallet-api-helpers';
-import { parsePayload } from './util';
+import { parsePayload } from '@shared/utils/payload-helpers';
 
 interface Location {
     state: {

--- a/packages/browser-wallet/src/popup/pages/SendTransaction/SendTransaction.tsx
+++ b/packages/browser-wallet/src/popup/pages/SendTransaction/SendTransaction.tsx
@@ -3,7 +3,7 @@ import { useAtomValue, useSetAtom } from 'jotai';
 import { fullscreenPromptContext } from '@popup/page-layouts/FullscreenPromptLayout';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
-import { AccountTransactionType, AccountAddress, SchemaVersion } from '@concordium/web-sdk';
+import { AccountTransactionType, AccountAddress } from '@concordium/web-sdk';
 import { usePrivateKey } from '@popup/shared/utils/account-helpers';
 import {
     sendTransaction,
@@ -27,20 +27,12 @@ import {
     SIMPLE_TRANSFER_ENERGY_TOTAL_COST,
 } from '@shared/utils/energy-helpers';
 import { calculateEnergyCost } from '@shared/utils/token-helpers';
-import { SmartContractParameters, SchemaWithContext } from '@concordium/browser-wallet-api-helpers';
 import { parsePayload } from '@shared/utils/payload-helpers';
+import { BackgroundSendTransactionPayload } from '@shared/utils/types';
 
 interface Location {
     state: {
-        payload: {
-            accountAddress: string;
-            type: AccountTransactionType;
-            payload: string;
-            parameters?: SmartContractParameters;
-            schema?: SchemaWithContext;
-            schemaVersion?: SchemaVersion;
-            url: string;
-        };
+        payload: BackgroundSendTransactionPayload;
     };
 }
 

--- a/packages/browser-wallet/src/popup/shared/TransactionReceipt/TransactionReceipt.tsx
+++ b/packages/browser-wallet/src/popup/shared/TransactionReceipt/TransactionReceipt.tsx
@@ -2,8 +2,6 @@
 import clsx from 'clsx';
 import { useTranslation } from 'react-i18next';
 import React, { useState } from 'react';
-import DisplayAddress, { AddressDisplayFormat } from 'wallet-common-helpers/src/components/DisplayAddress';
-import { chunkString } from 'wallet-common-helpers';
 import {
     AccountTransactionType,
     AccountTransaction,
@@ -17,6 +15,7 @@ import { Cis2TransferParameters } from '@shared/utils/types';
 import { SmartContractParameters } from '@concordium/browser-wallet-api-helpers';
 import { TokenMetadata } from '@shared/storage/types';
 import { getMetadataDecimals } from '@shared/utils/token-helpers';
+import { chunkString, DisplayAddress, AddressDisplayFormat } from 'wallet-common-helpers';
 import DisplayCost from './DisplayCost';
 import { getTransactionTypeName } from '../utils/transaction-helpers';
 import DisplayUpdateContract from './displayPayload/DisplayUpdateContract';

--- a/packages/browser-wallet/src/popup/shared/TransactionReceipt/displayPayload/DisplayGenericPayload.tsx
+++ b/packages/browser-wallet/src/popup/shared/TransactionReceipt/displayPayload/DisplayGenericPayload.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { AccountTransactionPayload, AccountAddress, CcdAmount } from '@concordium/web-sdk';
-import DisplayAddress, { AddressDisplayFormat } from 'wallet-common-helpers/src/components/DisplayAddress';
-import { displayAsCcd } from 'wallet-common-helpers/lib/utils/ccd';
+import { displayAsCcd, DisplayAddress, AddressDisplayFormat } from 'wallet-common-helpers';
 
 interface Props {
     payload: AccountTransactionPayload;

--- a/packages/browser-wallet/src/popup/shared/TransactionReceipt/displayPayload/DisplayInitContract.tsx
+++ b/packages/browser-wallet/src/popup/shared/TransactionReceipt/displayPayload/DisplayInitContract.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { InitContractPayload } from '@concordium/web-sdk';
-import { displayAsCcd } from 'wallet-common-helpers/lib/utils/ccd';
+import { displayAsCcd } from 'wallet-common-helpers';
 import { SmartContractParameters } from '@concordium/browser-wallet-api-helpers';
 import DisplayParameters from '../DisplayParameters';
 

--- a/packages/browser-wallet/src/popup/shared/TransactionReceipt/displayPayload/DisplaySimpleTransfer.tsx
+++ b/packages/browser-wallet/src/popup/shared/TransactionReceipt/displayPayload/DisplaySimpleTransfer.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { SimpleTransferPayload } from '@concordium/web-sdk';
-import { displayAsCcd } from 'wallet-common-helpers/lib/utils/ccd';
-import DisplayAddress, { AddressDisplayFormat } from 'wallet-common-helpers/src/components/DisplayAddress';
+import { displayAsCcd, DisplayAddress, AddressDisplayFormat } from 'wallet-common-helpers';
 
 interface Props {
     payload: SimpleTransferPayload;

--- a/packages/browser-wallet/src/popup/shared/TransactionReceipt/displayPayload/DisplayUpdateContract.tsx
+++ b/packages/browser-wallet/src/popup/shared/TransactionReceipt/displayPayload/DisplayUpdateContract.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { UpdateContractPayload } from '@concordium/web-sdk';
-import { displayAsCcd } from 'wallet-common-helpers/lib/utils/ccd';
+import { displayAsCcd } from 'wallet-common-helpers';
 import { SmartContractParameters } from '@concordium/browser-wallet-api-helpers';
 import DisplayParameters from '../DisplayParameters';
 

--- a/packages/browser-wallet/src/popup/store/token.ts
+++ b/packages/browser-wallet/src/popup/store/token.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { Atom, atom } from 'jotai';
-import { mapRecordValues } from 'wallet-common-helpers/src/utils/basicHelpers';
+import { mapRecordValues } from 'wallet-common-helpers';
 import { atomFamily } from 'jotai/utils';
 import { ChromeStorageKey, TokenIdAndMetadata, TokenMetadata, TokenStorage } from '@shared/storage/types';
 import { ContractBalances, getContractBalances } from '@shared/utils/token-helpers';

--- a/packages/browser-wallet/src/shared/utils/types.ts
+++ b/packages/browser-wallet/src/shared/utils/types.ts
@@ -1,5 +1,9 @@
 /* eslint-disable @typescript-eslint/ban-types */
-import { IdProofOutput } from '@concordium/web-sdk';
+import {
+    SchemaWithContext,
+    SmartContractParameters,
+} from '@concordium/browser-wallet-api-helpers/lib/wallet-api-types';
+import type { IdProofOutput, SchemaVersion, AccountTransactionType } from '@concordium/web-sdk';
 import { RefAttributes } from 'react';
 /**
  * @description
@@ -69,3 +73,13 @@ export type Cis2TransferParameters = [
         to: Cis2TransferParametersAccount;
     }
 ];
+
+export type BackgroundSendTransactionPayload = {
+    accountAddress: string;
+    type: AccountTransactionType;
+    payload: string;
+    parameters?: SmartContractParameters;
+    schema?: SchemaWithContext;
+    schemaVersion?: SchemaVersion;
+    url: string;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2018,7 +2018,7 @@ __metadata:
     tsconfig-paths-webpack-plugin: ^3.5.2
     typescript: ^4.3.5
     uuid: ^8.3.2
-    wallet-common-helpers: "https://github.com/Concordium/concordium-wallet-common-helpers.git#33f65c96e30baf165dd005bc58d261cfbf71118e"
+    wallet-common-helpers: "https://github.com/Concordium/concordium-wallet-common-helpers.git#744f6914608b61b884b84203de774111ff0178e1"
   languageName: unknown
   linkType: soft
 
@@ -2039,7 +2039,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@concordium/common-sdk@npm:6.2.0, @concordium/common-sdk@npm:^6.2.0":
+"@concordium/common-sdk@npm:6.2.0":
   version: 6.2.0
   resolution: "@concordium/common-sdk@npm:6.2.0"
   dependencies:
@@ -2057,7 +2057,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@concordium/common-sdk@npm:6.4.0, @concordium/common-sdk@npm:^6.4.0":
+"@concordium/common-sdk@npm:6.4.0, @concordium/common-sdk@npm:^6.3.0, @concordium/common-sdk@npm:^6.4.0":
   version: 6.4.0
   resolution: "@concordium/common-sdk@npm:6.4.0"
   dependencies:
@@ -22251,11 +22251,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wallet-common-helpers@https://github.com/Concordium/concordium-wallet-common-helpers.git#33f65c96e30baf165dd005bc58d261cfbf71118e":
+"wallet-common-helpers@https://github.com/Concordium/concordium-wallet-common-helpers.git#744f6914608b61b884b84203de774111ff0178e1":
   version: 1.5.0
-  resolution: "wallet-common-helpers@https://github.com/Concordium/concordium-wallet-common-helpers.git#commit=33f65c96e30baf165dd005bc58d261cfbf71118e"
+  resolution: "wallet-common-helpers@https://github.com/Concordium/concordium-wallet-common-helpers.git#commit=744f6914608b61b884b84203de774111ff0178e1"
   dependencies:
-    "@concordium/common-sdk": ^6.2.0
+    "@concordium/common-sdk": ^6.3.0
     buffer: ^6.0.3
     cbor: ^8.0.0
     clsx: ^1.1.1
@@ -22264,7 +22264,7 @@ __metadata:
   peerDependencies:
     react: ">=16"
     react-dom: ">=16"
-  checksum: d382487092aca3a07102d4d3e2306b0ba1f4df9298a3dbdbe4b75b6bf87003c4f5cc68c5c540e78b35468ab90442f75fbd837da2c6046ff6a8357baa4965ebb8
+  checksum: c70afe4a8908e566cfea405d0755267d8a4a96a0cc92bfed0d1121b4d8c2a4f193a1fdf95c429fa4f3fdef6cb52ae5c62f55a2ed60ba20c2f27cc7cbac42bfda
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Purpose

 - Fix crashes when opening token raw Metadata (and other modals) 
 - Fix bad parameters from dApps crashing the wallet (the request is now rejected instead)

## Changes

Use updated wallet-common-helpers that support both commonJS (for tests) and ES Modules (for the wallet itself)
 - I recently changed that library to use commonJS modules instead of ES, to make the tests run, but it turns out that references to react-dom then stopped working. Now it uses compiles both versions and we use ES modules in the wallet build and commonJS when running the tests now.
 
 To fix the bad parameters crashing the wallet, I've added a check in the background script that rejects the transaction, if we are unable to serialize the parameters.
 - I had to move some things around, because the parse function we use for serialized values between the dApp/background/popup was located in the API, which uses the common-sdk (to avoid injecting wasm on websites), but that causes the background script to crash. 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
