### PR TITLE
Prevent adding a credential with attributes not listed in schema

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -11,6 +11,8 @@
 -   An issue where the import window would fail to open.
 -   Updated the JSON schema for the verifiable credential schema validation, so that invalid schemas are rejected.
 -   An issue where a verifiable with the `NotActivated` status would show as `Pending`.
+-   An issue that allowed empty credential statements to be accepted by the wallet-api.
+-   An issue where the wallet allowed for requests adding credentials with more attributes than listed in the schema.
 
 ## 1.1.2
 

--- a/packages/browser-wallet/src/popup/pages/AddWeb3IdCredential/AddWeb3IdCredential.tsx
+++ b/packages/browser-wallet/src/popup/pages/AddWeb3IdCredential/AddWeb3IdCredential.tsx
@@ -121,7 +121,15 @@ export default function AddWeb3IdCredential({ onAllow, onReject }: Props) {
             }
 
             if (missingRequiredAttributeKeys.length > 0) {
-                setError(t('error.attribute', { attributeKeys: missingRequiredAttributeKeys }));
+                setError(t('error.attribute.required', { attributeKeys: missingRequiredAttributeKeys }));
+            }
+
+            // Ensure that a credential with more attributes than listed by the schema cannot be added.
+            const schemaAttributes = Object.keys(schema.properties.credentialSubject.properties.attributes.properties);
+            for (const credentialAttribute of Object.keys(credential.credentialSubject.attributes)) {
+                if (!schemaAttributes.includes(credentialAttribute)) {
+                    setError(t('error.attribute.additional', { credentialAttribute, schemaAttributes }));
+                }
             }
         }
     }, [schema?.properties.credentialSubject.properties.attributes.required]);

--- a/packages/browser-wallet/src/popup/pages/AddWeb3IdCredential/AddWeb3IdCredential.tsx
+++ b/packages/browser-wallet/src/popup/pages/AddWeb3IdCredential/AddWeb3IdCredential.tsx
@@ -63,7 +63,7 @@ export default function AddWeb3IdCredential({ onAllow, onReject }: Props) {
     const network = useAtomValue(networkConfigurationAtom);
 
     const [error, setError] = useState<string>();
-    const [validationComplete, setValidationComplete] = useState<boolean>();
+    const [validationComplete, setValidationComplete] = useState<boolean>(false);
 
     const { credential: rawCredential, url, metadataUrl } = state.payload;
     const credential: APIVerifiableCredential = parse(rawCredential);
@@ -136,6 +136,8 @@ export default function AddWeb3IdCredential({ onAllow, onReject }: Props) {
                     return;
                 }
             }
+
+            setValidationComplete(true);
         }
     }, [Boolean(schema)]);
 

--- a/packages/browser-wallet/src/popup/pages/AddWeb3IdCredential/i18n/en.ts
+++ b/packages/browser-wallet/src/popup/pages/AddWeb3IdCredential/i18n/en.ts
@@ -10,7 +10,7 @@ const t = {
         attribute: {
             required: 'The received credential is missing one or more required attributes ({{ attributeKeys }})',
             additional:
-                'The attribute with key [{{ credentialAttribute }}] is not available in the list of schema attributes: [{{ schemaAttributes }} ]',
+                'The attribute with key [{{ credentialAttribute }}] is not available in the list of schema attributes: [{{ schemaAttributes }}]',
         },
         localization: 'Failed to get localization',
     },

--- a/packages/browser-wallet/src/popup/pages/AddWeb3IdCredential/i18n/en.ts
+++ b/packages/browser-wallet/src/popup/pages/AddWeb3IdCredential/i18n/en.ts
@@ -7,7 +7,11 @@ const t = {
             'We are unable to add the web3Id credential to the wallet due to the following issue, please report this to the issuer:',
         metadata: 'We are unable to load the metadata for the credential.',
         schema: 'We are unable to load the schema specification for the credential.',
-        attribute: 'The received credential is missing one or more required attributes ({{ attributeKeys }})',
+        attribute: {
+            required: 'The received credential is missing one or more required attributes ({{ attributeKeys }})',
+            additional:
+                'The attribute with key [{{ credentialAttribute }}] is not available in the list of schema attributes: [{{ schemaAttributes }} ]',
+        },
         localization: 'Failed to get localization',
     },
 };


### PR DESCRIPTION
## Purpose
Improve schema validation when adding a Web3 ID credential. 

## Changes
- Now checks that the credential to be added does not contain any attribute not mentioned in the schema.
- Added a missing CHANGELOG entry from another PR.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.