### PR TITLE
Display issuer metadata in credential details page

### DIFF
--- a/packages/browser-wallet/src/popup/pages/VerifiableCredential/VerifiableCredential.scss
+++ b/packages/browser-wallet/src/popup/pages/VerifiableCredential/VerifiableCredential.scss
@@ -11,6 +11,11 @@
     }
 }
 
+.issuer-logo {
+    width: rem(28px);
+    height: rem(28px);
+}
+
 .verifiable-credential {
     color: $color-white;
     border-radius: rem(16px);

--- a/packages/browser-wallet/src/popup/pages/VerifiableCredential/VerifiableCredentialDetails.tsx
+++ b/packages/browser-wallet/src/popup/pages/VerifiableCredential/VerifiableCredentialDetails.tsx
@@ -20,11 +20,61 @@ import {
 import { fetchContractName } from '@shared/utils/token-helpers';
 import { TimeStampUnit, dateFromTimestamp, ClassName } from 'wallet-common-helpers';
 import { withDateAndTime } from '@shared/utils/time-helpers';
+import Img from '@popup/shared/Img';
 import { accountRoutes } from '../Account/routes';
 import { ConfirmGenericTransferState } from '../Account/ConfirmGenericTransfer';
 import RevokeIcon from '../../../assets/svg/revoke.svg';
-import { useCredentialEntry } from './VerifiableCredentialHooks';
+import { useCredentialEntry, useIssuerMetadata } from './VerifiableCredentialHooks';
 import { DisplayAttribute, VerifiableCredentialCard, VerifiableCredentialCardHeader } from './VerifiableCredentialCard';
+
+/**
+ * Component for displaying issuer metadata, if any is available.
+ * All the fields in the issuer metadata are optional, and if none of
+ * them are provided, then the component returns null.
+ * @param issuer the did for the issuer
+ */
+function DisplayIssuerMetadata({ issuer }: { issuer: string }) {
+    const { t } = useTranslation('verifiableCredential');
+    const issuerMetadata = useIssuerMetadata(issuer);
+
+    if (
+        issuerMetadata === undefined ||
+        (issuerMetadata.description === undefined &&
+            issuerMetadata.icon === undefined &&
+            issuerMetadata.name === undefined &&
+            issuerMetadata.url === undefined)
+    ) {
+        return null;
+    }
+
+    return (
+        <div className="verifiable-credential__body-attributes">
+            <h3>{t('details.issuer.title')}</h3>
+            {issuerMetadata.icon && <Img className="issuer-logo" src={issuerMetadata.icon.url} withDefaults />}
+            {issuerMetadata.name && (
+                <DisplayAttribute
+                    attributeKey="issuerName"
+                    attributeTitle={t('details.issuer.name')}
+                    attributeValue={issuerMetadata.name}
+                />
+            )}
+            {issuerMetadata.description && (
+                <DisplayAttribute
+                    attributeKey="issuerName"
+                    attributeTitle={t('details.issuer.description')}
+                    attributeValue={issuerMetadata.description}
+                />
+            )}
+            {issuerMetadata.url && (
+                <DisplayAttribute
+                    attributeKey="issuerName"
+                    attributeTitle={t('details.issuer.url')}
+                    attributeValue={issuerMetadata.url}
+                />
+            )}
+        </div>
+    );
+}
 
 /**
  * Component for displaying the extra details about a verifiable credential, i.e. the
@@ -35,10 +85,12 @@ function VerifiableCredentialExtraDetails({
     status,
     metadata,
     className,
+    issuer,
 }: {
     credentialEntry: CredentialQueryResponse;
     status: VerifiableCredentialStatus;
     metadata: VerifiableCredentialMetadata;
+    issuer: string;
 } & ClassName) {
     const { t } = useTranslation('verifiableCredential');
 
@@ -72,6 +124,7 @@ function VerifiableCredentialExtraDetails({
                         />
                     )}
                 </div>
+                <DisplayIssuerMetadata issuer={issuer} />
             </div>
         </div>
     );
@@ -194,6 +247,7 @@ export default function VerifiableCredentialDetails({
                     credentialEntry={credentialEntry}
                     status={status}
                     metadata={metadata}
+                    issuer={credential.issuer}
                 />
             )}
             {!showExtraDetails && (

--- a/packages/browser-wallet/src/popup/pages/VerifiableCredential/i18n/da.ts
+++ b/packages/browser-wallet/src/popup/pages/VerifiableCredential/i18n/da.ts
@@ -13,6 +13,12 @@ const t: typeof en = {
         id: 'Legitimationholders ID',
         validFrom: 'Gyldig fra',
         validUntil: 'Gyldig indtil',
+        issuer: {
+            title: 'Udstedt af',
+            name: 'Navn',
+            description: 'Beskrivelse',
+            url: 'Hjemmeside',
+        },
     },
     status: {
         Active: 'Aktiv',

--- a/packages/browser-wallet/src/popup/pages/VerifiableCredential/i18n/en.ts
+++ b/packages/browser-wallet/src/popup/pages/VerifiableCredential/i18n/en.ts
@@ -11,6 +11,12 @@ const t = {
         id: 'Credential holder ID',
         validFrom: 'Valid from',
         validUntil: 'Valid until',
+        issuer: {
+            title: 'Issued by',
+            name: 'Name',
+            description: 'Description',
+            url: 'Website',
+        },
     },
     status: {
         Active: 'Active',

--- a/packages/browser-wallet/src/shared/utils/verifiable-credential-helpers.ts
+++ b/packages/browser-wallet/src/shared/utils/verifiable-credential-helpers.ts
@@ -335,7 +335,7 @@ function deserializeRegistryMetadata(serializedRegistryMetadata: string): Metada
 export async function getCredentialRegistryMetadata(client: ConcordiumGRPCClient, contractAddress: ContractAddress) {
     const instanceInfo = await client.getInstanceInfo(contractAddress);
     if (instanceInfo === undefined) {
-        return undefined;
+        throw new Error('Given contract address was not a created instance');
     }
 
     const result = await client.invokeContract({
@@ -491,6 +491,47 @@ const verifiableCredentialMetadataSchema = {
     },
 };
 
+const issuerMetadataSchema = {
+    $ref: '#/definitions/IssuerMetadata',
+    $schema: 'http://json-schema.org/draft-07/schema#',
+    definitions: {
+        HexString: {
+            type: 'string',
+        },
+        IssuerMetadata: {
+            additionalProperties: false,
+            properties: {
+                description: {
+                    type: 'string',
+                },
+                icon: {
+                    $ref: '#/definitions/MetadataUrl',
+                },
+                name: {
+                    type: 'string',
+                },
+                url: {
+                    type: 'string',
+                },
+            },
+            type: 'object',
+        },
+        MetadataUrl: {
+            additionalProperties: false,
+            properties: {
+                hash: {
+                    $ref: '#/definitions/HexString',
+                },
+                url: {
+                    type: 'string',
+                },
+            },
+            required: ['url'],
+            type: 'object',
+        },
+    },
+};
+
 export interface VerifiableCredentialMetadata {
     title: string;
     logo: MetadataUrl;
@@ -606,7 +647,10 @@ export async function getVerifiableCredentialEntry(
 async function fetchDataFromUrl<T>(
     { url, hash }: MetadataUrl,
     abortController: AbortController,
-    jsonSchema: typeof verifiableCredentialMetadataSchema | typeof verifiableCredentialSchemaSchema
+    jsonSchema:
+        | typeof verifiableCredentialMetadataSchema
+        | typeof verifiableCredentialSchemaSchema
+        | typeof issuerMetadataSchema
 ): Promise<T> {
     const response = await fetch(url, {
         headers: new Headers({ 'Access-Control-Allow-Origin': '*' }),
@@ -661,6 +705,23 @@ export async function fetchCredentialMetadata(
     abortController: AbortController
 ): Promise<VerifiableCredentialMetadata> {
     return fetchDataFromUrl(metadata, abortController, verifiableCredentialMetadataSchema);
+}
+
+export interface IssuerMetadata {
+    name?: string;
+    icon?: MetadataUrl;
+    description?: string;
+    url?: string;
+}
+
+/**
+ * Retrieves registry issuer metadata from the specified URL.
+ */
+export async function fetchIssuerMetadata(
+    metadata: MetadataUrl,
+    abortController: AbortController
+): Promise<IssuerMetadata> {
+    return fetchDataFromUrl(metadata, abortController, issuerMetadataSchema);
 }
 
 /**

--- a/packages/browser-wallet/src/shared/utils/verifiable-credential-helpers.ts
+++ b/packages/browser-wallet/src/shared/utils/verifiable-credential-helpers.ts
@@ -659,7 +659,7 @@ async function fetchDataFromUrl<T>(
     });
 
     if (!response.ok) {
-        throw new Error(`Failed to fetch the schema at: ${url}`);
+        throw new Error(`Failed to fetch the data at: ${url}`);
     }
 
     const body = Buffer.from(await response.arrayBuffer());


### PR DESCRIPTION
## Purpose
Display issuer metadata to the user (if available).

## Changes
- Now fetching the issuer metadata and showing on the extra details page for a verifiable credential. Note that all the fields in the metadata are optional, so there might not be anything to show.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.