### PR TITLE
Fix faulty identity selector

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+-   Incorrect verifiable presentations created, due to incorrect identity/identityProviderIndex used.
+
 ## 1.1.1
 
 ### Fixed

--- a/packages/browser-wallet/src/popup/pages/Web3ProofRequest/utils.ts
+++ b/packages/browser-wallet/src/popup/pages/Web3ProofRequest/utils.ts
@@ -51,7 +51,7 @@ export function getAccountCredentialCommitmentInput(
         throw new Error('IdQualifier not fulfilled');
     }
 
-    const identity = (identities || []).find(isIdentityOfCredential);
+    const identity = (identities || []).find((id) => isIdentityOfCredential(id)(credential));
 
     if (!identity || identity.status !== CreationStatus.Confirmed) {
         throw new Error('No identity found for credential');


### PR DESCRIPTION
## Purpose

Fix that sometimes the account credential issuer / identityProviderIndex was incorrect.

## Changes

Fix lookup of identity, which just chose the first identity always.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
