### PR TITLE
Update transaction messages

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.0.2
 
+### Changed
+
+-   Updated messages when confirming baker/delegation transactions.
+
 ### Fixed
 
 -   Some issues in the baking and delegation text.

--- a/packages/browser-wallet/src/popup/pages/Account/ConfirmTransfer/TransactionMessage.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/ConfirmTransfer/TransactionMessage.tsx
@@ -32,40 +32,44 @@ export function TransactionMessage({ transactionType, payload }: Props) {
 
         switch (transactionType) {
             case AccountTransactionType.ConfigureBaker: {
+                const cooldownPeriod = secondsToDaysRoundedDown(parametersV1?.poolOwnerCooldown);
                 if (isBakerAccount(accountInfo)) {
                     const newStake = (payload as ConfigureBakerPayload).stake?.microCcdAmount;
                     if (newStake === undefined) {
                         return undefined;
                     }
-                    if (accountInfo.accountBaker.stakedAmount > newStake) {
-                        return t('configureBaker.lowerBakerStake');
-                    }
                     if (newStake === 0n) {
-                        return t('configureBaker.removeBaker');
+                        return t('configureBaker.removeBaker', { cooldownPeriod });
+                    }
+                    if (accountInfo.accountBaker.stakedAmount > newStake) {
+                        return t('configureBaker.lowerBakerStake', { cooldownPeriod });
                     }
                 } else {
-                    return t('configureBaker.registerBaker');
+                    return t('configureBaker.registerBaker', { cooldownPeriod });
                 }
                 break;
             }
             case AccountTransactionType.ConfigureDelegation: {
+                const cooldownPeriod = secondsToDaysRoundedDown(parametersV1?.delegatorCooldown);
                 if (isDelegatorAccount(accountInfo)) {
                     const newStake = (payload as ConfigureDelegationPayload).stake?.microCcdAmount;
                     if (newStake === undefined) {
                         return undefined;
                     }
-                    if (accountInfo.accountDelegation.stakedAmount > newStake) {
-                        return t('configureDelegation.lowerDelegationStake', {
-                            cooldownPeriod: secondsToDaysRoundedDown(parametersV1?.delegatorCooldown),
-                        });
-                    }
                     if (newStake === 0n) {
                         return t('configureDelegation.remove', {
-                            cooldownPeriod: secondsToDaysRoundedDown(parametersV1?.delegatorCooldown),
+                            cooldownPeriod,
+                        });
+                    }
+                    if (accountInfo.accountDelegation.stakedAmount > newStake) {
+                        return t('configureDelegation.lowerDelegationStake', {
+                            cooldownPeriod,
                         });
                     }
                 } else {
-                    return t('configureDelegation.register');
+                    return t('configureDelegation.register', {
+                        cooldownPeriod,
+                    });
                 }
                 break;
             }

--- a/packages/browser-wallet/src/popup/pages/Account/i18n/en.ts
+++ b/packages/browser-wallet/src/popup/pages/Account/i18n/en.ts
@@ -325,17 +325,18 @@ const t = {
     transactionMessage: {
         configureBaker: {
             registerBaker:
-                'You are about to submit a register baker transaction that locks some of your funds in a stake. If you want to unlock the stake again, there will be a cool-down period.',
+                'You are about to submit a register baker transaction that locks some of your funds in a stake. If you want to unlock the stake again, there will be a cool-down period of {{ cooldownPeriod }} days.',
             lowerBakerStake:
-                'You are about to submit a transaction that lowers your baker stake. Lowering your stake has a cool-down period, meaning it will not take effect immediately.\n\nThe baker cannot be removed and the stake cannot be changed until the cool-down is over.',
-            removeBaker: 'Are you sure you want to make the following transaction to stop baking?',
+                'You are about to submit a baker transaction that lowers your  baker stake. It will take effect after {{ cooldownPeriod }} days and the baker stake cannot be changed during this period of time.',
+            removeBaker:
+                'Are you sure you want to make the following transaction to stop baking? It will take effect after {{ cooldownPeriod }} days and the baker stake cannot be changed during this period of time.',
         },
         configureDelegation: {
             register:
-                'This will lock your delegation amount for at least {{ cooldownPeriod}} days from the time you remove or decrease your delegation.',
+                'You are about to submit a register delegation transaction that locks some of your funds in a stake. If you want to unlock the stake again, there will be a cool-down period of {{ cooldownPeriod }} days.',
             lowerDelegationStake:
                 'You are about to submit a delegation transaction that lowers your delegation amount. It will take effect after {{ cooldownPeriod }} days and the delegation amount cannot be changed during this period of time.',
-            remove: 'Are you sure you want to remove your delegation?',
+            remove: 'Are you sure you want to make the following transaction to stop delegation? It will take effect after {{ cooldownPeriod }} days and the delegation amount cannot be changed during this period of time.',
         },
     },
     accountPending: 'This account is still pending finalization.',


### PR DESCRIPTION
## Purpose

Update transaction messages to all include cooldownPeriod + align the texts between baking and delegation.

## Changes

- Changed transactionMessage text.
- Fixed reduceStake messages being shown instead of remove message when stake = 0.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
