### PR TITLE
Fix target delegation being updated incorrectly

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.4
+
+### Fixed
+
+-   Delegation target being changed to passive delegation when the user did not choose to update it.
+
 ## 1.0.3
 
 ### Fixed

--- a/packages/browser-wallet/src/popup/pages/Account/Earn/Delegate/utils.ts
+++ b/packages/browser-wallet/src/popup/pages/Account/Earn/Delegate/utils.ts
@@ -73,7 +73,7 @@ export const getDelegationFlowChanges = (
 
 function toPayload(values: DeepPartial<ConfigureDelegationFlowState>): ConfigureDelegationPayload {
     let delegationTarget: DelegationTarget | undefined;
-    if (values.pool == null) {
+    if (values.pool === null) {
         delegationTarget = { delegateType: DelegationTargetType.PassiveDelegation };
     } else if (values.pool !== undefined) {
         delegationTarget = { delegateType: DelegationTargetType.Baker, bakerId: BigInt(values.pool) };


### PR DESCRIPTION
## Purpose

Fix delegation target being updated to passive delegation when the user did not choose to update it.

## Changes

Change loose equality to strict to differentiate between null and undefined.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
