### PR TITLE
Update schema validation for credential schema

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+-   Adjusted the schema validation for credential schemas to no longer require title and description. The type is now required to be 'object'.
+
 ### Fixed
 
 -   An issue where changing the credential metadata URL to an invalid URL, or a URL that does not contain a credential metadata file, would result in an empty screen.

--- a/packages/browser-wallet/src/shared/storage/types.ts
+++ b/packages/browser-wallet/src/shared/storage/types.ts
@@ -319,9 +319,12 @@ export type TimestampProperty = {
 };
 
 type CredentialSchemaAttributes = {
+    title?: string;
+    description?: string;
+    type: 'object';
     properties: Record<string, CredentialSchemaProperty | TimestampProperty>;
     required: string[];
-} & CredentialSchemaProperty;
+};
 
 interface CredentialSchemaSubject {
     type: string;

--- a/packages/browser-wallet/src/shared/utils/verifiable-credential-helpers.ts
+++ b/packages/browser-wallet/src/shared/utils/verifiable-credential-helpers.ts
@@ -377,9 +377,6 @@ const verifiableCredentialSchemaSchema = {
                                         description: {
                                             type: 'string',
                                         },
-                                        format: {
-                                            type: 'string',
-                                        },
                                         properties: {
                                             additionalProperties: {
                                                 anyOf: [
@@ -419,10 +416,11 @@ const verifiableCredentialSchemaSchema = {
                                             type: 'string',
                                         },
                                         type: {
+                                            const: 'object',
                                             type: 'string',
                                         },
                                     },
-                                    required: ['description', 'properties', 'required', 'title', 'type'],
+                                    required: ['type', 'properties', 'required'],
                                     type: 'object',
                                 },
                                 id: {


### PR DESCRIPTION
## Purpose
Adjust the schema validation for credential schemas as attributes should not require title and description.

## Changes
- Updated the attribute type in the credential schema.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.