### PR TITLE
Validate that credential statements are not empty

### DIFF
--- a/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
+++ b/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
@@ -225,7 +225,7 @@ interface MainWalletApi {
     /**
      * Request that the user provides a proof for the given statements.
      * @param challenge bytes chosen by the verifier. Should be HEX encoded.
-     * @param statement the web3Id statements that should be proven.
+     * @param statements the web3Id statements that should be proven. The promise rejects if the array of statements is empty.
      * @returns The presentation for the statements.
      */
     requestVerifiablePresentation(challenge: string, statements: CredentialStatements): Promise<VerifiablePresentation>;

--- a/packages/browser-wallet-api/src/wallet-api.ts
+++ b/packages/browser-wallet-api/src/wallet-api.ts
@@ -289,6 +289,10 @@ class WalletApi extends EventEmitter implements IWalletApi {
     }
 
     public async requestVerifiablePresentation(challenge: HexString, statements: CredentialStatements) {
+        if (statements === undefined || statements.length === 0) {
+            throw new Error('A request for a verifiable presentation must contain statements');
+        }
+
         const res = await this.messageHandler.sendMessage<MessageStatusWrapper<string>>(MessageType.Web3IdProof, {
             // We have to stringify the statements because they can contain bigints
             statements: stringify(statements),


### PR DESCRIPTION
## Purpose
Fix an issue where the proof prompt was just a blank screen. This was due to receving a request with no statements, which is not a valid request.

## Changes
- Validate that `statements` is non-empty.

## Checklist
- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.