### PR TITLE
Fix grpc client first call failing

### DIFF
--- a/packages/browser-wallet-api/src/gRPC-transport.ts
+++ b/packages/browser-wallet-api/src/gRPC-transport.ts
@@ -24,10 +24,12 @@ import {
 export class BWGRPCTransport implements RpcTransport {
     messageHandler: InjectedMessageHandler;
 
-    transport: RpcTransport | undefined;
+    transport: RpcTransport;
 
     constructor(messageHandler: InjectedMessageHandler) {
         this.messageHandler = messageHandler;
+        // baseUrl is placeholder that is replaced during the call.
+        this.transport = new GrpcWebFetchTransport({ baseUrl: '' });
     }
 
     mergeOptions(options: RpcOptions) {
@@ -55,10 +57,8 @@ export class BWGRPCTransport implements RpcTransport {
                 if (!response.success) {
                     throw new Error(response.message);
                 }
-                // Perform the actual gRPC request:
-                this.transport = new GrpcWebFetchTransport({ baseUrl: response.result });
-                // mergeOptions to actually apply current defaultOptions
-                const unary = this.transport.unary(method, input, this.mergeOptions(options));
+                // Perform the actual gRPC request: (Overwrite the baseUrl to use the one we got from the wallet)
+                const unary = this.transport.unary(method, input, { ...options, baseUrl: response.result });
                 // Forward results for all the 4 outputs:
                 unary.headers.then(defHeader.resolve.bind(defHeader)).catch(defHeader.reject.bind(defHeader));
                 unary.response.then(defMessage.resolve.bind(defMessage)).catch(defMessage.reject.bind(defMessage));
@@ -105,10 +105,9 @@ export class BWGRPCTransport implements RpcTransport {
                 if (!response.success) {
                     throw new Error(response.message);
                 }
-                // Perform the actual gRPC request:
-                this.transport = new GrpcWebFetchTransport({ baseUrl: response.result });
-                // mergeOptions to actually apply current defaultOptions
-                const stream = this.transport.serverStreaming(method, input, this.mergeOptions(options));
+
+                // Perform the actual gRPC request: (Overwrite the baseUrl to use the one we got from the wallet)
+                const stream = this.transport.serverStreaming(method, input, { ...options, baseUrl: response.result });
                 // Forward results for all the 4 outputs:
                 stream.headers.then(defHeader.resolve.bind(defHeader)).catch(defHeader.reject.bind(defHeader));
                 stream.responses.onNext(responseStream.notifyNext.bind(responseStream));

--- a/packages/browser-wallet-api/src/gRPC-transport.ts
+++ b/packages/browser-wallet-api/src/gRPC-transport.ts
@@ -57,7 +57,8 @@ export class BWGRPCTransport implements RpcTransport {
                 }
                 // Perform the actual gRPC request:
                 this.transport = new GrpcWebFetchTransport({ baseUrl: response.result });
-                const unary = this.transport.unary(method, input, options);
+                // mergeOptions to actually apply current defaultOptions
+                const unary = this.transport.unary(method, input, this.mergeOptions(options));
                 // Forward results for all the 4 outputs:
                 unary.headers.then(defHeader.resolve.bind(defHeader)).catch(defHeader.reject.bind(defHeader));
                 unary.response.then(defMessage.resolve.bind(defMessage)).catch(defMessage.reject.bind(defMessage));
@@ -106,7 +107,8 @@ export class BWGRPCTransport implements RpcTransport {
                 }
                 // Perform the actual gRPC request:
                 this.transport = new GrpcWebFetchTransport({ baseUrl: response.result });
-                const stream = this.transport.serverStreaming(method, input, options);
+                // mergeOptions to actually apply current defaultOptions
+                const stream = this.transport.serverStreaming(method, input, this.mergeOptions(options));
                 // Forward results for all the 4 outputs:
                 stream.headers.then(defHeader.resolve.bind(defHeader)).catch(defHeader.reject.bind(defHeader));
                 stream.responses.onNext(responseStream.notifyNext.bind(responseStream));

--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 -   Display of a `deployModule` transaction now includes a copy button for the module reference.
 
+### Fixed
+
+-   First call of the gRPC client no longer always fail.
+
 ## 1.0.5
 
 ### Added

--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Changed
 
 -   In the display of a `deployModule` transaction, the previously titled module hash is now titled module reference.
--   Updated web-sdk to fix incorrect estimated cost for `deployModule` transaction.
 
 ### Added
 
@@ -13,7 +12,9 @@
 
 ### Fixed
 
--   First call of the gRPC client no longer always fail.
+-   First call of the gRPC client no longer always fails.
+-   First call of the gRPC client after changing network now uses the correct network.
+-   Updated web-sdk to fix incorrect estimated cost for `deployModule` transaction.
 
 ## 1.0.5
 


### PR DESCRIPTION
## Purpose

Before, the URL was not actually immediately used, instead the client would always use the previous call's URL, which on the first call is undefined. It also meant that after changing network, the first call would still be directed to the old network. 
This should fix that.


## Changes

Apply base settings immediately before performing the actual call.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
