### PR TITLE
Fix behaviour when attempting to creating existing account

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 -   Support for eID (Criipto) identity document types.
+-   When creating an account that already exist, it will now be added to the wallet.
 
 ### Changed
 

--- a/packages/browser-wallet/package.json
+++ b/packages/browser-wallet/package.json
@@ -18,6 +18,7 @@
         "@concordium/browser-wallet-api": "workspace:^",
         "@concordium/browser-wallet-api-helpers": "workspace:^",
         "@concordium/web-sdk": "^3.4.0",
+        "@protobuf-ts/runtime-rpc": "^2.8.2",
         "@scure/bip39": "^1.1.0",
         "axios": "^0.27.2",
         "buffer": "^6.0.3",

--- a/packages/browser-wallet/src/background/confirmation.ts
+++ b/packages/browser-wallet/src/background/confirmation.ts
@@ -51,20 +51,6 @@ async function monitorCredentialStatus(initialNetwork: NetworkConfiguration, cre
 
         try {
             const response = await client.getBlockItemStatus(deploymentHash);
-            // transaction has been discarded by the node.
-            if (!response) {
-                await updateCredentials(
-                    [
-                        {
-                            ...info,
-                            status: CreationStatus.Rejected,
-                        },
-                    ],
-                    genesisHash
-                );
-                return false;
-            }
-
             // transaction has not finalized yet
             if (response?.status !== TransactionStatusEnum.Finalized) {
                 return true;
@@ -80,7 +66,20 @@ async function monitorCredentialStatus(initialNetwork: NetworkConfiguration, cre
                 genesisHash
             );
             return false;
-        } catch {
+        } catch (e) {
+            // transaction has been discarded by the node.
+            if ((e as Error).message.includes('transaction%20not%20found')) {
+                await updateCredentials(
+                    [
+                        {
+                            ...info,
+                            status: CreationStatus.Rejected,
+                        },
+                    ],
+                    genesisHash
+                );
+                return false;
+            }
             return true;
         }
     });

