### PR TITLE
Remove double unit for CCD in token overview

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -21,6 +21,7 @@
 -   Incorrect navigation flow on the "earn" page when switching between accounts.
 -   Recovery no longer assigns duplicate names to identities when new identities are visited earlier than existing ones during the recovery process.
 -   Missing translations for some identity attributes.
+-   Removed double unit on CCD in token overview.
 
 ### Fixed
 

--- a/packages/browser-wallet/src/popup/pages/Account/Tokens/Tokens.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/Tokens/Tokens.tsx
@@ -106,7 +106,7 @@ function Fungibles({ account, toDetails }: ListProps) {
                 <CcdIcon className="token-list__icon token-list__icon--ccd" />
                 <div>
                     <div className="token-list__name">{CCD_METADATA.name}</div>
-                    <div className="token-list__balance">{displayAsCcd(accountInfo.accountAmount)} CCD</div>
+                    <div className="token-list__balance">{displayAsCcd(accountInfo.accountAmount)}</div>
                 </div>
             </div>
             {tokens.map((token) => (


### PR DESCRIPTION
## Purpose

Fix double unit on CCD in the token overview.

## Changes

Removed CCD unit display after CCD amount in token overview.  

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.