### PR TITLE
Use correct text for not activated status

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 
 -   Updated the JSON schema for the verifiable credential schema validation, so that invalid schemas are rejected.
--   An issue where a verifiable with the `NotActive` status would show as `Pending`.
+-   An issue where a verifiable with the `NotActivated` status would show as `Pending`.
 
 ## 1.1.2
 

--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+-   The status of a credential being added is now `Pending` instead of `NotActivated`.
+
 ### Fixed
 
 -   Updated the JSON schema for the verifiable credential schema validation, so that invalid schemas are rejected.

--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 -   Updated the JSON schema for the verifiable credential schema validation, so that invalid schemas are rejected.
+-   An issue where a verifiable with the `NotActive` status would show as `Pending`.
 
 ## 1.1.2
 

--- a/packages/browser-wallet/src/popup/pages/AddWeb3IdCredential/AddWeb3IdCredential.tsx
+++ b/packages/browser-wallet/src/popup/pages/AddWeb3IdCredential/AddWeb3IdCredential.tsx
@@ -204,7 +204,7 @@ export default function AddWeb3IdCredential({ onAllow, onReject }: Props) {
                             credentialSubject={credential.credentialSubject}
                             className="add-web3Id-credential__card"
                             schema={schema}
-                            credentialStatus={VerifiableCredentialStatus.NotActivated}
+                            credentialStatus={VerifiableCredentialStatus.Pending}
                             metadata={metadata}
                             localization={localization}
                         />

--- a/packages/browser-wallet/src/popup/pages/VerifiableCredential/VerifiableCredentialStatus.tsx
+++ b/packages/browser-wallet/src/popup/pages/VerifiableCredential/VerifiableCredentialStatus.tsx
@@ -29,7 +29,7 @@ export default function StatusIcon({ status }: { status: VerifiableCredentialSta
             break;
         case VerifiableCredentialStatus.NotActivated:
             icon = <PendingIcon />;
-            text = t('Pending');
+            text = t('NotActivated');
             break;
         case VerifiableCredentialStatus.Pending:
             icon = <PendingIcon />;


### PR DESCRIPTION
## Purpose
Use the correct translation for `NotActivated`.

## Changes
- Use the correct translation.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.