### PR TITLE
Fix proof blank screen, when wallet contains vc that is not on chain

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+-   Wallet crashing when showing a proof request, while having a verifiable credential that is not yet on chain (or we otherwise fail to retrieve the status)
+
 ## 1.1.1
 
 ### Fixed

--- a/packages/browser-wallet/src/popup/pages/Web3ProofRequest/Web3ProofRequest.tsx
+++ b/packages/browser-wallet/src/popup/pages/Web3ProofRequest/Web3ProofRequest.tsx
@@ -66,7 +66,9 @@ async function getAllCredentialStatuses(
 ): Promise<Record<string, VerifiableCredentialStatus | undefined>> {
     const statuses = await Promise.all(
         credentials.map((credential) =>
-            getVerifiableCredentialStatus(client, credential.id).then((status) => [credential.id, status])
+            getVerifiableCredentialStatus(client, credential.id)
+                .then((status) => [credential.id, status])
+                .catch(() => [credential.id, VerifiableCredentialStatus.Pending])
         )
     );
     return Object.fromEntries(statuses);


### PR DESCRIPTION
## Purpose

Stop crashing when the wallet contains verifiable credentials that are not on chain yet.

## Changes

Catch when getting status, like we do in the hook.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
