### PR TITLE
Fix rendering of max contract execution energy

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   Sign message's rendered view displaying 'a' when deserialization failed.
 -   Sign message deserialization failing with new `deserializeTypeValue`.
+-   An issue where the max contract execution energy was not rendered correctly for init contract transactions.
 
 ## 1.1.10
 

--- a/packages/browser-wallet/src/popup/shared/TransactionReceipt/displayPayload/DisplayInitContract.tsx
+++ b/packages/browser-wallet/src/popup/shared/TransactionReceipt/displayPayload/DisplayInitContract.tsx
@@ -26,7 +26,7 @@ export default function DisplayInitContract({ payload, parameters }: Props) {
             {displayAsCcd(payload.amount.microCcdAmount)}
             <h5>{t('maxEnergy')}:</h5>
             <span>
-                {payload.maxContractExecutionEnergy.toString()} {t('nrg')}
+                {payload.maxContractExecutionEnergy.value.toString()} {t('nrg')}
             </span>
             <DisplayParameters parameters={parameters} />
         </>


### PR DESCRIPTION
## Purpose
Correctly render the max contract execution energy for init contract transactions.

## Changes
- Use the internal value of the execution energy when displaying it.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.