### PR TITLE
Fix proofs with number attributes

### DIFF
--- a/packages/browser-wallet-api/src/wallet-api.ts
+++ b/packages/browser-wallet-api/src/wallet-api.ts
@@ -259,7 +259,7 @@ class WalletApi extends EventEmitter implements IWalletApi {
         const res = await this.messageHandler.sendMessage<MessageStatusWrapper<string>>(
             MessageType.AddWeb3IdCredential,
             {
-                credential,
+                credential: stringify(credential),
                 metadataUrl,
             }
         );

--- a/packages/browser-wallet/src/background/web3Id.ts
+++ b/packages/browser-wallet/src/background/web3Id.ts
@@ -103,7 +103,7 @@ export async function web3IdAddCredentialFinishHandler(input: {
  * Run condition which ensures that the web3IdCredential request is valid.
  */
 export const runIfValidWeb3IdCredentialRequest: RunCondition<MessageStatusWrapper<undefined>> = async (msg) => {
-    const { credential }: { credential: APIVerifiableCredential } = msg.payload;
+    const credential: APIVerifiableCredential = parse(msg.payload.credential);
     const network = await storedCurrentNetwork.get();
 
     if (!network) {
@@ -151,7 +151,7 @@ async function createWeb3Proof(input: Web3IdProofInput): Promise<ProofBackground
 }
 
 export const createWeb3IdProofHandler: ExtensionMessageHandler = (msg, _sender, respond) => {
-    createWeb3Proof(msg.payload)
+    createWeb3Proof(parse(msg.payload))
         .then(respond)
         .catch((e: Error) => respond({ status: BackgroundResponseStatus.Error, error: e.message }));
     return true;

--- a/packages/browser-wallet/src/popup/pages/AddWeb3IdCredential/AddWeb3IdCredential.tsx
+++ b/packages/browser-wallet/src/popup/pages/AddWeb3IdCredential/AddWeb3IdCredential.tsx
@@ -25,6 +25,7 @@ import {
 import { APIVerifiableCredential } from '@concordium/browser-wallet-api-helpers';
 import { networkConfigurationAtom } from '@popup/store/settings';
 import { MetadataUrl } from '@concordium/browser-wallet-api-helpers/lib/wallet-api-types';
+import { parse } from '@shared/utils/payload-helpers';
 import { VerifiableCredentialCard } from '../VerifiableCredential/VerifiableCredentialCard';
 
 type Props = {
@@ -36,7 +37,7 @@ interface Location {
     state: {
         payload: {
             url: string;
-            credential: APIVerifiableCredential;
+            credential: string;
             metadataUrl: MetadataUrl;
         };
     };
@@ -58,7 +59,8 @@ export default function AddWeb3IdCredential({ onAllow, onReject }: Props) {
 
     const [error, setError] = useState<string>();
 
-    const { credential, url, metadataUrl } = state.payload;
+    const { credential: rawCredential, url, metadataUrl } = state.payload;
+    const credential: APIVerifiableCredential = parse(rawCredential);
 
     useEffect(() => onClose(onReject), [onClose, onReject]);
 

--- a/packages/browser-wallet/src/popup/pages/Web3ProofRequest/VerifiableCredentialStatement.tsx
+++ b/packages/browser-wallet/src/popup/pages/Web3ProofRequest/VerifiableCredentialStatement.tsx
@@ -25,7 +25,7 @@ import { createWeb3IdDIDFromCredential, DisplayCredentialStatementProps, SecretS
 function getPropertyTitle(attributeTag: string, schema: VerifiableCredentialSchema) {
     // TODO use localization here
     const property = schema.properties.credentialSubject.properties.attributes.properties[attributeTag];
-    return property.title;
+    return property ? property.title : attributeTag;
 }
 
 function useStatementValue(statement: SecretStatementV2, schema: VerifiableCredentialSchema): string {

--- a/packages/browser-wallet/src/popup/pages/Web3ProofRequest/Web3ProofRequest.tsx
+++ b/packages/browser-wallet/src/popup/pages/Web3ProofRequest/Web3ProofRequest.tsx
@@ -36,6 +36,7 @@ import { parse } from '@shared/utils/payload-helpers';
 import { VerifiableCredential, VerifiableCredentialStatus } from '@shared/storage/types';
 import { getVerifiableCredentialStatus } from '@shared/utils/verifiable-credential-helpers';
 import { useAsyncMemo } from 'wallet-common-helpers';
+import { stringify } from '@concordium/browser-wallet-api/src/util';
 import {
     getAccountCredentialCommitmentInput,
     getViableAccountCredentialsForStatement,
@@ -189,7 +190,7 @@ export default function Web3ProofRequest({ onReject, onSubmit }: Props) {
 
         const result: ProofBackgroundResponse<string> = await popupMessageHandler.sendInternalMessage(
             InternalMessageType.CreateWeb3IdProof,
-            input
+            stringify(input)
         );
 
         if (result.status !== BackgroundResponseStatus.Success) {

--- a/packages/browser-wallet/src/popup/pages/Web3ProofRequest/utils.ts
+++ b/packages/browser-wallet/src/popup/pages/Web3ProofRequest/utils.ts
@@ -101,7 +101,17 @@ export function getViableAccountCredentialsForStatement(
 
 // TODO Replace with canProveAtomicStatement when SDK is updated
 function doesCredentialSatisfyStatement(statement: AtomicStatementV2, cred: VerifiableCredential): boolean {
-    const value = cred.credentialSubject.attributes[statement.attributeTag];
+    let value = cred.credentialSubject.attributes[statement.attributeTag];
+
+    // temporary handling of numbers saved as numbers;
+    if (typeof value === 'number') {
+        value = BigInt(value);
+    }
+
+    if (value === undefined) {
+        return false;
+    }
+
     switch (statement.type) {
         case StatementTypes.AttributeInRange:
             return statement.lower <= value && statement.upper > value;


### PR DESCRIPTION
## Purpose

Enable proofs with number attributes.

## Changes

- Handle number attributes in proofs
 - Don't crash on non-existant attributes (might be moot due to the next point)
 - Now filter credential that don't have the attribute, even if its nonMembership.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
