### PR TITLE
Wallet api types/lax schematype

### DIFF
--- a/packages/browser-wallet-api-helpers/CHANGELOG.md
+++ b/packages/browser-wallet-api-helpers/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.5.1
+
+### Changed
+
+-   Made it possible to define the `type` of `SchemaWithContext` as a string along with the existing `SchemaType` enum.
+
 ## 2.5.0
 
 ### Added

--- a/packages/browser-wallet-api-helpers/package.json
+++ b/packages/browser-wallet-api-helpers/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/browser-wallet-api-helpers",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "license": "Apache-2.0",
     "packageManager": "yarn@3.2.0",
     "main": "lib/index.js",

--- a/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
+++ b/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
@@ -39,13 +39,14 @@ export enum EventType {
     ChainChanged = 'chainChanged',
 }
 
+export type SchemaTypeString = 'module' | 'parameter';
 export enum SchemaType {
     Module = 'module',
     Parameter = 'parameter',
 }
 
 export type SchemaWithContext = {
-    type: SchemaType;
+    type: SchemaType | SchemaTypeString;
     value: string;
 };
 

--- a/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
+++ b/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
@@ -39,13 +39,18 @@ export enum EventType {
     ChainChanged = 'chainChanged',
 }
 
-export type SchemaTypeString = 'module' | 'parameter';
+
 export enum SchemaType {
     Module = 'module',
     Parameter = 'parameter',
 }
 
+type LaxStringEnumValue<E extends string> = `${E}`;
+
 export type SchemaWithContext = {
+    type: LaxStringEnumValue<SchemaType>;
+    value: string;
+};
     type: SchemaType | SchemaTypeString;
     value: string;
 };

--- a/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
+++ b/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
@@ -39,7 +39,6 @@ export enum EventType {
     ChainChanged = 'chainChanged',
 }
 
-
 export enum SchemaType {
     Module = 'module',
     Parameter = 'parameter',
@@ -49,9 +48,6 @@ type LaxStringEnumValue<E extends string> = `${E}`;
 
 export type SchemaWithContext = {
     type: LaxStringEnumValue<SchemaType>;
-    value: string;
-};
-    type: SchemaType | SchemaTypeString;
     value: string;
 };
 


### PR DESCRIPTION
This makes it possible to construct an object adhering to the `SchemaWithContext` type from the JS SDK, to make it easier for a user to directly use the SDK to call the wallet API.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
