### PR TITLE
Use CCD cost instead of energy cost to validateBakerStake

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -8,6 +8,7 @@
 -   Added missing key to events in the list of events inside the transaction details.
 -   Baking and delegation icons now also work in dark mode.
 -   An application crash when attempting to update the baker stake.
+-   Fixed incorrect cost used to validate baker stake.
 
 ## 1.0.1
 

--- a/packages/browser-wallet/src/popup/pages/Account/Earn/Baking/FlowPages/Amount.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/Earn/Baking/FlowPages/Amount.tsx
@@ -12,6 +12,7 @@ import { validateBakerStake } from '@popup/shared/utils/transaction-helpers';
 import { WithAccountInfo } from '@popup/shared/utils/account-helpers';
 import { accountPageContext } from '@popup/pages/Account/utils';
 import DisabledAmountInput from '@popup/shared/DisabledAmountInput';
+import { convertEnergyToMicroCcd } from '@shared/utils/energy-helpers';
 import { earnPageContext, isAboveStakeWarningThreshold, STAKE_WARNING_THRESHOLD } from '../../utils';
 import { ConfigureBakerFlowState, getCost } from '../utils';
 import { AmountWarning, WarningModal } from '../../Warning';
@@ -35,7 +36,11 @@ export default function AmountPage({ initial, onNext, formValues, accountInfo }:
     });
     const amount = form.watch('amount');
 
-    const cost = useMemo(() => getCost(accountInfo, formValues, amount), [amount]);
+    const cost = useMemo(
+        () =>
+            chainParameters ? convertEnergyToMicroCcd(getCost(accountInfo, formValues, amount), chainParameters) : 0n,
+        [chainParameters, amount]
+    );
 
     const validateAmount: Validate<string> = (amountToValidate) =>
         validateBakerStake(amountToValidate, chainParameters, accountInfo, cost);


### PR DESCRIPTION
## Purpose

Fix incorrect cost used to validate baker stake.

## Changes

Convert energy cost to CCD before using it to validate baker stake.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

