### PR TITLE
Replace json-rpc with grpc in voting dApp

### DIFF
--- a/examples/voting/CHANGELOG.md
+++ b/examples/voting/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Changelog
 
+## 1.1.1
+
+-   Migrate dApp from using deprecated JSON-RPC client to new gRPC client.
+
 ## 1.1.0
 
-- Add jenkins file
+-   Add jenkins file
 
 ## 1.0.0
 
-- Initial voting frontend
+-   Initial voting frontend

--- a/examples/voting/package.json
+++ b/examples/voting/package.json
@@ -1,11 +1,11 @@
 {
     "name": "voting",
     "license": "Apache-2.0",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "packageManager": "yarn@3.2.0",
     "dependencies": {
         "@concordium/browser-wallet-api-helpers": "^2.0.0",
-        "@concordium/web-sdk": "^3.3.1",
+        "@concordium/web-sdk": "^6.0.0",
         "bootstrap": "^5.2.1",
         "cross-env": "^7.0.3",
         "moment": "^2.29.4",

--- a/examples/voting/package.json
+++ b/examples/voting/package.json
@@ -27,6 +27,9 @@
         "ts-node": "^10.8.0",
         "typescript": "^4.7.2"
     },
+    "resolutions": {
+        "@concordium/web-sdk": "^6.0.0"
+    },
     "scripts": {
         "build": "node --loader ts-node/esm ./esbuild.config.ts; cp ./public/static/img/* ./dist",
         "start": "node ./serve",

--- a/examples/voting/src/CreateElectionPage.js
+++ b/examples/voting/src/CreateElectionPage.js
@@ -5,7 +5,6 @@
 /* eslint-disable react/jsx-filename-extension */
 import React, { useEffect, useState } from 'react';
 import { Button, Col, Container, FloatingLabel, Form, InputGroup, Row, Spinner } from 'react-bootstrap';
-import { TransactionStatusEnum } from '@concordium/web-sdk';
 import { Link } from 'react-router-dom';
 import moment from 'moment';
 import Wallet, { createElection, init } from './Wallet';
@@ -44,13 +43,12 @@ function CreateElectionPage() {
             const interval = setInterval(
                 () =>
                     client
-                        .getJsonRpcClient()
-                        .getTransactionStatus(submittedTxHash)
+                        .getGrpcClient()
+                        .getBlockItemStatus(submittedTxHash)
                         .then((status) => {
-                            if (status && status.status === TransactionStatusEnum.Finalized && status.outcomes) {
-                                const outcome = Object.values(status.outcomes)[0];
-                                if (outcome.result.outcome === 'success') {
-                                    const contractIndex = outcome.result.events[0].address.index;
+                            if (status && status.status === 'finalized') {
+                                if (status.outcome.summary.contractInitialized.address.index !== undefined) {
+                                    const contractIndex = status.outcome.summary.contractInitialized.address.index;
                                     setCreatedContractId(contractIndex);
                                 } else {
                                     console.error('creation failed');

--- a/examples/voting/src/Wallet.js
+++ b/examples/voting/src/Wallet.js
@@ -46,7 +46,7 @@ export async function connect(client, setConnectedAccount) {
 // The smart contract voting module is deployed on the testnet chain.
 async function checkConnectedToTestnet(client) {
     return client
-        .getJsonRpcClient()
+        .getGrpcClient()
         .getCryptographicParameters(TESTNET_GENESIS_BLOCK_HASH.toString())
         .then((result) => {
             if (result === undefined || result?.value === null) {
@@ -96,7 +96,7 @@ export async function createElection(
 }
 
 export async function getView(client, contractIndex) {
-    return client.getJsonRpcClient().invokeContract({
+    return client.getGrpcClient().invokeContract({
         contract: { index: BigInt(contractIndex), subindex: BigInt(0) },
         method: 'voting.view',
     });
@@ -115,7 +115,7 @@ export async function getVotes(client, contractIndex, numOptions) {
             toBuffer(RAW_SCHEMA_BASE64, 'base64')
         );
 
-        const promise = client.getJsonRpcClient().invokeContract({
+        const promise = client.getGrpcClient().invokeContract({
             contract: { index: BigInt(contractIndex), subindex: BigInt(0) },
             method: 'voting.getNumberOfVotes',
             parameter: param,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2065,6 +2065,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@concordium/common-sdk@npm:9.0.0":
+  version: 9.0.0
+  resolution: "@concordium/common-sdk@npm:9.0.0"
+  dependencies:
+    "@concordium/rust-bindings": 1.1.0
+    "@grpc/grpc-js": ^1.3.4
+    "@noble/ed25519": ^1.7.1
+    "@protobuf-ts/runtime-rpc": ^2.8.2
+    "@scure/bip39": ^1.1.0
+    bs58check: ^2.1.2
+    buffer: ^6.0.3
+    cross-fetch: 3.1.5
+    hash.js: ^1.1.7
+    iso-3166-1: ^2.1.1
+    json-bigint: ^1.0.0
+    uuid: ^8.3.2
+  checksum: b640846415dfb18b4bb549519ab7fa7825c6b5e84adf1cfaeeea89bb54341e5176e71f00b732ea9bb375aac938842434ab1d6d5ffe2a5f360efc236ea5b0ef4a
+  languageName: node
+  linkType: hard
+
 "@concordium/react-components@npm:^0.2.0":
   version: 0.2.0
   resolution: "@concordium/react-components@npm:0.2.0"
@@ -2087,6 +2107,13 @@ __metadata:
   version: 1.0.0
   resolution: "@concordium/rust-bindings@npm:1.0.0"
   checksum: f13a9ff622d45974eb6b49261291ef726faba888867d9beeb4a754200d0666c8fba6c983db5481c45d1f6ff3256716e6fae65b7f572c826417a0595e384e828c
+  languageName: node
+  linkType: hard
+
+"@concordium/rust-bindings@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@concordium/rust-bindings@npm:1.1.0"
+  checksum: 4890306b5df5fb85012cc6c6a6daf15ec1d24c528ac487a4547e8758738a1205b2386a1d4b015dc45312811466d853819edff4b9921d3674afe13ade5cacc061
   languageName: node
   linkType: hard
 
@@ -2126,6 +2153,20 @@ __metadata:
     buffer: ^6.0.3
     process: ^0.11.10
   checksum: 779bb90cb7e5bfa25ad5bd0fa40447fc1fd92acc1b4bc24ac78f5c0010a0ff282a2db00153a84239328290b21c91d5d21364c54aac7404a81e7ad58a74daa597
+  languageName: node
+  linkType: hard
+
+"@concordium/web-sdk@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "@concordium/web-sdk@npm:6.0.0"
+  dependencies:
+    "@concordium/common-sdk": 9.0.0
+    "@concordium/rust-bindings": 1.1.0
+    "@grpc/grpc-js": ^1.3.4
+    "@protobuf-ts/grpcweb-transport": ^2.8.2
+    buffer: ^6.0.3
+    process: ^0.11.10
+  checksum: 23cfda2813ed86ed165f427edab237e5c20af70405d450541479294a1093b60843ce9d7f8a2dbeb69e174e0aed0ec51bee109e0fb7e22f121bff5c11c4bb24de
   languageName: node
   linkType: hard
 
@@ -22171,7 +22212,7 @@ __metadata:
   resolution: "voting@workspace:examples/voting"
   dependencies:
     "@concordium/browser-wallet-api-helpers": ^2.0.0
-    "@concordium/web-sdk": ^3.3.1
+    "@concordium/web-sdk": ^6.0.0
     "@types/node": ^18.7.23
     "@types/react": ^18.0.9
     "@types/react-dom": ^18.0.5


### PR DESCRIPTION
## Purpose
- JSON-RPC is deprecated and will be eventually removed from all our libraries. This PR migrates the voting dApp.

## Changes
-  Replace using jsonRPC with gRPC

