### PR TITLE
Fix duplicate identity names after recovery 

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Improved readability of events in transaction details.
 
+### Fixed
+
+-   Recovery no longer assigns duplicate names to identities when new identities are visited earlier than existing ones during the recovery process.
+
 ## 1.0.0
 
 ### Added


### PR DESCRIPTION
## Purpose

Fix duplicate identity names after recovery 

## Changes

Identity nextId is no longer incremented by existing identities, it is now initialized to after the existing amount

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
