### PR TITLE
Add link to voting tutorial

### DIFF
--- a/examples/voting/CHANGELOG.md
+++ b/examples/voting/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+-   Initial voting frontend

--- a/examples/voting/package.json
+++ b/examples/voting/package.json
@@ -1,6 +1,7 @@
 {
     "name": "voting",
     "license": "Apache-2.0",
+    "version": "1.0.0",
     "packageManager": "yarn@3.2.0",
     "dependencies": {
         "@concordium/browser-wallet-api-helpers": "^2.0.0",

--- a/examples/voting/src/CreateElectionPage.js
+++ b/examples/voting/src/CreateElectionPage.js
@@ -10,6 +10,7 @@ import { Link } from 'react-router-dom';
 import moment from 'moment';
 import Wallet, { createElection, init } from './Wallet';
 import { CONTRACT_NAME, MODULE_REF } from './config';
+import Footer from './Footer';
 
 async function addOption(options, setOptions, newOption, setOptionInput) {
     if (options.includes(newOption)) {
@@ -161,6 +162,7 @@ function CreateElectionPage() {
                     )}
                 </Col>
             </Row>
+            <Footer />
         </Container>
     );
 }

--- a/examples/voting/src/Footer.js
+++ b/examples/voting/src/Footer.js
@@ -1,0 +1,24 @@
+/* eslint-disable react/jsx-filename-extension */
+import React from 'react';
+import { Col } from 'react-bootstrap';
+import packageInfo from '../package.json';
+
+function Footer() {
+    return (
+        <>
+            <hr />
+            <Col style={{ textAlign: 'center' }}>
+                Version: {packageInfo.version} |{' '}
+                <a
+                    href="https://developer.concordium.software/en/mainnet/smart-contracts/tutorials/voting/index.html"
+                    target="_blank"
+                    rel="noreferrer"
+                >
+                    Explore the voting tutorial here.
+                </a>
+            </Col>
+        </>
+    );
+}
+
+export default Footer;

--- a/examples/voting/src/HomePage.js
+++ b/examples/voting/src/HomePage.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import { Button, Col, Container, Row } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
+import Footer from './Footer';
 
 function HomePage() {
     return (
@@ -22,6 +23,7 @@ function HomePage() {
                     </Link>
                 </Col>
             </Row>
+            <Footer />
         </Container>
     );
 }

--- a/examples/voting/src/Results.js
+++ b/examples/voting/src/Results.js
@@ -12,6 +12,7 @@ import { detectConcordiumProvider } from '@concordium/browser-wallet-api-helpers
 import { decodeView, decodeVotes } from './buffer';
 import { getView, getVotes } from './Wallet';
 import { REFRESH_INTERVAL } from './config';
+import Footer from './Footer';
 
 function VoteLink(props) {
     const { electionId, endsInMillis } = props;
@@ -155,6 +156,7 @@ function Results() {
             <footer>
                 <p>*Smart contract index on the Concordium chain</p>
             </footer>
+            <Footer />
         </Container>
     );
 }

--- a/examples/voting/src/VotePage.js
+++ b/examples/voting/src/VotePage.js
@@ -6,6 +6,7 @@ import { useParams, Link } from 'react-router-dom';
 import { Button, Col, Container, Form, Row } from 'react-bootstrap';
 import Wallet, { castVote, init, getView } from './Wallet';
 import { decodeView } from './buffer';
+import Footer from './Footer';
 
 function VotePage() {
     const params = useParams();
@@ -101,6 +102,7 @@ function VotePage() {
             <footer>
                 <p>*Smart contract index on the Concordium chain</p>
             </footer>
+            <Footer />
         </Container>
     );
 }


### PR DESCRIPTION
## Purpose

All hosted front ends should have a way to find the source code easily. Either through a link to an associated tutorial (that contains links to the source code) or if no tutorial exists through a link to the source code.

## Changes

- Add link to tutorial.
- Add `ChangeLog`.
- Add `version` to front end.
