### PR TITLE
Improve how confirmTransfer displays errors

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   Validate during Baker/delegation stake reduction that at disposal funds can cover the fee.
 -   Delegation target being changed to passive delegation when the user did not choose to update it.
+-   Improve display of errors from the node when sending transactions.
 
 ## 1.0.3
 

--- a/packages/browser-wallet/src/popup/pages/Account/ConfirmTransfer/ConfirmTransfer.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/ConfirmTransfer/ConfirmTransfer.tsx
@@ -138,7 +138,7 @@ export default function ConfirmTransfer(props: Props) {
                     <Button width="narrow" className="m-r-10" onClick={() => nav(-1)}>
                         {t('confirmTransfer.buttons.back')}
                     </Button>
-                    <Button width="narrow" onClick={() => send().catch((e) => addToast(e.toString()))}>
+                    <Button width="narrow" onClick={() => send().catch((e) => addToast(decodeURIComponent(e.message)))}>
                         {t('confirmTransfer.buttons.send')}
                     </Button>
                 </div>


### PR DESCRIPTION
## Purpose

Display errors from node in a nicer way.

## Changes

- display error message instead of stringifying the error + decode uri encoding.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
