### PR TITLE
Fix issue with baker/delegation navigation when switching account

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 -   In the manage page for adding CIS-2 tokens, the contract index is now always initially empty.
+-   Incorrect navigation flow on the "earn" page when switching between accounts.
 
 ### Fixed
 

--- a/packages/browser-wallet/src/popup/pages/Account/Earn/Earn.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/Earn/Earn.tsx
@@ -16,9 +16,8 @@ import { useSelectedAccountInfo } from '@popup/shared/AccountInfoListenerContext
 import { useHasPendingTransaction } from '@popup/shared/utils/transaction-helpers';
 import { useAtomValue } from 'jotai';
 import { grpcClientAtom } from '@popup/store/settings';
-import { displayAsCcd, useAsyncMemo, useUpdateEffect } from 'wallet-common-helpers';
+import { displayAsCcd, useAsyncMemo } from 'wallet-common-helpers';
 import ButtonGroup from '@popup/shared/ButtonGroup';
-import { selectedAccountAtom } from '@popup/store/account';
 import { absoluteRoutes } from '@popup/constants/routes';
 import { useBlockChainParameters } from '@popup/shared/BlockChainParametersProvider';
 import Baking from './Baking';
@@ -40,19 +39,6 @@ const defaultBakingMinimumEquityCapital = 14000000000n;
 
 function Earn({ chainParameters }: EarnProps) {
     const { t } = useTranslation('account', { keyPrefix: 'earn' });
-    const accountInfo = ensureDefined(useSelectedAccountInfo(), 'Expected to find account info for selected account');
-    const nav = useNavigate();
-
-    const hasPendingDelegationTransaction = useHasPendingTransaction(AccountTransactionType.ConfigureDelegation);
-    const hasPendingBakerTransaction = useHasPendingTransaction(AccountTransactionType.ConfigureBaker);
-
-    useEffect(() => {
-        if (isDelegatorAccount(accountInfo) || hasPendingDelegationTransaction) {
-            nav(routes.delegate);
-        } else if (isBakerAccount(accountInfo) || hasPendingBakerTransaction) {
-            nav(routes.baking);
-        }
-    }, [accountInfo]);
 
     return (
         <div className="earn-page">
@@ -88,12 +74,20 @@ function Earn({ chainParameters }: EarnProps) {
 
 export default function EarnRoutes() {
     const { setDetailsExpanded } = useContext(accountPageContext);
-    const account = useAtomValue(selectedAccountAtom);
+    const accountInfo = ensureDefined(useSelectedAccountInfo(), 'Expected to find account info for selected account');
     const nav = useNavigate();
+    const hasPendingDelegationTransaction = useHasPendingTransaction(AccountTransactionType.ConfigureDelegation);
+    const hasPendingBakerTransaction = useHasPendingTransaction(AccountTransactionType.ConfigureBaker);
 
-    useUpdateEffect(() => {
-        nav(`${absoluteRoutes.home.account.path}/${accountRoutes.earn}`);
-    }, [account]);
+    useEffect(() => {
+        if (isDelegatorAccount(accountInfo) || hasPendingDelegationTransaction) {
+            nav(routes.delegate);
+        } else if (isBakerAccount(accountInfo) || hasPendingBakerTransaction) {
+            nav(routes.baking);
+        } else {
+            nav(`${absoluteRoutes.home.account.path}/${accountRoutes.earn}`);
+        }
+    }, [accountInfo]);
 
     const client = useAtomValue(grpcClientAtom);
     const chainParameters = useBlockChainParameters();


### PR DESCRIPTION
## Purpose
Ensure that the correct screen is shown when switching account while in the "earn" tab.

## Changes
- Move check of whether the account is a baker or delegator, and navigate accordingly, to the base component.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.