### PR TITLE
Update baking/delegation defaults to align with mobile wallets

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -7,6 +7,8 @@
 -   Improved readability of events in transaction details.
 -   When choosing baker stake amount, the minimumEquityCapital is no longer the default value for non bakers.
 -   Baker transactions no longer display a minimum of 3 decimals when confirming the transaction.
+-   When registering as a baker, restaking and being open for delegation are now the default options.
+-   When registering for delegation, restaking and targeting a baker are now the default options.
 
 ### Fixed
 

--- a/packages/browser-wallet/src/popup/pages/Account/Earn/Baking/FlowPages/OpenForDelegation.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/Earn/Baking/FlowPages/OpenForDelegation.tsx
@@ -23,7 +23,7 @@ export default function OpenForDelegationPage({ initial, onNext, accountInfo }: 
     const { t: tShared } = useTranslation('shared', { keyPrefix: 'baking' });
     const { t } = useTranslation('account', { keyPrefix: 'baking.configure' });
     const defaultValues: Partial<OpenForDelegationForm> = useMemo(
-        () => (initial === undefined ? { openForDelegation: OpenStatus.ClosedForAll } : { openForDelegation: initial }),
+        () => (initial === undefined ? { openForDelegation: OpenStatus.OpenForAll } : { openForDelegation: initial }),
         [initial]
     );
     const onSubmit = (vs: OpenForDelegationForm) => onNext(vs.openForDelegation);

--- a/packages/browser-wallet/src/popup/pages/Account/Earn/Baking/FlowPages/Restake.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/Earn/Baking/FlowPages/Restake.tsx
@@ -16,7 +16,7 @@ type RestakePageProps = MultiStepFormPageProps<ConfigureBakerFlowState['restake'
 export default function RestakePage({ initial, onNext }: RestakePageProps) {
     const { t } = useTranslation('account', { keyPrefix: 'baking.configure' });
     const defaultValues: Partial<RestakePageForm> = useMemo(
-        () => (initial === undefined ? { restake: false } : { restake: initial }),
+        () => (initial === undefined ? { restake: true } : { restake: initial }),
         [initial]
     );
     const onSubmit = (vs: RestakePageForm) => onNext(vs.restake);

--- a/packages/browser-wallet/src/popup/pages/Account/Earn/Delegate/ConfigureDelegationFlow.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/Earn/Delegate/ConfigureDelegationFlow.tsx
@@ -57,7 +57,7 @@ function PoolPage({ onNext, initial, accountInfo }: PoolPageProps) {
     const client = useAtomValue(grpcClientAtom);
     const form = useForm<PoolPageForm>({
         defaultValues:
-            initial === null || initial === undefined ? { isBaker: false } : { isBaker: true, bakerId: initial },
+            initial === null || initial === undefined ? { isBaker: true } : { isBaker: true, bakerId: initial },
     });
     const isBakerValue = form.watch('isBaker');
 
@@ -297,7 +297,7 @@ type RestakePageProps = MultiStepFormPageProps<
 function RestakePage({ initial, onNext }: RestakePageProps) {
     const { t } = useTranslation('account', { keyPrefix: 'delegate.configure' });
     const defaultValues: Partial<RestakePageForm> = useMemo(
-        () => (initial === undefined ? { redelegate: false } : { redelegate: initial }),
+        () => (initial === undefined ? { redelegate: true } : { redelegate: initial }),
         [initial]
     );
     const onSubmit = (vs: RestakePageForm) => onNext(vs.redelegate);


### PR DESCRIPTION
## Purpose

Align default options with mobile wallet.

## Changes

- Change baker defaults for `restake` and `poolStatus`.
- Change delegation defaults for `restake` and `target`. 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
