### PR TITLE
Verify id statements when checking for valid proofs

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 -   An issue where changing the credential metadata URL to an invalid URL, or a URL that does not contain a credential metadata file, would result in an empty screen.
+-   Enabled ID statement checks for Web3 ID proof requests containing account credential statements.
 
 ## 1.1.3
 

--- a/packages/browser-wallet/src/background/web3Id.ts
+++ b/packages/browser-wallet/src/background/web3Id.ts
@@ -8,6 +8,8 @@ import {
     verifyAtomicStatements,
     isAccountCredentialStatement,
     IDENTITY_SUBJECT_SCHEMA,
+    verifyIdstatement,
+    IdStatement,
 } from '@concordium/web-sdk';
 import {
     sessionVerifiableCredentials,
@@ -178,7 +180,8 @@ export const runIfValidWeb3IdProof: RunCondition<MessageStatusWrapper<undefined>
         // If a statement does not verify, an error is thrown.
         statements.every((credStatement) =>
             isAccountCredentialStatement(credStatement)
-                ? verifyAtomicStatements(credStatement.statement, IDENTITY_SUBJECT_SCHEMA)
+                ? verifyAtomicStatements(credStatement.statement, IDENTITY_SUBJECT_SCHEMA) &&
+                  verifyIdstatement(credStatement.statement as IdStatement)
                 : verifyAtomicStatements(credStatement.statement)
         );
 


### PR DESCRIPTION
## Purpose
Enable verification of ID statements like we had for ID2.0.

## Changes
- Now also runs `verifyIdStatement`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.