### PR TITLE
Use web-sdk 7.0.3 only

### DIFF
--- a/examples/add-example-Web3Id/package.json
+++ b/examples/add-example-Web3Id/package.json
@@ -8,6 +8,6 @@
         "start": "live-server ./index.html --mount=/sdk.js:../../node_modules/@concordium/web-sdk/lib/concordium.min.js --mount=/helpers.js:../../packages/browser-wallet-api-helpers/lib/concordiumHelpers.min.js"
     },
     "dependencies": {
-        "@concordium/web-sdk": "^7.0.0"
+        "@concordium/web-sdk": "^7.0.3"
     }
 }

--- a/examples/eSealing/package.json
+++ b/examples/eSealing/package.json
@@ -5,7 +5,7 @@
     "license": "Apache-2.0",
     "dependencies": {
         "@concordium/react-components": "0.4.0-rc.5",
-        "@concordium/web-sdk": "^7.0.0",
+        "@concordium/web-sdk": "^7.0.3",
         "@thi.ng/leb128": "^2.1.18",
         "@types/sha256": "^0.2.0",
         "@walletconnect/types": "^2.1.4",

--- a/examples/nft-minting/package.json
+++ b/examples/nft-minting/package.json
@@ -3,7 +3,7 @@
     "packageManager": "yarn@3.2.0",
     "dependencies": {
         "@concordium/browser-wallet-api-helpers": "workspace:^",
-        "@concordium/web-sdk": "^7.0.0",
+        "@concordium/web-sdk": "^7.0.3",
         "cors": "^2.8.5",
         "express": "^4.18.1",
         "express-fileupload": "^1.4.0",

--- a/examples/piggybank/package.json
+++ b/examples/piggybank/package.json
@@ -3,7 +3,7 @@
     "packageManager": "yarn@3.2.0",
     "dependencies": {
         "@concordium/browser-wallet-api-helpers": "workspace:^",
-        "@concordium/web-sdk": "^7.0.0",
+        "@concordium/web-sdk": "^7.0.3",
         "react": "^18.1.0",
         "react-dom": "^18.1.0"
     },

--- a/examples/two-step-transfer/package.json
+++ b/examples/two-step-transfer/package.json
@@ -8,6 +8,6 @@
         "start": "live-server ../two-step-transfer/index.html --mount=/sdk.js:../../node_modules/@concordium/web-sdk/lib/concordium.min.js --mount=/helpers.js:../../packages/browser-wallet-api-helpers/lib/concordiumHelpers.min.js"
     },
     "dependencies": {
-        "@concordium/web-sdk": "^7.0.0"
+        "@concordium/web-sdk": "^7.0.3"
     }
 }

