### PR TITLE
Throw error in replacer if date is invalid

### DIFF
--- a/packages/browser-wallet-api/src/util.ts
+++ b/packages/browser-wallet-api/src/util.ts
@@ -32,6 +32,9 @@ function replacer(this: any, k: string, value: any) {
     }
     const rawValue = this[k];
     if (rawValue instanceof Date) {
+        if (Number.isNaN(rawValue.getTime())) {
+            throw new Error(`Received a Date instance that was an invalid Date. Raw value was: [${rawValue}]`);
+        }
         return { '@type': serializationTypes.Date, value };
     }
     if (Buffer.isBuffer(rawValue)) {

--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 -   An issue where changing the credential metadata URL to an invalid URL, or a URL that does not contain a credential metadata file, would result in an empty screen.
+-   An issue where an invalid Date would result in the epoch timestamp instead of returning an error.
 
 ## 1.1.3
 


### PR DESCRIPTION
## Purpose
Prevent an issuer from trying to add an invalid date to the wallet.

## Changes
- Throw an error in the JSON replacer if the Date is not valid.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.