### PR TITLE
Fix addCIS2Tokens adding tokens to selected account

### DIFF
--- a/examples/two-step-transfer/index.html
+++ b/examples/two-step-transfer/index.html
@@ -199,6 +199,12 @@
                         })
                         .catch(alert);
                 });
+                document.getElementById('addWCCD').addEventListener('click', () => {
+                    provider
+                        .addCIS2Tokens(currentAccountAddress, [''], 2059n, 0n)
+                        .then((added) => alert('Added tokens: ' + added.map((id) => '"' + id + '"')))
+                        .catch(alert);
+                });
             }
 
             setupPage();
@@ -226,5 +232,6 @@
         <button id="signMessageBinary">SignSponsoredTransactionLikeMessage</button>
         <button id="registerData">Register message (HEX encoded) (must be a hex string)</button>
         <button id="registerDataCBOR">Register message (CBOR encoded)</button>
+        <button id="addWCCD">Add WCCD view</button>
     </body>
 </html>

--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -13,6 +13,7 @@
 -   In the manage page for adding CIS-2 tokens, the contract index is now always initially empty.
 -   Incorrect navigation flow on the "earn" page when switching between accounts.
 -   Recovery no longer assigns duplicate names to identities when new identities are visited earlier than existing ones during the recovery process.
+-   AddCIS2Tokens through API now adds tokens to the given account, instead of the currently selected one.
 
 ## 1.0.0
 


### PR DESCRIPTION
## Purpose

Fix addCIS2Tokens adding tokens to selected account.

## Changes

- Adding a set function to accountTokensFamily.
- addCIS2Tokens now adds token to the connected/request account instead of the currently selected one.
- add button to add WCCD in two-step-transfer.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

