### PR TITLE
Fix delegation target always defaulting to baker

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -8,6 +8,7 @@
 -   Added missing key to events in the list of events inside the transaction details.
 -   Baking and delegation icons now also work in dark mode.
 -   An application crash when attempting to update the baker stake.
+-   Delegation target always defaulting to baker, even if current target was a passive delegation.
 
 ## 1.0.1
 

--- a/packages/browser-wallet/src/popup/pages/Account/Earn/Delegate/ConfigureDelegationFlow.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/Earn/Delegate/ConfigureDelegationFlow.tsx
@@ -56,8 +56,7 @@ function PoolPage({ onNext, initial, accountInfo }: PoolPageProps) {
     const { t: tShared } = useTranslation('shared');
     const client = useAtomValue(grpcClientAtom);
     const form = useForm<PoolPageForm>({
-        defaultValues:
-            initial === null || initial === undefined ? { isBaker: true } : { isBaker: true, bakerId: initial },
+        defaultValues: initial === null ? { isBaker: false } : { isBaker: true, bakerId: initial },
     });
     const isBakerValue = form.watch('isBaker');
 


### PR DESCRIPTION

## Purpose

Fix delegation target always defaulting to baker, even if current target was a passive delegation.

## Changes

Fixed the default to passive delegation, when account is already using passive delegation.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
