### PR TITLE
Baker crash

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -7,6 +7,7 @@
 -   Some issues in the baking and delegation text.
 -   Added missing key to events in the list of events inside the transaction details.
 -   Baking and delegation icons now also work in dark mode.
+-   An application crash when attempting to update the baker stake.
 
 ## 1.0.1
 

--- a/packages/browser-wallet/package.json
+++ b/packages/browser-wallet/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/browser-wallet",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Browser extension wallet for the Concordium blockchain",
     "author": "Concordium Software",
     "license": "Apache-2.0",

--- a/packages/browser-wallet/src/popup/pages/Account/Earn/Baking/FlowPages/Amount.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/Earn/Baking/FlowPages/Amount.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect, useMemo, useState } from 'react';
-import { AccountInfo, isBakerAccount, OpenStatus } from '@concordium/web-sdk';
+import { isBakerAccount } from '@concordium/web-sdk';
 import { useTranslation } from 'react-i18next';
-import { getCcdSymbol, isValidCcdString, ccdToMicroCcd } from 'wallet-common-helpers';
+import { getCcdSymbol, ccdToMicroCcd } from 'wallet-common-helpers';
 import { Validate } from 'react-hook-form';
 
 import Form, { useForm } from '@popup/shared/Form';
@@ -9,29 +9,12 @@ import { MultiStepFormPageProps } from '@popup/shared/MultiStepForm';
 import Submit from '@popup/shared/Form/Submit';
 import FormAmountInput from '@popup/shared/Form/AmountInput';
 import { validateBakerStake } from '@popup/shared/utils/transaction-helpers';
-import { getConfigureBakerEnergyCost } from '@shared/utils/energy-helpers';
 import { WithAccountInfo } from '@popup/shared/utils/account-helpers';
 import { accountPageContext } from '@popup/pages/Account/utils';
 import DisabledAmountInput from '@popup/shared/DisabledAmountInput';
 import { earnPageContext, isAboveStakeWarningThreshold, STAKE_WARNING_THRESHOLD } from '../../utils';
-import { configureBakerChangesPayload, ConfigureBakerFlowState } from '../utils';
+import { ConfigureBakerFlowState, getCost } from '../utils';
 import { AmountWarning, WarningModal } from '../../Warning';
-
-function getCost(accountInfo: AccountInfo, formValues: Partial<ConfigureBakerFlowState>, amount: string) {
-    const formValuesFull = {
-        restake: formValues.restake || true,
-        openForDelegation: formValues.openForDelegation || OpenStatus.ClosedForAll,
-        metadataUrl: formValues.metadataUrl || '',
-        commissionRates: formValues.commissionRates || {
-            transactionCommission: 0,
-            bakingCommission: 0,
-            finalizationCommission: 0,
-        },
-        keys: formValues.keys || null,
-        amount: isValidCcdString(amount) ? amount : '0',
-    };
-    return getConfigureBakerEnergyCost(configureBakerChangesPayload(accountInfo)(formValuesFull));
-}
 
 type AmountPageForm = {
     amount: string;

--- a/packages/browser-wallet/src/popup/pages/Account/Earn/Baking/utils.ts
+++ b/packages/browser-wallet/src/popup/pages/Account/Earn/Baking/utils.ts
@@ -9,8 +9,9 @@ import {
     BakerKeysWithProofs,
 } from '@concordium/web-sdk';
 import { decimalToRewardFraction } from '@popup/shared/utils/baking-helpers';
+import { getConfigureBakerEnergyCost } from '@shared/utils/energy-helpers';
 import { not } from '@shared/utils/function-helpers';
-import { ccdToMicroCcd, isDefined, microCcdToCcd, NotOptional } from 'wallet-common-helpers';
+import { ccdToMicroCcd, isDefined, isValidCcdString, microCcdToCcd, NotOptional } from 'wallet-common-helpers';
 
 export type ConfigureBakerFlowState = {
     restake: boolean;
@@ -123,14 +124,19 @@ export const toPayload = ({
     finalizationRewardCommission: decimalToRewardFraction(commissionRates?.finalizationCommission),
 });
 
+export function getConfigureBakerChanges(updates: ConfigureBakerFlowState, accountInfo?: AccountInfo) {
+    const existing = accountInfo !== undefined ? getExistingBakerValues(accountInfo) : undefined;
+    const changes = existing !== undefined ? getBakerFlowChanges(existing, updates) : updates;
+    return changes;
+}
+
 /**
  * Converts values of flow to a configure baker payload.
  *
- * Throws if no changes to existing values have been made.
+ * @throws if no changes to existing values have been made.
  */
 export const configureBakerChangesPayload = (accountInfo?: AccountInfo) => (values: ConfigureBakerFlowState) => {
-    const existing = accountInfo !== undefined ? getExistingBakerValues(accountInfo) : undefined;
-    const changes = existing !== undefined ? getBakerFlowChanges(existing, values) : values;
+    const changes = getConfigureBakerChanges(values, accountInfo);
 
     if (Object.values(changes).every(not(isDefined))) {
         throw new Error(
@@ -140,3 +146,33 @@ export const configureBakerChangesPayload = (accountInfo?: AccountInfo) => (valu
 
     return toPayload(changes);
 };
+
+function getFormOrExistingValue<T>(formValue?: T, existingBakerValue?: T) {
+    if (formValue !== undefined) {
+        return formValue;
+    }
+    if (existingBakerValue !== undefined) {
+        return existingBakerValue;
+    }
+
+    // Either a value should have been set by the user in the form, or the account
+    // should already be a baker with existing values. Otherwise this indicates an
+    // error in the UI flow.
+    throw new Error('Neither the form nor an existing baker value was available');
+}
+
+export function getCost(accountInfo: AccountInfo, formValues: Partial<ConfigureBakerFlowState>, amount: string) {
+    const existingBakerValues = getExistingBakerValues(accountInfo);
+    const formOrExistingAmount = getFormOrExistingValue(amount, existingBakerValues?.amount);
+
+    const formValuesFull = {
+        restake: getFormOrExistingValue(formValues.restake, existingBakerValues?.restake),
+        openForDelegation: getFormOrExistingValue(formValues.openForDelegation, existingBakerValues?.openForDelegation),
+        metadataUrl: getFormOrExistingValue(formValues.metadataUrl, existingBakerValues?.metadataUrl),
+        commissionRates: getFormOrExistingValue(formValues.commissionRates, existingBakerValues?.commissionRates),
+        keys: formValues.keys || null,
+        amount: isValidCcdString(formOrExistingAmount) ? formOrExistingAmount : '0',
+    };
+
+    return getConfigureBakerEnergyCost(toPayload(getConfigureBakerChanges(formValuesFull, accountInfo)));
+}


### PR DESCRIPTION
## Purpose
Fix an issue where updating the baker stake for a baker would make the wallet crash.

## Changes
- Allow no changes to the baker settings when calculating the cost.
- Use current baker settings as fallback when calculating cost instead of random default values.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.