### PR TITLE
Change from json-rpc to grpc

### DIFF
--- a/examples/eSealing/CHANGELOG.md
+++ b/examples/eSealing/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 1.1.2
+
+-   Migrate dApp from using deprecated JSON-RPC client to new gRPC client.
+
+## 1.1.1
+
+-   Initial eSealing front end.

--- a/examples/eSealing/package.json
+++ b/examples/eSealing/package.json
@@ -5,7 +5,6 @@
     "license": "Apache-2.0",
     "dependencies": {
         "@concordium/react-components": "^0.3.0",
-        "@concordium/web-sdk": "^3.3.1",
         "@thi.ng/leb128": "^2.1.18",
         "@types/sha256": "^0.2.0",
         "@walletconnect/types": "^2.1.4",

--- a/examples/eSealing/package.json
+++ b/examples/eSealing/package.json
@@ -1,10 +1,10 @@
 {
     "name": "e_sealing",
     "packageManager": "yarn@3.2.0",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "license": "Apache-2.0",
     "dependencies": {
-        "@concordium/react-components": "^0.2.0",
+        "@concordium/react-components": "^0.3.0",
         "@concordium/web-sdk": "^3.3.1",
         "@thi.ng/leb128": "^2.1.18",
         "@types/sha256": "^0.2.0",

--- a/examples/eSealing/src/Root.tsx
+++ b/examples/eSealing/src/Root.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
-import { WithWalletConnector } from '@concordium/react-components';
+import { WithWalletConnector, TESTNET } from '@concordium/react-components';
 import SEALING from './eSealing';
-import { TESTNET } from './constants';
 
 /**
  * Connect to wallet, setup application state context, and render children when the wallet API is ready for use.

--- a/examples/eSealing/src/constants.ts
+++ b/examples/eSealing/src/constants.ts
@@ -1,13 +1,6 @@
 // The TESTNET_GENESIS_BLOCK_HASH is used to check that the user has its browser wallet connected to testnet and not to mainnet.
-import {
-    BrowserWalletConnector,
-    ephemeralConnectorType,
-    Network,
-    WalletConnectConnector,
-} from '@concordium/react-components';
+import { BrowserWalletConnector, ephemeralConnectorType, WalletConnectConnector } from '@concordium/react-components';
 import { SignClientTypes } from '@walletconnect/types';
-
-export const TESTNET_GENESIS_BLOCK_HASH = '4221332d34e1694168c2a0c0b3fd0f273809612cb13d000d5c2e00e85f50f796';
 
 export const E_SEALING_CONTRACT_NAME = 'eSealing';
 
@@ -27,12 +20,6 @@ const WALLET_CONNECT_OPTS: SignClientTypes.Options = {
         url: '#',
         icons: ['https://walletconnect.com/walletconnect-logo.png'],
     },
-};
-export const TESTNET: Network = {
-    name: 'testnet',
-    genesisHash: TESTNET_GENESIS_BLOCK_HASH,
-    jsonRpcUrl: 'https://json-rpc.testnet.concordium.com',
-    ccdScanBaseUrl: 'https://testnet.ccdscan.io',
 };
 
 export const BROWSER_WALLET = ephemeralConnectorType(BrowserWalletConnector.create);

--- a/examples/eSealing/src/eSealing.tsx
+++ b/examples/eSealing/src/eSealing.tsx
@@ -156,7 +156,7 @@ export default function SEALING(props: WalletConnectionProps) {
 
     useEffect(() => {
         // View file record.
-        if (grpcClient && account && fileHashHex !== '') {
+        if (grpcClient && fileHashHex !== '') {
             viewFile(grpcClient, fileHashHex)
                 .then((record) => {
                     setGetFileError('');
@@ -169,7 +169,7 @@ export default function SEALING(props: WalletConnectionProps) {
                     setWitness('');
                 });
         }
-    }, [grpcClient, account, fileHashHex]);
+    }, [grpcClient, fileHashHex]);
 
     const [isRegisterFilePage, setIsRegisterFilePage] = useState(true);
     const [hash, setHash] = useState('');

--- a/examples/eSealing/src/eSealing.tsx
+++ b/examples/eSealing/src/eSealing.tsx
@@ -4,10 +4,10 @@ import {
     toBuffer,
     deserializeReceiveReturnValue,
     serializeUpdateContractParameters,
-    JsonRpcClient,
+    ConcordiumGRPCClient,
 } from '@concordium/web-sdk';
 import sha256 from 'sha256';
-import { withJsonRpcClient, WalletConnectionProps, useConnection, useConnect } from '@concordium/react-components';
+import { useGrpcClient, TESTNET, WalletConnectionProps, useConnection, useConnect } from '@concordium/react-components';
 import { version } from '../package.json';
 
 import { register } from './utils';
@@ -94,7 +94,7 @@ const InputFieldStyle = {
     padding: '10px 20px',
 };
 
-async function viewFile(rpcClient: JsonRpcClient, fileHashHex: string) {
+async function viewFile(rpcClient: ConcordiumGRPCClient, fileHashHex: string) {
     const param = serializeUpdateContractParameters(
         E_SEALING_CONTRACT_NAME,
         'getFile',
@@ -134,6 +134,7 @@ export default function SEALING(props: WalletConnectionProps) {
 
     const { connection, setConnection, account, genesisHash } = useConnection(connectedAccounts, genesisHashes);
     const { connect, isConnecting, connectError } = useConnect(activeConnector, setConnection);
+    const grpcClient = useGrpcClient(TESTNET);
 
     const [isLoading, setLoading] = useState(false);
 
@@ -155,8 +156,8 @@ export default function SEALING(props: WalletConnectionProps) {
 
     useEffect(() => {
         // View file record.
-        if (connection && account && fileHashHex !== '') {
-            withJsonRpcClient(connection, (rpcClient) => viewFile(rpcClient, fileHashHex))
+        if (grpcClient && account && fileHashHex !== '') {
+            viewFile(grpcClient, fileHashHex)
                 .then((record) => {
                     setGetFileError('');
                     setTimestamp(record.timestamp);
@@ -168,7 +169,7 @@ export default function SEALING(props: WalletConnectionProps) {
                     setWitness('');
                 });
         }
-    }, [connection, account, fileHashHex]);
+    }, [grpcClient, account, fileHashHex]);
 
     const [isRegisterFilePage, setIsRegisterFilePage] = useState(true);
     const [hash, setHash] = useState('');

--- a/examples/eSealing/src/utils.ts
+++ b/examples/eSealing/src/utils.ts
@@ -1,5 +1,5 @@
 import { createContext } from 'react';
-import { AccountTransactionType, CcdAmount, UpdateContractPayload } from '@concordium/web-sdk';
+import { AccountTransactionType, CcdAmount } from '@concordium/web-sdk';
 import { WalletConnection, moduleSchemaFromBase64 } from '@concordium/react-components';
 import { E_SEALING_CONTRACT_NAME, E_SEALING_RAW_SCHEMA } from './constants';
 
@@ -24,7 +24,7 @@ export async function register(
             },
             receiveName: `${E_SEALING_CONTRACT_NAME}.registerFile`,
             maxContractExecutionEnergy: 30000n,
-        } as UpdateContractPayload,
+        },
         {
             parameters: fileHashHex,
             schema: moduleSchemaFromBase64(E_SEALING_RAW_SCHEMA),

--- a/examples/eSealing/src/utils.ts
+++ b/examples/eSealing/src/utils.ts
@@ -1,6 +1,6 @@
 import { createContext } from 'react';
 import { AccountTransactionType, CcdAmount, UpdateContractPayload } from '@concordium/web-sdk';
-import { WalletConnection } from '@concordium/react-components';
+import { WalletConnection, moduleSchemaFromBase64 } from '@concordium/react-components';
 import { E_SEALING_CONTRACT_NAME, E_SEALING_RAW_SCHEMA } from './constants';
 
 /**
@@ -25,10 +25,10 @@ export async function register(
             receiveName: `${E_SEALING_CONTRACT_NAME}.registerFile`,
             maxContractExecutionEnergy: 30000n,
         } as UpdateContractPayload,
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        fileHashHex,
-        E_SEALING_RAW_SCHEMA
+        {
+            parameters: fileHashHex,
+            schema: moduleSchemaFromBase64(E_SEALING_RAW_SCHEMA),
+        }
     );
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1910,7 +1910,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@concordium/browser-wallet-api-helpers@^2.0.0, @concordium/browser-wallet-api-helpers@workspace:^, @concordium/browser-wallet-api-helpers@workspace:packages/browser-wallet-api-helpers":
+"@concordium/browser-wallet-api-helpers@^2.0.0, @concordium/browser-wallet-api-helpers@^2.5.0, @concordium/browser-wallet-api-helpers@workspace:^, @concordium/browser-wallet-api-helpers@workspace:packages/browser-wallet-api-helpers":
   version: 0.0.0-use.local
   resolution: "@concordium/browser-wallet-api-helpers@workspace:packages/browser-wallet-api-helpers"
   dependencies:
@@ -2076,6 +2076,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@concordium/react-components@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@concordium/react-components@npm:0.3.0"
+  dependencies:
+    "@concordium/wallet-connectors": ^0.3.1
+  peerDependencies:
+    react: ^18
+  checksum: 08cc8077f77bc8faaf977e0dbc9270f386575f928d886c4efb3d888fe017edbd36653381e17a20b272409037e648f3eb023501d166e9df0ecd0b4a0c9537c110
+  languageName: node
+  linkType: hard
+
 "@concordium/rust-bindings@npm:0.10.0":
   version: 0.10.0
   resolution: "@concordium/rust-bindings@npm:0.10.0"
@@ -2098,6 +2109,17 @@ __metadata:
     "@walletconnect/qrcode-modal": ^1.8.0
     "@walletconnect/sign-client": ^2.1.4
   checksum: 262af06d5d09e452d307022c66a1d303d8aad1c21f6bfeb6bc24acb4f102bc5deb492de7e093612b05a6f67a9031f6801089f6aec671d0ae7eb26d7ead9cf528
+  languageName: node
+  linkType: hard
+
+"@concordium/wallet-connectors@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "@concordium/wallet-connectors@npm:0.3.1"
+  dependencies:
+    "@concordium/browser-wallet-api-helpers": ^2.5.0
+    "@walletconnect/qrcode-modal": ^1.8.0
+    "@walletconnect/sign-client": ^2.1.4
+  checksum: 7ef4287d05977fe741d47d53ea9424f603c8acfe0a0c0af1bfea2c5752b0bc5750be942badaa414a6694e7be4032e8d1a91f8ab69327cdcff016f28da0cf6a23
   languageName: node
   linkType: hard
 
@@ -10182,7 +10204,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "e_sealing@workspace:examples/eSealing"
   dependencies:
-    "@concordium/react-components": ^0.2.0
+    "@concordium/react-components": ^0.3.0
     "@concordium/web-sdk": ^3.3.1
     "@craftamap/esbuild-plugin-html": ^0.4.0
     "@thi.ng/leb128": ^2.1.18

--- a/yarn.lock
+++ b/yarn.lock
@@ -10205,7 +10205,6 @@ __metadata:
   resolution: "e_sealing@workspace:examples/eSealing"
   dependencies:
     "@concordium/react-components": ^0.3.0
-    "@concordium/web-sdk": ^3.3.1
     "@craftamap/esbuild-plugin-html": ^0.4.0
     "@thi.ng/leb128": ^2.1.18
     "@types/node": ^18.7.23


### PR DESCRIPTION
## Purpose

- JSON-RPC is deprecated and will be eventually removed from all our libraries. This PR migrates the eSealing dApp.

## Changes

- Replace using jsonRPC with gRPC

