### PR TITLE
Ensure when validating baker/delegation stake reduction that atDisposal can cover fee

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.4
+
+### Fixed
+
+-   Validate during Baker/delegation stake reduction that at disposal funds can cover the fee.
+
 ## 1.0.3
 
 ### Fixed

--- a/packages/browser-wallet/src/popup/shared/i18n/da.ts
+++ b/packages/browser-wallet/src/popup/shared/i18n/da.ts
@@ -62,6 +62,7 @@ const t: typeof en = {
             zero: 'Beløbet må ikke være nul',
             belowBakerThreshold: 'Indsat mængde er under grænsen {{ threshold }} for bagning',
             exceedingDelegationCap: "delegeret mængde må ikke gå over valgt bager gruppe's loft på {{ max }}.",
+            insufficientFundsAtDisposal: 'Ikke nok penge til rådighed',
         },
         transaction: {
             type: {

--- a/packages/browser-wallet/src/popup/shared/i18n/en.ts
+++ b/packages/browser-wallet/src/popup/shared/i18n/en.ts
@@ -62,6 +62,7 @@ const t = {
             zero: 'Amount may not be zero',
             belowBakerThreshold: 'Minimum stake: {{ threshold }}',
             exceedingDelegationCap: "Amount may not exceed the target pool's cap of {{ max }}.",
+            insufficientFundsAtDisposal: 'Insufficient funds at disposal',
         },
         transaction: {
             type: {


### PR DESCRIPTION
## Purpose

Fix when reducing baker/delegation stake, that a user could continue and then get rejected by the node.

## Changes

Validate that current atDisposal can cover the fee.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
