### PR TITLE
Fix request ccd flash

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 -   An issue where the transaction list view would show the `Request CCD` button while loading the initial batch of transactions.
+-   Added a missing translation for the `Request CCD` button.
 
 ## 1.0.4
 

--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+-   An issue where the transaction list view would show the `Request CCD` button while loading the initial batch of transactions.
+
 ## 1.0.4
 
 ### Fixed

--- a/packages/browser-wallet/src/popup/pages/Account/TransactionLog/TransactionList.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/TransactionLog/TransactionList.tsx
@@ -307,7 +307,7 @@ export default function TransactionList({ onTransactionClick }: TransactionListP
                                 ccdDrop(accountAddress);
                             }}
                         >
-                            Request CCD
+                            {t('requestCcd')}
                         </Button>
                     )}
                 </div>

--- a/packages/browser-wallet/src/popup/pages/Account/TransactionLog/TransactionList.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/TransactionLog/TransactionList.tsx
@@ -291,7 +291,7 @@ export default function TransactionList({ onTransactionClick }: TransactionListP
 
     let transactionListComponent;
     if (allTransactions.length === 0) {
-        if (isNextPageLoading) {
+        if (isNextPageLoading || hasNextPage) {
             transactionListComponent = null;
         } else {
             // If a test network then display button.

--- a/packages/browser-wallet/src/popup/pages/Account/TransactionLog/i18n/da.ts
+++ b/packages/browser-wallet/src/popup/pages/Account/TransactionLog/i18n/da.ts
@@ -9,7 +9,8 @@ const t: typeof en = {
     events: 'Hændelser',
     rejectReason: 'Afvisningsårsag',
     error: 'Fejl ved hentning af transaktionshistorik',
-    noTransactions: 'Denne konto har ingen transakationer endnu.',
+    noTransactions: 'Denne konto har ingen transaktioner endnu.',
+    requestCcd: 'Anmod om CCD',
 };
 
 export default t;

--- a/packages/browser-wallet/src/popup/pages/Account/TransactionLog/i18n/en.ts
+++ b/packages/browser-wallet/src/popup/pages/Account/TransactionLog/i18n/en.ts
@@ -8,6 +8,7 @@ const t = {
     rejectReason: 'Reject reason',
     noTransactions: 'This account has no transactions yet.',
     error: 'Unable to retrieve transaction history',
+    requestCcd: 'Request CCD',
 };
 
 export default t;


### PR DESCRIPTION
## Purpose
Fixes an issue where the translation list would briefly show the `Request CCD` button while loading transactions, i.e. before it was fully determined if the given account had any transactions.

## Changes
- Added a missing translation for the Request CCD button.
- Correctly determine when to show nothing in the transaction list and when to show the request CCD button.
- Fixed a typo.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.