### PR TITLE
Deploy module fixes

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.0.6
+
+### Changed
+
+-   In the display of a `deployModule` transaction, the previously titled module hash is now titled module reference.
+
+### Added
+
+-   Display of a `deployModule` transaction now includes a copy button for the module reference.
+
 ## 1.0.5
 
 ### Added

--- a/packages/browser-wallet/package.json
+++ b/packages/browser-wallet/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/browser-wallet",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "description": "Browser extension wallet for the Concordium blockchain",
     "author": "Concordium Software",
     "license": "Apache-2.0",

--- a/packages/browser-wallet/src/popup/pages/SendTransaction/i18n/da.ts
+++ b/packages/browser-wallet/src/popup/pages/SendTransaction/i18n/da.ts
@@ -25,7 +25,6 @@ const t: typeof en = {
         missingNonce: 'Vi var ikke i stand til at finde den næste nonce for afsenderen',
     },
     version: 'Version',
-    sourceHash: 'Modul hash',
 };
 
 export default t;

--- a/packages/browser-wallet/src/popup/pages/SendTransaction/i18n/en.ts
+++ b/packages/browser-wallet/src/popup/pages/SendTransaction/i18n/en.ts
@@ -23,7 +23,6 @@ const t = {
         missingNonce: 'No nonce was found for the chosen account',
     },
     version: 'Version',
-    sourceHash: 'Module hash',
 };
 
 export default t;

--- a/packages/browser-wallet/src/popup/shared/TransactionReceipt/TransactionReceipt.scss
+++ b/packages/browser-wallet/src/popup/shared/TransactionReceipt/TransactionReceipt.scss
@@ -58,6 +58,10 @@ $transaction-receipt-horizontal-padding: rem(20px);
         width: rem(180px);
         overflow-wrap: break-word;
     }
+
+    &__copy-button {
+        min-width: rem(18px);
+    }
 }
 
 :where(.transaction-receipt) h5 {

--- a/packages/browser-wallet/src/popup/shared/TransactionReceipt/TransactionReceipt.scss
+++ b/packages/browser-wallet/src/popup/shared/TransactionReceipt/TransactionReceipt.scss
@@ -59,6 +59,11 @@ $transaction-receipt-horizontal-padding: rem(20px);
         overflow-wrap: break-word;
     }
 
+    &__with-copy {
+        gap: rem(5px);
+        margin-left: rem(18px);
+    }
+
     &__copy-button {
         min-width: rem(18px);
     }

--- a/packages/browser-wallet/src/popup/shared/TransactionReceipt/displayPayload/DisplayDeployModule.tsx
+++ b/packages/browser-wallet/src/popup/shared/TransactionReceipt/displayPayload/DisplayDeployModule.tsx
@@ -19,7 +19,7 @@ export default function DisplayDeployModule({ payload }: Props) {
     return (
         <>
             <OptionalField title={t('version')} value={payload.version} />
-            <h5>{t('sourceHash')}:</h5>
+            <h5>{t('moduleReference')}:</h5>
             <div className="flex align-center">
                 <p className="mono transaction-receipt__value text-center m-0">{chunkString(hash, 32).join('\n')}</p>
                 <CopyButton className="transaction-receipt__copy-button" value={hash} />

--- a/packages/browser-wallet/src/popup/shared/TransactionReceipt/displayPayload/DisplayDeployModule.tsx
+++ b/packages/browser-wallet/src/popup/shared/TransactionReceipt/displayPayload/DisplayDeployModule.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { DeployModulePayload, sha256 } from '@concordium/web-sdk';
 import { chunkString } from 'wallet-common-helpers';
+import CopyButton from '@popup/shared/CopyButton';
 import OptionalField from './OptionalField';
 
 interface Props {
@@ -19,7 +20,10 @@ export default function DisplayDeployModule({ payload }: Props) {
         <>
             <OptionalField title={t('version')} value={payload.version} />
             <h5>{t('sourceHash')}:</h5>
-            <div className="mono transaction-receipt__value text-center">{chunkString(hash, 32).join('\n')}</div>
+            <div className="flex align-center">
+                <p className="mono transaction-receipt__value text-center m-0">{chunkString(hash, 32).join('\n')}</p>
+                <CopyButton className="transaction-receipt__copy-button" value={hash} />
+            </div>
         </>
     );
 }

--- a/packages/browser-wallet/src/popup/shared/TransactionReceipt/displayPayload/DisplayDeployModule.tsx
+++ b/packages/browser-wallet/src/popup/shared/TransactionReceipt/displayPayload/DisplayDeployModule.tsx
@@ -20,7 +20,7 @@ export default function DisplayDeployModule({ payload }: Props) {
         <>
             <OptionalField title={t('version')} value={payload.version} />
             <h5>{t('moduleReference')}:</h5>
-            <div className="flex align-center">
+            <div className="flex align-center transaction-receipt__with-copy">
                 <p className="mono transaction-receipt__value text-center m-0">{chunkString(hash, 32).join('\n')}</p>
                 <CopyButton className="transaction-receipt__copy-button" value={hash} />
             </div>


### PR DESCRIPTION
## Purpose

Fixes for `deployModule` display.

## Changes

Bumped version to 1.0.6.

In deploy module display:
- Change `module hash` to `module reference`.
- Add copy button for module reference.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
