### PR TITLE
Add popups when updating baking/delegation

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
--   Popups when updating baking/delegation that the update will take effect will after the next payday, and reminders to give baker keys to the node.
+-   Popups, when updating baking/delegation, that inform the user that the update will take effect after the next payday, and reminders to give baker keys to the node.
 
 ### Changed
 

--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.0.2
 
+### Added
+
+-   Popups when updating baking/delegation that the update will take effect will after the next payday, and reminders to give baker keys to the node.
+
 ### Fixed
 
 -   Some issues in the baking and delegation text.

--- a/packages/browser-wallet/src/popup/pages/Account/ConfirmTransfer/ConfirmTransfer.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/ConfirmTransfer/ConfirmTransfer.tsx
@@ -66,6 +66,7 @@ export default function ConfirmTransfer(props: Props) {
     const nav = useNavigate();
     const addToast = useSetAtom(addToastAtom);
     const addPendingTransaction = useUpdateAtom(addPendingTransactionAtom);
+    const [showNotice, setShowNotice] = useState(false);
 
     useEffect(() => {
         if (selectedAddress !== address) {
@@ -96,6 +97,7 @@ export default function ConfirmTransfer(props: Props) {
 
         addPendingTransaction(createPendingTransactionFromAccountTransaction(transaction, transactionHash, cost));
         setHash(transactionHash);
+        setShowNotice(true);
     };
 
     if (!address) {
@@ -115,7 +117,12 @@ export default function ConfirmTransfer(props: Props) {
 
     return (
         <div className="w-full flex-column justify-space-between align-center">
-            <TransactionMessage transactionType={transactionType} payload={payload} />
+            <TransactionMessage
+                transactionType={transactionType}
+                payload={payload}
+                showNotice={showNotice}
+                setShowNotice={setShowNotice}
+            />
             {props.showAsTokenTransfer ? (
                 <TokenTransferReceipt
                     {...commonProps}

--- a/packages/browser-wallet/src/popup/pages/Account/ConfirmTransfer/TransactionMessage.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/ConfirmTransfer/TransactionMessage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
     AccountTransactionPayload,
@@ -12,18 +12,24 @@ import {
 import { useSelectedAccountInfo } from '@popup/shared/AccountInfoListenerContext/AccountInfoListenerContext';
 import { useBlockChainParameters } from '@popup/shared/BlockChainParametersProvider';
 import { secondsToDaysRoundedDown } from '@shared/utils/time-helpers';
+import Modal from '@popup/shared/Modal';
+import Button from '@popup/shared/Button';
 import { filterType } from '../Earn/utils';
 
 interface Props {
     payload: AccountTransactionPayload;
     transactionType: AccountTransactionType;
+    setShowNotice: (show: boolean) => void;
+    showNotice: boolean;
 }
 
-export function TransactionMessage({ transactionType, payload }: Props) {
+export function TransactionMessage({ transactionType, payload, showNotice, setShowNotice }: Props) {
     const { t } = useTranslation('account', { keyPrefix: 'transactionMessage' });
+    const { t: tShared } = useTranslation('shared');
     const accountInfo = useSelectedAccountInfo();
     const chainParameters = useBlockChainParameters();
     const parametersV1 = chainParameters ? filterType(isChainParametersV1)(chainParameters) : undefined;
+    const [noticeMessage, setNoticeMessage] = useState<string>();
 
     const message = useMemo(() => {
         if (!accountInfo) {
@@ -34,27 +40,26 @@ export function TransactionMessage({ transactionType, payload }: Props) {
             case AccountTransactionType.ConfigureBaker: {
                 if (isBakerAccount(accountInfo)) {
                     const newStake = (payload as ConfigureBakerPayload).stake?.microCcdAmount;
-                    if (newStake === undefined) {
-                        return undefined;
-                    }
-                    if (accountInfo.accountBaker.stakedAmount > newStake) {
+                    if (newStake && accountInfo.accountBaker.stakedAmount > newStake) {
                         return t('configureBaker.lowerBakerStake');
                     }
                     if (newStake === 0n) {
                         return t('configureBaker.removeBaker');
                     }
-                } else {
-                    return t('configureBaker.registerBaker');
+                    if ((payload as ConfigureBakerPayload).keys) {
+                        setNoticeMessage(t('configureBaker.notice.updateKeys'));
+                    } else {
+                        setNoticeMessage(t('configureBaker.notice.update'));
+                    }
+                    return undefined;
                 }
-                break;
+                setNoticeMessage(t('configureBaker.notice.start'));
+                return t('configureBaker.registerBaker');
             }
             case AccountTransactionType.ConfigureDelegation: {
                 if (isDelegatorAccount(accountInfo)) {
                     const newStake = (payload as ConfigureDelegationPayload).stake?.microCcdAmount;
-                    if (newStake === undefined) {
-                        return undefined;
-                    }
-                    if (accountInfo.accountDelegation.stakedAmount > newStake) {
+                    if (newStake && accountInfo.accountDelegation.stakedAmount > newStake) {
                         return t('configureDelegation.lowerDelegationStake', {
                             cooldownPeriod: secondsToDaysRoundedDown(parametersV1?.delegatorCooldown),
                         });
@@ -64,10 +69,11 @@ export function TransactionMessage({ transactionType, payload }: Props) {
                             cooldownPeriod: secondsToDaysRoundedDown(parametersV1?.delegatorCooldown),
                         });
                     }
-                } else {
-                    return t('configureDelegation.register');
+                    setNoticeMessage(t('configureDelegation.notice.update'));
+                    return undefined;
                 }
-                break;
+                setNoticeMessage(t('configureDelegation.notice.start'));
+                return t('configureDelegation.register');
             }
             default:
                 break;
@@ -75,9 +81,18 @@ export function TransactionMessage({ transactionType, payload }: Props) {
         return undefined;
     }, [parametersV1?.delegatorCooldown]);
 
-    if (!message) {
-        return null;
-    }
-
-    return <p className="white-space-break text-center m-h-20 m-t-20 m-b-0">{message}</p>;
+    return (
+        <>
+            <Modal open={Boolean(noticeMessage) && showNotice} disableClose>
+                <div>
+                    <h3 className="m-t-0">{tShared('notice')}</h3>
+                    <p className="white-space-break ">{noticeMessage}</p>
+                    <Button className="m-t-10" width="wide" onClick={() => setShowNotice(false)}>
+                        {tShared('okay')}
+                    </Button>
+                </div>
+            </Modal>
+            {message && <p className="white-space-break text-center m-h-20 m-t-20 m-b-0">{message}</p>}
+        </>
+    );
 }

--- a/packages/browser-wallet/src/popup/pages/Account/i18n/da.ts
+++ b/packages/browser-wallet/src/popup/pages/Account/i18n/da.ts
@@ -332,10 +332,10 @@ const t: typeof en = {
                 'Du er ved at indsende en transaktion som formindsker din baker stake. At formindske din baker stake har en cool-down periode, hvilket betyder at ændringen ikke træder i kraft med det samme.\n\nBakeren kan ikke fjernes og din baker stake kan ikke ændres indtil cool-down perioden er overstået.',
             removeBaker: 'Er du sikker du vil lave denne transaktion som stopper baking?',
             notice: {
-                start: 'Når din transaktion er blevet finalized, vil baker registringen starte fra den efterfølgende pay day.\n\nHusk at genstarte din node med de nye baker keys',
+                start: 'Når din transaktion er finalized, vil baker registreringen starte fra den efterfølgende pay day.\n\nHusk at genstarte din node med de nye baker keys',
                 update: 'Når din transaktion er blevet finalized, vil baker opdateringen træde i kraft fra den efterfølgende pay day.',
                 updateKeys:
-                    'Når din transaktion er blevet finalized, vil de nye baker keys blive valide fra den efterfølgende pay day.\n\nDu burde derfor genstarte din node med de nye baker keys så tæt på den næste pay day som muligt.',
+                    'Når din transaktion er finalized, vil de nye baker keys blive gyldige fra den efterfølgende pay day.\n\nDu bør derfor genstarte din node med de nye baker keys så tæt på den næste pay day som muligt.',
             },
         },
         configureDelegation: {

--- a/packages/browser-wallet/src/popup/pages/Account/i18n/da.ts
+++ b/packages/browser-wallet/src/popup/pages/Account/i18n/da.ts
@@ -331,13 +331,23 @@ const t: typeof en = {
             lowerBakerStake:
                 'Du er ved at indsende en transaktion som formindsker din baker stake. At formindske din baker stake har en cool-down periode, hvilket betyder at ændringen ikke træder i kraft med det samme.\n\nBakeren kan ikke fjernes og din baker stake kan ikke ændres indtil cool-down perioden er overstået.',
             removeBaker: 'Er du sikker du vil lave denne transaktion som stopper baking?',
+            notice: {
+                start: 'Når din transaktion er blevet finalized, vil baker registringen starte fra den efterfølgende pay day.\n\nHusk at genstarte din node med de nye baker keys',
+                update: 'Når din transaktion er blevet finalized, vil baker opdateringen træde i kraft fra den efterfølgende pay day.',
+                updateKeys:
+                    'Når din transaktion er blevet finalized, vil de nye baker keys blive valide fra den efterfølgende pay day.\n\nDu burde derfor genstarte din node med de nye baker keys så tæt på den næste pay day som muligt.',
+            },
         },
         configureDelegation: {
             register:
                 'Du er ved at indsende en transaktion som registrerer dig som en delegator, hvillket som låser nogle af dine CCD som delegation stake. Hvis du vil frigøre din stake, vil der være en cool-down periode på {{ cooldownPeriod }} dage.',
             lowerDelegationStake:
-                'Du er ved at indsende en transaktion som formindkser din delegation stake. Det vil træde i kraft efter {{ cooldownPeriod }} dage og din delegation saldo kan ikke ændres i denne periode.',
+                'Du er ved at indsende en transaktion som formindsker din delegation stake. Det vil træde i kraft efter {{ cooldownPeriod }} dage og din delegation saldo kan ikke ændres i denne periode.',
             remove: 'Er du sikker du vil fjerne din delegation?',
+            notice: {
+                start: 'Når din transaktion er blevet finalized, vil delegation starte fra den efterfølgende pay day.',
+                update: 'Når din transaktion er blevet finalized, vil delegation opdateringen træde i kraft fra den efterfølgende pay day.',
+            },
         },
     },
     accountPending: 'Denne konto er stadig ved at blive oprettet.',

--- a/packages/browser-wallet/src/popup/pages/Account/i18n/en.ts
+++ b/packages/browser-wallet/src/popup/pages/Account/i18n/en.ts
@@ -329,6 +329,12 @@ const t = {
             lowerBakerStake:
                 'You are about to submit a transaction that lowers your baker stake. Lowering your stake has a cool-down period, meaning it will not take effect immediately.\n\nThe baker cannot be removed and the stake cannot be changed until the cool-down is over.',
             removeBaker: 'Are you sure you want to make the following transaction to stop baking?',
+            notice: {
+                start: 'Once your transaction has successfully finalized, the baker registration will take effect from the next pay day.\n\nRemember to restart your node with the baker keys.',
+                update: 'Once your transaction has successfully finalized, the baker update will take effect from the next pay day.',
+                updateKeys:
+                    'Once your transaction has successfully finalized, the new baker keys will take effect from the next pay day.\n\nThis means the node should be restarted with the new keys, as close to the next pay day as possible.',
+            },
         },
         configureDelegation: {
             register:
@@ -336,6 +342,10 @@ const t = {
             lowerDelegationStake:
                 'You are about to submit a delegation transaction that lowers your delegation amount. It will take effect after {{ cooldownPeriod }} days and the delegation amount cannot be changed during this period of time.',
             remove: 'Are you sure you want to remove your delegation?',
+            notice: {
+                start: 'Once your transaction has successfully finalized, the delegation will take effect from the next pay day.',
+                update: 'Once your transaction has successfully finalized, the delegation update will take effect from the next pay day.',
+            },
         },
     },
     accountPending: 'This account is still pending finalization.',

--- a/packages/browser-wallet/src/popup/shared/i18n/da.ts
+++ b/packages/browser-wallet/src/popup/shared/i18n/da.ts
@@ -161,6 +161,8 @@ const t: typeof en = {
         },
     },
     continue: 'Fortsæt',
+    okay: 'Okay',
+    notice: 'Bemærk',
 };
 
 export default t;

--- a/packages/browser-wallet/src/popup/shared/i18n/en.ts
+++ b/packages/browser-wallet/src/popup/shared/i18n/en.ts
@@ -162,6 +162,8 @@ const t = {
         },
     },
     continue: 'Continue',
+    okay: 'Okay',
+    notice: 'Notice',
 };
 
 export default t;


### PR DESCRIPTION
## Purpose

Add popups that appear after sending configure baker/delegation transactions.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
