### PR TITLE
Fix sign message rendered message display

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 
 -   Sign message's rendered view displaying 'a' when deserialization failed.
--   Sign message deserialization failing with new `deserializeTypeValue`.
+-   Sign message's stringification failing with new `deserializeTypeValue`.
 
 ## 1.1.10
 

--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.1.11
+
+### Fixed
+
+-   Sign message's rendered view displaying 'a' when deserialization failed.
+-   Sign message deserialization failing with new `deserializeTypeValue`.
+
 ## 1.1.10
 
 ### Changed

--- a/packages/browser-wallet/src/popup/pages/SignMessage/SignMessage.tsx
+++ b/packages/browser-wallet/src/popup/pages/SignMessage/SignMessage.tsx
@@ -20,6 +20,7 @@ import { addToastAtom } from '@popup/state';
 import ExternalRequestLayout from '@popup/page-layouts/ExternalRequestLayout';
 import TabBar from '@popup/shared/TabBar';
 import clsx from 'clsx';
+import { stringify } from 'json-bigint';
 
 type Props = {
     onSubmit(signature: AccountTransactionSignature): void;
@@ -47,13 +48,13 @@ function BinaryDisplay({ message, url }: { message: MessageObject; url: string }
 
     const parsedMessage = useMemo(() => {
         try {
-            return JSON.stringify(
+            return stringify(
                 deserializeTypeValue(Buffer.from(message.data, 'hex'), Buffer.from(message.schema, 'base64')),
                 undefined,
                 2
             );
         } catch (e) {
-            return 'a';
+            return t('unableToDeserialize');
         }
     }, []);
 

--- a/packages/browser-wallet/src/popup/pages/SignMessage/i18n/da.ts
+++ b/packages/browser-wallet/src/popup/pages/SignMessage/i18n/da.ts
@@ -5,6 +5,7 @@ const t: typeof en = {
     descriptionWithSchema:
         '{{ dApp }} har sendt en rå besked og et schema til at oversætte den. Vi har oversat beskeden, men du burde kun underskrive hvis du stoler på {{ dApp }}',
     deserializedDisplay: 'Oversat',
+    unableToDeserialize: 'Det var ikke muligt at oversætte beskeden',
     rawDisplay: 'Rå',
     sign: 'Signér',
     reject: 'Afvis',

--- a/packages/browser-wallet/src/popup/pages/SignMessage/i18n/en.ts
+++ b/packages/browser-wallet/src/popup/pages/SignMessage/i18n/en.ts
@@ -3,6 +3,7 @@ const t = {
     descriptionWithSchema:
         "{{ dApp }} has provided the raw message and a schema to render it. We've rendered the message but you should only sign it if you trust {{ dApp }}.",
     deserializedDisplay: 'Rendered',
+    unableToDeserialize: 'Unable to render message',
     rawDisplay: 'Raw',
     sign: 'Sign',
     reject: 'Reject',


### PR DESCRIPTION
## Purpose

Fix Request message was not rendered correctly.

## Changes

-   Fix Sign message's rendered view displaying 'a' when deserialization failed.
-   Sign message deserialization failing with new `deserializeTypeValue`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
