### PR TITLE
Add network to docker image tag

### DIFF
--- a/examples/wCCD/Jenkinsfile
+++ b/examples/wCCD/Jenkinsfile
@@ -6,7 +6,7 @@ pipeline {
     agent any
     environment {
         image_repo = "concordium/dapp-wccd"
-        image_name = "${image_repo}:${image_tag}"
+        image_name = "${image_repo}:${network}-${image_tag}"
     }
     stages {
         stage('dockerhub-login') {


### PR DESCRIPTION
## Purpose

Docker images are now built for a specific network, added network to image tag.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
