### PR TITLE
Use real URL as key for schema updates

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+-   An issue where credential schemas were not updated with the correct key.
+
 ## 1.1.5
 
 ### Added

--- a/packages/browser-wallet/src/shared/utils/verifiable-credential-helpers.ts
+++ b/packages/browser-wallet/src/shared/utils/verifiable-credential-helpers.ts
@@ -916,7 +916,7 @@ export async function getCredentialSchemas(
     abortControllers: AbortController[],
     client: ConcordiumGRPCClient
 ) {
-    const onChainSchemas: VerifiableCredentialSchema[] = [];
+    const onChainSchemas: { schema: VerifiableCredentialSchema; url: string }[] = [];
 
     const allContractAddresses = credentials.map((vc) => getCredentialRegistryContractAddress(vc.id));
     const issuerContractAddresses = new Set(allContractAddresses);
@@ -937,7 +937,7 @@ export async function getCredentialSchemas(
                     registryMetadata.credentialSchema.schema,
                     controller
                 );
-                onChainSchemas.push(credentialSchema);
+                onChainSchemas.push({ schema: credentialSchema, url: registryMetadata.credentialSchema.schema.url });
             } catch (e) {
                 // Ignore errors that occur because we aborted, as that is expected to happen.
                 if (!controller.signal.aborted) {
@@ -1044,12 +1044,12 @@ export async function getChangesToCredentialSchemas(
     for (const updatedSchema of upToDateSchemas) {
         if (Object.keys(updatedSchemasInStorage).length === 0) {
             updatedSchemasInStorage = {
-                [updatedSchema.$id]: updatedSchema,
+                [updatedSchema.url]: updatedSchema.schema,
             };
             updateReceived = true;
         } else {
-            updatedSchemasInStorage[updatedSchema.$id] = updatedSchema;
-            if (JSON.stringify(storedSchemas[updatedSchema.$id]) !== JSON.stringify(updatedSchema)) {
+            updatedSchemasInStorage[updatedSchema.url] = updatedSchema.schema;
+            if (JSON.stringify(storedSchemas[updatedSchema.url]) !== JSON.stringify(updatedSchema)) {
                 updateReceived = true;
             }
         }


### PR DESCRIPTION
## Purpose
Fix an issuse where credential schemas did not update correctly.

## Changes
- Use the `URL` where we got the schema from as the key when updating the local storage.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.