### PR TITLE
Fix importing web3Id credentials without the schemas already in storage

### DIFF
--- a/packages/browser-wallet/src/popup/pages/VerifiableCredentialBackup/VerifiableCredentialImport.tsx
+++ b/packages/browser-wallet/src/popup/pages/VerifiableCredentialBackup/VerifiableCredentialImport.tsx
@@ -61,7 +61,7 @@ function updateList<T>(stored: T[], toAdd: T[], isEqual: (a: T, b: T) => boolean
 function updateRecord<T>(
     stored: Record<string, T>,
     toAdd: Record<string, T>,
-    update: (updated: Record<string, T>) => void
+    update: (updated: Record<string, T>) => Promise<void>
 ) {
     const updated = { ...stored };
     Object.entries(toAdd).forEach(([key, value]) => {
@@ -70,7 +70,7 @@ function updateRecord<T>(
         }
     });
 
-    update(updated);
+    return update(updated);
 }
 
 export default function VerifiableCredentialImport() {
@@ -100,8 +100,8 @@ export default function VerifiableCredentialImport() {
                     (a, b) => a.id === b.id,
                     setVerifiableCredentials
                 );
-                updateRecord(storedSchemas.value, schemas, setSchemas);
-                updateRecord(storedMetadata.value, metadata, setMetadata);
+                await updateRecord(storedSchemas.value, schemas, setSchemas);
+                await updateRecord(storedMetadata.value, metadata, setMetadata);
                 setImported(filteredCredentials);
             }
         } catch (e) {


### PR DESCRIPTION
## Purpose

Avoid crashing when importing credentials with schemas that are not already in storage.

## Changes

Wait for schemas and metadata to be saved before displaying imported credentials.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.