### PR TITLE
Support web-sdk v7

### DIFF
--- a/packages/browser-wallet-api-helpers/src/util.ts
+++ b/packages/browser-wallet-api-helpers/src/util.ts
@@ -1,2 +1,12 @@
 export type LaxStringEnumValue<E extends string> = `${E}`;
 export type LaxNumberEnumValue<E extends number> = `${E}` extends `${infer T extends number}` ? T : never;
+
+/**
+ *
+ * @example
+ * type Test = { nested: { amount: number } };
+ * type Out = DeepReplaceType<Test, number, string>; // Becomes the type: { nested: { amount: string } }.
+ */
+export type DeepReplaceType<Target, From, To> = {
+    [Key in keyof Target]: Target[Key] extends From ? To : DeepReplaceType<Target[Key], From, To>;
+};

--- a/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
+++ b/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
@@ -13,8 +13,9 @@ import type {
     VerifiablePresentation,
     CredentialSubject,
     HexString,
+    CcdAmount,
 } from '@concordium/web-sdk';
-import { LaxNumberEnumValue, LaxStringEnumValue } from './util';
+import { DeepReplaceType, LaxNumberEnumValue, LaxStringEnumValue } from './util';
 
 export interface MetadataUrl {
     url: string;
@@ -48,17 +49,27 @@ export interface CredentialProof {
     verificationMethod: string;
 }
 
-export type SendTransactionPayload =
+/**
+ * Interface covering both the old (prior v7) and new CcdAmount in web-sdk.
+ */
+export interface HasMicroCcd {
+    microCcdAmount: bigint;
+}
+
+type SendTransactionPayloadRaw =
     | Exclude<AccountTransactionPayload, UpdateContractPayload | InitContractPayload>
     | Omit<UpdateContractPayload, 'message'>
     | Omit<InitContractPayload, 'param'>;
+
+export type SendTransactionPayload = DeepReplaceType<SendTransactionPayloadRaw, CcdAmount, HasMicroCcd>;
 
 export type SmartContractParameters =
     | { [key: string]: SmartContractParameters }
     | SmartContractParameters[]
     | number
     | string
-    | boolean;
+    | boolean
+    | bigint;
 
 export type SignMessageObject = {
     /** as base64 */


### PR DESCRIPTION
## Purpose

This will enable support of newer versions of the web-sdk (v7) without any breaking changes.

## Changes

Replace `CcdAmount` with broader type `HasMicroCcd` which works with both old and new version of web-sdk.

Context: Since v7 of `web-sdk` removes methods on `CcdAmount` it cannot be used with the current released version of the wallet api (helpers), since this uses the old type which require these methods. Since the wallet does not rely on these methods and only on the internal field `microCcdAmount` of `CcdAmount` we can support both versions by reflecting this in the type.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