--- a/packages/browser-wallet/src/background/confirmation.ts
+++ b/packages/browser-wallet/src/background/confirmation.ts
@@ -14,6 +14,7 @@ import {
 import { loop, not } from '@shared/utils/function-helpers';
 import { identityMatch } from '@shared/utils/identity-helpers';
 import { IdentityTokenContainer, IdentityProviderIdentityStatus } from 'wallet-common-helpers';
+import type { RpcError } from '@protobuf-ts/runtime-rpc';
 import { updateCredentials, updateIdentities } from './update';
 
 const isPendingCred = (cred: WalletCredential): cred is PendingWalletCredential =>
@@ -68,7 +69,7 @@ async function monitorCredentialStatus(initialNetwork: NetworkConfiguration, cre
             return false;
         } catch (e) {
             // transaction has been discarded by the node.
-            if ((e as Error).message.includes('transaction%20not%20found')) {
+            if ((e as RpcError).code === 'NOT_FOUND') {
                 await updateCredentials(
                     [
                         {

--- a/packages/browser-wallet/src/background/credential-deployment.ts
+++ b/packages/browser-wallet/src/background/credential-deployment.ts
@@ -49,7 +49,7 @@ async function createAndSendCredential(credIn: CredentialInput): Promise<Credent
         };
 
         // Send Request
-        const successful = createConcordiumClient(network.grpcUrl, network.grpcPort, {
+        const successful = await createConcordiumClient(network.grpcUrl, network.grpcPort, {
             timeout: GRPCTIMEOUT,
         }).sendCredentialDeploymentTransaction(request, [signature]);
         if (!successful) {

--- a/packages/browser-wallet/src/background/credential-deployment.ts
+++ b/packages/browser-wallet/src/background/credential-deployment.ts
@@ -56,21 +56,25 @@ async function createAndSendCredential(credIn: CredentialInput): Promise<Credent
         // Check that the credential has not already been deployed:
         try {
             const accountInfo = await client.getAccountInfo(new CredentialRegistrationId(credId));
+            const existingAddress = accountInfo.accountAddress;
             await addCredential(
                 {
                     identityIndex,
                     providerIndex,
                     credId,
                     credNumber,
-                    address: accountInfo.accountAddress,
+                    address: existingAddress,
                     status: CreationStatus.Confirmed,
                 },
                 network.genesisHash
             );
 
+            // Set Selected to new account
+            await storedSelectedAccount.set(existingAddress);
+
             return {
                 status: BackgroundResponseStatus.Aborted,
-                address,
+                address: existingAddress,
             };
         } catch {
             // If an error is thrown, we assume this is because the credential has not been deployed yet.

--- a/packages/browser-wallet/src/popup/pages/AddAccount/Confirm.tsx
+++ b/packages/browser-wallet/src/popup/pages/AddAccount/Confirm.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useCallback } from 'react';
+import React, { useMemo, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { useNavigate } from 'react-router-dom';
@@ -20,6 +20,7 @@ import { getGlobal, getNet } from '@shared/utils/network-helpers';
 import { addToastAtom } from '@popup/state';
 import { getNextEmptyCredNumber } from '@popup/shared/utils/account-helpers';
 import { useDecryptedSeedPhrase } from '@popup/shared/utils/seed-phrase-helpers';
+import Modal from '@popup/shared/Modal';
 import AccountDetails from '../Account/AccountDetails';
 
 export default function Confirm() {
@@ -33,6 +34,7 @@ export default function Confirm() {
     const addToast = useSetAtom(addToastAtom);
     const seedPhrase = useDecryptedSeedPhrase((e) => addToast(e.message));
     const [creatingCredentialRequest, setCreatingRequest] = useAtom(creatingCredentialRequestAtom);
+    const [accountRecovered, setAccountRecovered] = useState(false);
 
     const identityProvider = useMemo(
         () => providers.find((p) => p.ipInfo.ipIdentity === selectedIdentity?.providerIndex),
@@ -77,6 +79,8 @@ export default function Confirm() {
             );
             if (response.status === BackgroundResponseStatus.Success) {
                 nav(absoluteRoutes.home.account.path);
+            } else if (response.status === BackgroundResponseStatus.Aborted) {
+                setAccountRecovered(true);
             } else {
                 addToast(response.error);
             }
@@ -94,6 +98,12 @@ export default function Confirm() {
     // TODO: Better faking of AccountDetails
     return (
         <div className="flex-column align-center">
+            <Modal open={Boolean(accountRecovered)} disableClose>
+                <p>{t('accountRecovered')}</p>
+                <Button width="wide" onClick={() => nav(absoluteRoutes.home.account.path)}>
+                    {t('goToAccount')}
+                </Button>
+            </Modal>
             <div className="w-full relative">
                 <AccountDetails
                     className="add-account-page__blur-details"

--- a/packages/browser-wallet/src/popup/pages/AddAccount/i18n/da.ts
+++ b/packages/browser-wallet/src/popup/pages/AddAccount/i18n/da.ts
@@ -7,6 +7,9 @@ const t: typeof en = {
     createIdentity: 'Opret identitet',
     maxAccountsReached:
         'Denne identitet har oprettet alle tilladte konti. For at lave flere konti skal du bruge en anden Concordium identitet.',
+    accountRecovered:
+        'Kontoen, der forsøgtes at blive oprettet, eksisterer allerede. Den er blevet tilføjet til denne wallet.',
+    goToAccount: 'Vis kontoen',
 };
 
 export default t;

--- a/packages/browser-wallet/src/popup/pages/AddAccount/i18n/en.ts
+++ b/packages/browser-wallet/src/popup/pages/AddAccount/i18n/en.ts
@@ -5,6 +5,8 @@ const t = {
     createIdentity: 'Create new identity',
     maxAccountsReached:
         'This identity has reached its account creation limit. To create more accounts you must use another Concordium identity.',
+    accountRecovered: 'The account that was attempted to be created already exists. It has been added to the wallet.',
+    goToAccount: 'Go to the account',
 };
 
 export default t;

--- a/packages/browser-wallet/src/shared/utils/types.ts
+++ b/packages/browser-wallet/src/shared/utils/types.ts
@@ -35,6 +35,11 @@ export type CredentialDeploymentBackgroundResponse =
     | {
           status: BackgroundResponseStatus.Error;
           reason: string;
+      }
+    | {
+          // Used to indicate that the credential has already been deployed, with the address supplied being the address of the associated account
+          status: BackgroundResponseStatus.Aborted;
+          address: string;
       };
 
 export type IdProofBackgroundResponse =

--- a/yarn.lock
+++ b/yarn.lock
@@ -1961,6 +1961,7 @@ __metadata:
     "@concordium/web-sdk": ^3.4.0
     "@craftamap/esbuild-plugin-html": ^0.4.0
     "@mdx-js/react": ^1.6.22
+    "@protobuf-ts/runtime-rpc": ^2.8.2
     "@scure/bip39": ^1.1.0
     "@storybook/addon-actions": ^6.5.7
     "@storybook/addon-docs": ^6.5.7


### PR DESCRIPTION
## Purpose

Fix bad behaviour, which has recently worsened, when creating an existing account.

## Changes

- Add existing account when trying to recreate it.
- Add missing await in credential-deployment.
- Fix `monitorCredentialStatus` not halting when "transaction not found".

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
