### PR TITLE
Relax AccountTransactionType in wallet-api

### DIFF
--- a/packages/browser-wallet-api-helpers/src/util.ts
+++ b/packages/browser-wallet-api-helpers/src/util.ts
@@ -1,0 +1,2 @@
+export type LaxStringEnumValue<E extends string> = `${E}`;
+export type LaxNumberEnumValue<E extends number> = `${E}` extends `${infer T extends number}` ? T : never;

--- a/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
+++ b/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
@@ -10,6 +10,7 @@ import type {
     IdProofOutput,
     ConcordiumGRPCClient,
 } from '@concordium/web-sdk';
+import { LaxNumberEnumValue, LaxStringEnumValue } from './util';
 
 export type SendTransactionPayload =
     | Exclude<AccountTransactionPayload, UpdateContractPayload | InitContractPayload>
@@ -43,9 +44,6 @@ export enum SchemaType {
     Module = 'module',
     Parameter = 'parameter',
 }
-
-type LaxStringEnumValue<E extends string> = `${E}`;
-type LaxNumberEnumValue<E extends number> = `${E}` extends `${infer T extends number}` ? T : never;
 
 export type SchemaWithContext = {
     type: LaxStringEnumValue<SchemaType>;

--- a/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
+++ b/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
@@ -45,6 +45,7 @@ export enum SchemaType {
 }
 
 type LaxStringEnumValue<E extends string> = `${E}`;
+type LaxNumberEnumValue<E extends number> = `${E}` extends `${infer T extends number}` ? T : never;
 
 export type SchemaWithContext = {
     type: LaxStringEnumValue<SchemaType>;
@@ -79,7 +80,7 @@ interface MainWalletApi {
      */
     sendTransaction(
         accountAddress: string,
-        type: AccountTransactionType.Update | AccountTransactionType.InitContract,
+        type: LaxNumberEnumValue<AccountTransactionType.Update | AccountTransactionType.InitContract>,
         payload: SendTransactionPayload,
         parameters: SmartContractParameters,
         schema: string | SchemaWithContext,
@@ -94,7 +95,7 @@ interface MainWalletApi {
      */
     sendTransaction(
         accountAddress: string,
-        type: AccountTransactionType,
+        type: LaxNumberEnumValue<AccountTransactionType>,
         payload: SendTransactionPayload
     ): Promise<string>;
     /**

--- a/packages/browser-wallet/test/wallet-api.test.ts
+++ b/packages/browser-wallet/test/wallet-api.test.ts
@@ -1,0 +1,18 @@
+import { LaxNumberEnumValue } from '@concordium/browser-wallet-api-helpers/src/util';
+
+enum Enum {
+    One = 1,
+    Two = 2,
+}
+
+function increment(arg: LaxNumberEnumValue<Enum>): Enum {
+    return arg + 1;
+}
+
+test('LaxNumberEnumValue accepts constants', () => {
+    expect(increment(1)).toEqual(2);
+});
+
+test('LaxNumberEnumValue accepts the enum values', () => {
+    expect(increment(Enum.One)).toEqual(2);
+});


### PR DESCRIPTION
## Purpose

Relax transaction type parameter in the `wallet-api`, so numbers can be given directly and tsc doesn't complain if a different version of the enum is used.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.