--- a/examples/voting/package.json
+++ b/examples/voting/package.json
@@ -5,7 +5,7 @@
     "packageManager": "yarn@3.2.0",
     "dependencies": {
         "@concordium/browser-wallet-api-helpers": "beta",
-        "@concordium/web-sdk": "^7.0.0",
+        "@concordium/web-sdk": "^7.0.3",
         "bootstrap": "^5.2.1",
         "cross-env": "^7.0.3",
         "moment": "^2.29.4",

--- a/examples/wCCD/package.json
+++ b/examples/wCCD/package.json
@@ -5,7 +5,7 @@
     "license": "Apache-2.0",
     "dependencies": {
         "@concordium/react-components": "0.4.0-rc.5",
-        "@concordium/web-sdk": "^7.0.0",
+        "@concordium/web-sdk": "^7.0.3",
         "@thi.ng/leb128": "^2.1.18",
         "@walletconnect/types": "^2.1.4",
         "mathjs": "^11.4.0",

--- a/packages/browser-wallet-api/package.json
+++ b/packages/browser-wallet-api/package.json
@@ -9,7 +9,7 @@
     "dependencies": {
         "@concordium/browser-wallet-api-helpers": "workspace:^",
         "@concordium/browser-wallet-message-hub": "workspace:^",
-        "@concordium/web-sdk": "^7.0.0",
+        "@concordium/web-sdk": "^7.0.3",
         "@concordium/web-sdk-legacy": "npm:@concordium/web-sdk@6",
         "@protobuf-ts/grpcweb-transport": "^2.8.2",
         "@protobuf-ts/runtime-rpc": "^2.8.2",

--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -7,6 +7,7 @@
 -   Sign message's rendered view displaying 'a' when deserialization failed.
 -   Sign message's stringification failing with new `deserializeTypeValue`.
 -   An issue where the max contract execution energy was not rendered correctly for init contract transactions.
+-   Updated web-sdk to fix an issue where init contract transactions were not serialized correctly.
 
 ## 1.1.10
 

--- a/packages/browser-wallet/package.json
+++ b/packages/browser-wallet/package.json
@@ -22,7 +22,7 @@
         "@concordium/browser-wallet-api": "workspace:^",
         "@concordium/browser-wallet-api-helpers": "workspace:^",
         "@concordium/browser-wallet-message-hub": "workspace:^",
-        "@concordium/web-sdk": "^7.0.0",
+        "@concordium/web-sdk": "^7.0.3",
         "@noble/ed25519": "^1.7.0",
         "@protobuf-ts/runtime-rpc": "^2.8.2",
         "@scure/bip39": "^1.1.0",
@@ -53,7 +53,7 @@
         "react-window-infinite-loader": "^1.0.8",
         "readable-stream": "^4.2.0",
         "uuid": "^8.3.2",
-        "wallet-common-helpers": "https://github.com/Concordium/concordium-wallet-common-helpers.git#f7cfb1ccc3100a34072dacc70f793766ab51ab41"
+        "wallet-common-helpers": "https://github.com/Concordium/concordium-wallet-common-helpers.git#12cba9df452e92130566dd0b525f814dbee85190"
     },
     "devDependencies": {
         "@babel/core": "^7.18.2",

--- a/packages/browser-wallet/package.json
+++ b/packages/browser-wallet/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@concordium/browser-wallet",
     "private": true,
-    "version": "1.1.10",
+    "version": "1.1.11",
     "description": "Browser extension wallet for the Concordium blockchain",
     "author": "Concordium Software",
     "license": "Apache-2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2195,7 +2195,7 @@ __metadata:
   dependencies:
     "@concordium/browser-wallet-api-helpers": "workspace:^"
     "@concordium/browser-wallet-message-hub": "workspace:^"
-    "@concordium/web-sdk": ^7.0.0
+    "@concordium/web-sdk": ^7.0.3
     "@concordium/web-sdk-legacy": "npm:@concordium/web-sdk@6"
     "@protobuf-ts/grpcweb-transport": ^2.8.2
     "@protobuf-ts/runtime-rpc": ^2.8.2
@@ -2224,7 +2224,7 @@ __metadata:
     "@concordium/browser-wallet-api": "workspace:^"
     "@concordium/browser-wallet-api-helpers": "workspace:^"
     "@concordium/browser-wallet-message-hub": "workspace:^"
-    "@concordium/web-sdk": ^7.0.0
+    "@concordium/web-sdk": ^7.0.3
     "@craftamap/esbuild-plugin-html": ^0.4.0
     "@mdx-js/react": ^1.6.22
     "@noble/ed25519": ^1.7.0
@@ -2291,7 +2291,7 @@ __metadata:
     tsconfig-paths-webpack-plugin: ^3.5.2
     typescript: ^5.2.2
     uuid: ^8.3.2
-    wallet-common-helpers: "https://github.com/Concordium/concordium-wallet-common-helpers.git#f7cfb1ccc3100a34072dacc70f793766ab51ab41"
+    wallet-common-helpers: "https://github.com/Concordium/concordium-wallet-common-helpers.git#12cba9df452e92130566dd0b525f814dbee85190"
   languageName: unknown
   linkType: soft
 
@@ -2335,12 +2335,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@concordium/rust-bindings@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@concordium/rust-bindings@npm:2.0.0"
-  dependencies:
-    buffer: ^6.0.3
-  checksum: f436926de9959d45971f317da6510c887cbb55a26ce6f7080aa32f66c9550fba9bdff68c6e34565e32eb10c8b332295af01c21b039c6fa5bd1d82bc8fb079111
+"@concordium/rust-bindings@npm:2.0.1":
+  version: 2.0.1
+  resolution: "@concordium/rust-bindings@npm:2.0.1"
+  checksum: 7cd81f4bf9132957379f6e5c08b4d397e92ed59284d12211281b365cc053ce796f293608e3f3ec85b4576ad61a8b7d6dcbf3d214051df599ec9febfd330d1233
   languageName: node
   linkType: hard
 
@@ -2371,13 +2369,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@concordium/web-sdk@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "@concordium/web-sdk@npm:7.0.0"
+"@concordium/web-sdk@npm:^7.0.3":
+  version: 7.0.3
+  resolution: "@concordium/web-sdk@npm:7.0.3"
   dependencies:
-    "@concordium/rust-bindings": 2.0.0
+    "@concordium/rust-bindings": 2.0.1
     "@grpc/grpc-js": ^1.9.4
     "@noble/ed25519": ^2.0.0
+    "@noble/hashes": ^1.3.2
     "@protobuf-ts/grpc-transport": ^2.9.1
     "@protobuf-ts/grpcweb-transport": ^2.9.1
     "@protobuf-ts/runtime-rpc": ^2.8.2
@@ -2390,7 +2389,7 @@ __metadata:
     iso-3166-1: ^2.1.1
     json-bigint: ^1.0.0
     uuid: ^8.3.2
-  checksum: 8cd6a9c9bad7bd999f6aa14c32bdf977ce4a12825fac54e9a9b544aefc74a3d36b3b005200ef1da473695284438f8ff1a89079f65953959d230eb2b2b6fb615e
+  checksum: 1cb8966c335655f0d9cdb19dd5f39acb655136ddae4181b29368dfa555852eac41f14d983792b5fbdaf5a2ce0383638c9b6c1e81a61cbecd6da61426f5753a6d
   languageName: node
   linkType: hard
 
@@ -3498,7 +3497,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:^1.2.0, @noble/hashes@npm:~1.3.0":
+"@noble/hashes@npm:^1.2.0, @noble/hashes@npm:^1.3.2, @noble/hashes@npm:~1.3.0":
   version: 1.3.2
   resolution: "@noble/hashes@npm:1.3.2"
   checksum: fe23536b436539d13f90e4b9be843cc63b1b17666a07634a2b1259dded6f490be3d050249e6af98076ea8f2ea0d56f578773c2197f2aa0eeaa5fba5bc18ba474
@@ -7541,7 +7540,7 @@ __metadata:
   resolution: "NFT-Minting@workspace:examples/nft-minting"
   dependencies:
     "@concordium/browser-wallet-api-helpers": "workspace:^"
-    "@concordium/web-sdk": ^7.0.0
+    "@concordium/web-sdk": ^7.0.3
     "@craftamap/esbuild-plugin-html": ^0.4.0
     "@types/react": ^18.0.9
     "@types/react-dom": ^18.0.5
@@ -7693,7 +7692,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "add-example-web3-id@workspace:examples/add-example-Web3Id"
   dependencies:
-    "@concordium/web-sdk": ^7.0.0
+    "@concordium/web-sdk": ^7.0.3
     live-server: ^1.2.2
   languageName: unknown
   linkType: soft
@@ -11087,7 +11086,7 @@ __metadata:
   resolution: "e_sealing@workspace:examples/eSealing"
   dependencies:
     "@concordium/react-components": 0.4.0-rc.5
-    "@concordium/web-sdk": ^7.0.0
+    "@concordium/web-sdk": ^7.0.3
     "@thi.ng/leb128": ^2.1.18
     "@types/node": ^18.7.23
     "@types/react": ^18.0.9
@@ -18384,7 +18383,7 @@ __metadata:
   resolution: "piggybank@workspace:examples/piggybank"
   dependencies:
     "@concordium/browser-wallet-api-helpers": "workspace:^"
-    "@concordium/web-sdk": ^7.0.0
+    "@concordium/web-sdk": ^7.0.3
     "@types/react": ^18.0.9
     "@types/react-dom": ^18.0.5
     "@vitejs/plugin-react-swc": ^3.4.0
@@ -22490,7 +22489,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "two-step-transfer@workspace:examples/two-step-transfer"
   dependencies:
-    "@concordium/web-sdk": ^7.0.0
+    "@concordium/web-sdk": ^7.0.3
     live-server: ^1.2.2
   languageName: unknown
   linkType: soft
@@ -23266,7 +23265,7 @@ __metadata:
   resolution: "voting@workspace:examples/voting"
   dependencies:
     "@concordium/browser-wallet-api-helpers": beta
-    "@concordium/web-sdk": ^7.0.0
+    "@concordium/web-sdk": ^7.0.3
     "@types/node": ^18.7.23
     "@types/react": ^18.0.9
     "@types/react-dom": ^18.0.5
@@ -23324,11 +23323,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wallet-common-helpers@https://github.com/Concordium/concordium-wallet-common-helpers.git#f7cfb1ccc3100a34072dacc70f793766ab51ab41":
+"wallet-common-helpers@https://github.com/Concordium/concordium-wallet-common-helpers.git#12cba9df452e92130566dd0b525f814dbee85190":
   version: 2.0.0
-  resolution: "wallet-common-helpers@https://github.com/Concordium/concordium-wallet-common-helpers.git#commit=f7cfb1ccc3100a34072dacc70f793766ab51ab41"
+  resolution: "wallet-common-helpers@https://github.com/Concordium/concordium-wallet-common-helpers.git#commit=12cba9df452e92130566dd0b525f814dbee85190"
   dependencies:
-    "@concordium/web-sdk": ^7.0.0
+    "@concordium/web-sdk": ^7.0.3
     buffer: ^6.0.3
     cbor: ^8.0.0
     clsx: ^2.0.0
@@ -23336,7 +23335,7 @@ __metadata:
   peerDependencies:
     react: ">=16"
     react-dom: ">=16"
-  checksum: f41e63b6bb608f83c78a2202c45e84018e280535782cf18c7e53044135bf0ba415afc3521f97e2dfd475e46037585d0ab7b97c1288d7c898c6d76e83a79ca950
+  checksum: e950cc5abfc3253d2df436aa44fc7b5e98ff3639e5281ac36015cefec98040aa0fae4c171fab2176f6d2a49e36355bf3212204bd8984810e54fed88bc8bb6572
   languageName: node
   linkType: hard
 
@@ -23390,7 +23389,7 @@ __metadata:
   resolution: "wccd@workspace:examples/wCCD"
   dependencies:
     "@concordium/react-components": 0.4.0-rc.5
-    "@concordium/web-sdk": ^7.0.0
+    "@concordium/web-sdk": ^7.0.3
     "@thi.ng/leb128": ^2.1.18
     "@types/node": ^18.7.23
     "@types/react": ^18.0.9


### PR DESCRIPTION
## Purpose
Update the used web-sdk to a version that contains a fix to init contract serialization. Also updates the wallet-common-helpers to a version that uses the same web-sdk version. A mismatch between the browser wallet and the wallet-common-helpers leads to bugs.

## Changes
- Updated to web-sdk 7.0.3

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.