### PR TITLE
Do not display extra decimals on commissions

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 -   Improved readability of events in transaction details.
+-   Baker transactions no longer display a minimum of 3 decimals when confirming the transaction.
 
 ## 1.0.0
 

--- a/packages/browser-wallet/src/popup/shared/utils/baking-helpers.ts
+++ b/packages/browser-wallet/src/popup/shared/utils/baking-helpers.ts
@@ -26,7 +26,7 @@ export function openStatusToDisplay(status: OpenStatus | OpenStatusText): string
     }
 }
 
-const formatCommission = toFixed(3);
+const formatCommission = toFixed(0);
 
 export const displayDecimalCommissionRate = (value: number) => formatCommission((value * 100).toString());
 export const displayFractionCommissionRate = (value: number) =>


### PR DESCRIPTION
## Purpose

Do not display extra decimals on commissions

## Changes

Set minimum decimals to 0 on commissions.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
