### PR TITLE
Remove transactionMessage after transaction has been submitted

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -5,12 +5,17 @@
 ### Added
 
 -   A build script for making builds that include the stagenet network.
+-   Text that a transaction has been submitted.
 
 ### Fixed
 
 -   The About page link to the terms and conditions pointed to the wrong URL. It now uses the value retrieved from the wallet proxy, or the correct default to the unified terms and conditions page.
 -   Link to transaction log on stagenet was incorrect.
 -   Fixed an empty recovery displaying an error instead of informing the user that nothing was found.
+
+### Changed
+
+-   Messages when confirming baker/delegation transactions no longer appears after the transaction has been submitted.
 
 ## 1.0.4
 

--- a/packages/browser-wallet/src/popup/pages/Account/ConfirmTransfer/ConfirmTransfer.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/ConfirmTransfer/ConfirmTransfer.tsx
@@ -32,6 +32,7 @@ import { SmartContractParameters } from '@concordium/browser-wallet-api-helpers'
 import { TokenMetadata } from '@shared/storage/types';
 import { accountRoutes } from '../routes';
 import { TransactionMessage } from './TransactionMessage';
+import TransactionPopup from './TransactionPopup';
 
 type BaseProps = {
     setDetailsExpanded: (expanded: boolean) => void;
@@ -66,7 +67,8 @@ export default function ConfirmTransfer(props: Props) {
     const nav = useNavigate();
     const addToast = useSetAtom(addToastAtom);
     const addPendingTransaction = useUpdateAtom(addPendingTransactionAtom);
-    const [showNotice, setShowNotice] = useState(false);
+    const [showPopup, setShowPopup] = useState(false);
+    const isSent = Boolean(hash);
 
     useEffect(() => {
         if (selectedAddress !== address) {
@@ -97,7 +99,7 @@ export default function ConfirmTransfer(props: Props) {
 
         addPendingTransaction(createPendingTransactionFromAccountTransaction(transaction, transactionHash, cost));
         setHash(transactionHash);
-        setShowNotice(true);
+        setShowPopup(true);
     };
 
     if (!address) {
@@ -117,12 +119,16 @@ export default function ConfirmTransfer(props: Props) {
 
     return (
         <div className="w-full flex-column justify-space-between align-center">
-            <TransactionMessage
+            <TransactionPopup
                 transactionType={transactionType}
                 payload={payload}
-                showNotice={showNotice}
-                setShowNotice={setShowNotice}
+                showPopup={showPopup}
+                setShowPopup={setShowPopup}
             />
+            {!isSent && <TransactionMessage transactionType={transactionType} payload={payload} />}
+            {isSent && (
+                <p className="white-space-break text-center m-h-20 m-t-20 m-b-0">{t('confirmTransfer.submitted')}</p>
+            )}
             {props.showAsTokenTransfer ? (
                 <TokenTransferReceipt
                     {...commonProps}
@@ -133,7 +139,7 @@ export default function ConfirmTransfer(props: Props) {
             ) : (
                 <GenericTransactionReceipt {...commonProps} />
             )}
-            {!hash && (
+            {!isSent && (
                 <div className="flex justify-center p-b-10 m-h-20">
                     <Button width="narrow" className="m-r-10" onClick={() => nav(-1)}>
                         {t('confirmTransfer.buttons.back')}
@@ -143,7 +149,7 @@ export default function ConfirmTransfer(props: Props) {
                     </Button>
                 </div>
             )}
-            {hash && (
+            {isSent && (
                 <div className="p-b-10">
                     <Button
                         width="medium"

--- a/packages/browser-wallet/src/popup/pages/Account/ConfirmTransfer/TransactionMessage.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/ConfirmTransfer/TransactionMessage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
     AccountTransactionPayload,
@@ -11,22 +11,20 @@ import {
 import { useSelectedAccountInfo } from '@popup/shared/AccountInfoListenerContext/AccountInfoListenerContext';
 import { useBlockChainParametersV1 } from '@popup/shared/BlockChainParametersProvider';
 import { secondsToDaysRoundedDown } from '@shared/utils/time-helpers';
-import Modal from '@popup/shared/Modal';
-import Button from '@popup/shared/Button';
 
 interface Props {
     payload: AccountTransactionPayload;
     transactionType: AccountTransactionType;
-    setShowNotice: (show: boolean) => void;
-    showNotice: boolean;
 }
 
-export function TransactionMessage({ transactionType, payload, showNotice, setShowNotice }: Props) {
+/**
+ * Component that displays a message related to a transaction before sending it.
+ * Note that only some transactions warrant a message.
+ */
+export function TransactionMessage({ transactionType, payload }: Props) {
     const { t } = useTranslation('account', { keyPrefix: 'transactionMessage' });
-    const { t: tShared } = useTranslation('shared');
     const accountInfo = useSelectedAccountInfo();
     const parametersV1 = useBlockChainParametersV1();
-    const [noticeMessage, setNoticeMessage] = useState<string>();
 
     const message = useMemo(() => {
         if (!accountInfo) {
@@ -44,14 +42,8 @@ export function TransactionMessage({ transactionType, payload, showNotice, setSh
                     if (newStake && accountInfo.accountBaker.stakedAmount > newStake) {
                         return t('configureBaker.lowerBakerStake', { cooldownPeriod });
                     }
-                    if ((payload as ConfigureBakerPayload).keys) {
-                        setNoticeMessage(t('configureBaker.notice.updateKeys'));
-                    } else {
-                        setNoticeMessage(t('configureBaker.notice.update'));
-                    }
                     return undefined;
                 }
-                setNoticeMessage(t('configureBaker.notice.start'));
                 return t('configureBaker.registerBaker', { cooldownPeriod });
             }
             case AccountTransactionType.ConfigureDelegation: {
@@ -68,10 +60,8 @@ export function TransactionMessage({ transactionType, payload, showNotice, setSh
                             cooldownPeriod,
                         });
                     }
-                    setNoticeMessage(t('configureDelegation.notice.update'));
                     return undefined;
                 }
-                setNoticeMessage(t('configureDelegation.notice.start'));
                 return t('configureDelegation.register', {
                     cooldownPeriod,
                 });
@@ -81,19 +71,5 @@ export function TransactionMessage({ transactionType, payload, showNotice, setSh
         }
         return undefined;
     }, [parametersV1?.delegatorCooldown]);
-
-    return (
-        <>
-            <Modal open={Boolean(noticeMessage) && showNotice} disableClose>
-                <div>
-                    <h3 className="m-t-0">{tShared('notice')}</h3>
-                    <p className="white-space-break ">{noticeMessage}</p>
-                    <Button className="m-t-10" width="wide" onClick={() => setShowNotice(false)}>
-                        {tShared('okay')}
-                    </Button>
-                </div>
-            </Modal>
-            {message && <p className="white-space-break text-center m-h-20 m-t-20 m-b-0">{message}</p>}
-        </>
-    );
+    return message ? <p className="white-space-break text-center m-h-20 m-t-20 m-b-0">{message}</p> : null;
 }

--- a/packages/browser-wallet/src/popup/pages/Account/ConfirmTransfer/TransactionPopup.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/ConfirmTransfer/TransactionPopup.tsx
@@ -36,7 +36,7 @@ export default function TransactionPopup({ transactionType, payload, showPopup, 
                 case AccountTransactionType.ConfigureBaker: {
                     if (isBakerAccount(accountInfo)) {
                         const newStake = (payload as ConfigureBakerPayload).stake?.microCcdAmount;
-                        if (!newStake || accountInfo.accountBaker.stakedAmount < newStake) {
+                        if (newStake === undefined || accountInfo.accountBaker.stakedAmount < newStake) {
                             if ((payload as ConfigureBakerPayload).keys) {
                                 return t('configureBaker.updateKeys');
                             }
@@ -50,7 +50,7 @@ export default function TransactionPopup({ transactionType, payload, showPopup, 
                 case AccountTransactionType.ConfigureDelegation: {
                     if (isDelegatorAccount(accountInfo)) {
                         const newStake = (payload as ConfigureDelegationPayload).stake?.microCcdAmount;
-                        if (!newStake || accountInfo.accountDelegation.stakedAmount < newStake) {
+                        if (newStake === undefined || accountInfo.accountDelegation.stakedAmount < newStake) {
                             return t('configureDelegation.update');
                         }
                     } else {

--- a/packages/browser-wallet/src/popup/pages/Account/ConfirmTransfer/TransactionPopup.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/ConfirmTransfer/TransactionPopup.tsx
@@ -1,0 +1,79 @@
+import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+    AccountTransactionPayload,
+    AccountTransactionType,
+    isBakerAccount,
+    isDelegatorAccount,
+    ConfigureBakerPayload,
+    ConfigureDelegationPayload,
+} from '@concordium/web-sdk';
+import { useSelectedAccountInfo } from '@popup/shared/AccountInfoListenerContext/AccountInfoListenerContext';
+import { useBlockChainParametersV1 } from '@popup/shared/BlockChainParametersProvider';
+import Modal from '@popup/shared/Modal';
+import Button from '@popup/shared/Button';
+
+interface Props {
+    payload: AccountTransactionPayload;
+    transactionType: AccountTransactionType;
+    setShowPopup: (show: boolean) => void;
+    showPopup: boolean;
+}
+
+/**
+ * Component that displays a popup with a message related to a transaction when sending it.
+ * Note that only some transactions warrant a popup/message.
+ */
+export default function TransactionPopup({ transactionType, payload, showPopup, setShowPopup }: Props) {
+    const { t } = useTranslation('account', { keyPrefix: 'transactionPopup' });
+    const { t: tShared } = useTranslation('shared');
+    const accountInfo = useSelectedAccountInfo();
+    const parametersV1 = useBlockChainParametersV1();
+
+    const message = useMemo(() => {
+        if (accountInfo) {
+            switch (transactionType) {
+                case AccountTransactionType.ConfigureBaker: {
+                    if (isBakerAccount(accountInfo)) {
+                        const newStake = (payload as ConfigureBakerPayload).stake?.microCcdAmount;
+                        if (!newStake || accountInfo.accountBaker.stakedAmount < newStake) {
+                            if ((payload as ConfigureBakerPayload).keys) {
+                                return t('configureBaker.updateKeys');
+                            }
+                            return t('configureBaker.update');
+                        }
+                    } else {
+                        return t('configureBaker.start');
+                    }
+                    break;
+                }
+                case AccountTransactionType.ConfigureDelegation: {
+                    if (isDelegatorAccount(accountInfo)) {
+                        const newStake = (payload as ConfigureDelegationPayload).stake?.microCcdAmount;
+                        if (!newStake || accountInfo.accountDelegation.stakedAmount < newStake) {
+                            return t('configureDelegation.update');
+                        }
+                    } else {
+                        return t('configureDelegation.start');
+                    }
+                    break;
+                }
+                default:
+                    break;
+            }
+        }
+        return undefined;
+    }, [parametersV1?.delegatorCooldown]);
+
+    return (
+        <Modal open={Boolean(message) && showPopup} disableClose>
+            <div>
+                <h3 className="m-t-0">{tShared('notice')}</h3>
+                <p className="white-space-break ">{message}</p>
+                <Button className="m-t-10" width="wide" onClick={() => setShowPopup(false)}>
+                    {tShared('okay')}
+                </Button>
+            </div>
+        </Modal>
+    );
+}

--- a/packages/browser-wallet/src/popup/pages/Account/i18n/da.ts
+++ b/packages/browser-wallet/src/popup/pages/Account/i18n/da.ts
@@ -47,6 +47,7 @@ const t: typeof en = {
         },
     },
     confirmTransfer: {
+        submitted: 'Transaktionen er blevet indsendt!',
         buttons: {
             back: 'tilbage',
             send: 'Send',
@@ -337,12 +338,6 @@ const t: typeof en = {
             lowerBakerStake:
                 'Du er ved at indsende en transaktion som formindsker din baker stake. At formindske din baker stake har en cool-down periode, hvilket betyder at ændringen ikke træder i kraft med det samme.\n\nBakeren kan ikke fjernes og din baker stake kan ikke ændres indtil cool-down perioden er overstået.',
             removeBaker: 'Er du sikker du vil lave denne transaktion som stopper baking?',
-            notice: {
-                start: 'Når din transaktion er finalized, vil baker registreringen starte fra den efterfølgende pay day.\n\nHusk at genstarte din node med de nye baker keys',
-                update: 'Når din transaktion er blevet finalized, vil baker opdateringen træde i kraft fra den efterfølgende pay day.',
-                updateKeys:
-                    'Når din transaktion er finalized, vil de nye baker keys blive gyldige fra den efterfølgende pay day.\n\nDu bør derfor genstarte din node med de nye baker keys så tæt på den næste pay day som muligt.',
-            },
         },
         configureDelegation: {
             register:
@@ -350,10 +345,18 @@ const t: typeof en = {
             lowerDelegationStake:
                 'Du er ved at indsende en transaktion som formindsker din delegation stake. Det vil træde i kraft efter {{ cooldownPeriod }} dage og din delegation saldo kan ikke ændres i denne periode.',
             remove: 'Er du sikker du vil fjerne din delegation?',
-            notice: {
-                start: 'Når din transaktion er blevet finalized, vil delegation starte fra den efterfølgende pay day.',
-                update: 'Når din transaktion er blevet finalized, vil delegation opdateringen træde i kraft fra den efterfølgende pay day.',
-            },
+        },
+    },
+    transactionPopup: {
+        configureBaker: {
+            start: 'Når din transaktion er finalized, vil baker registreringen starte fra den efterfølgende pay day.\n\nHusk at genstarte din node med de nye baker keys',
+            update: 'Når din transaktion er blevet finalized, vil baker opdateringen træde i kraft fra den efterfølgende pay day.',
+            updateKeys:
+                'Når din transaktion er finalized, vil de nye baker keys blive gyldige fra den efterfølgende pay day.\n\nDu bør derfor genstarte din node med de nye baker keys så tæt på den næste pay day som muligt.',
+        },
+        configureDelegation: {
+            start: 'Når din transaktion er blevet finalized, vil delegation starte fra den efterfølgende pay day.',
+            update: 'Når din transaktion er blevet finalized, vil delegation opdateringen træde i kraft fra den efterfølgende pay day.',
         },
     },
     accountPending: 'Denne konto er stadig ved at blive oprettet.',

--- a/packages/browser-wallet/src/popup/pages/Account/i18n/en.ts
+++ b/packages/browser-wallet/src/popup/pages/Account/i18n/en.ts
@@ -45,6 +45,7 @@ const t = {
         },
     },
     confirmTransfer: {
+        submitted: 'Transaction submitted!',
         buttons: {
             back: 'Back',
             send: 'Send',
@@ -336,12 +337,6 @@ const t = {
                 'You are about to submit a baker transaction that lowers your baker stake. It will take effect at the first pay day after a cool-down period {{ cooldownPeriod }} days and the baker stake cannot be changed during this period of time.',
             removeBaker:
                 'Are you sure you want to make the following transaction to stop baking? It will take effect at the first pay day after a cool-down period {{ cooldownPeriod }} days and the baker stake cannot be changed during this period of time.',
-            notice: {
-                start: 'Once your transaction has successfully finalized, the baker registration will take effect from the next pay day.\n\nRemember to restart your node with the baker keys.',
-                update: 'Once your transaction has successfully finalized, the baker update will take effect from the next pay day.',
-                updateKeys:
-                    'Once your transaction has successfully finalized, the new baker keys will take effect from the next pay day.\n\nThis means the node should be restarted with the new keys, as close to the next pay day as possible.',
-            },
         },
         configureDelegation: {
             register:
@@ -349,10 +344,18 @@ const t = {
             lowerDelegationStake:
                 'You are about to submit a delegation transaction that lowers your delegation amount. It will take effect at the first pay day after a cool-down period {{ cooldownPeriod }} days and the delegation amount cannot be changed during this period of time.',
             remove: 'Are you sure you want to make the following transaction to stop delegation? It will take effect at the first pay day after a cool-down period {{ cooldownPeriod }} days and the delegation amount cannot be changed during this period of time.',
-            notice: {
-                start: 'Once your transaction has successfully finalized, the delegation will take effect from the next pay day.',
-                update: 'Once your transaction has successfully finalized, the delegation update will take effect from the next pay day.',
-            },
+        },
+    },
+    transactionPopup: {
+        configureBaker: {
+            start: 'Once your transaction has successfully finalized, the baker registration will take effect from the next pay day.\n\nRemember to restart your node with the baker keys.',
+            update: 'Once your transaction has successfully finalized, the baker update will take effect from the next pay day.',
+            updateKeys:
+                'Once your transaction has successfully finalized, the new baker keys will take effect from the next pay day.\n\nThis means the node should be restarted with the new keys, as close to the next pay day as possible.',
+        },
+        configureDelegation: {
+            start: 'Once your transaction has successfully finalized, the delegation will take effect from the next pay day.',
+            update: 'Once your transaction has successfully finalized, the delegation update will take effect from the next pay day.',
         },
     },
     accountPending: 'This account is still pending finalization.',


### PR DESCRIPTION
## Purpose

Align with mobile wallet on "finish transaction" screen.

## Changes

- Refactor `transactionMessage` into two components.
- Stop displaying `transactionMessage` after the transaction has been sent.
- Display "Transaction Submitted!" after it was submitted.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
