### PR TITLE
Remove usage of instanceof when sanitizing wallet-api inputs

### DIFF
--- a/examples/piggybank/src/utils.ts
+++ b/examples/piggybank/src/utils.ts
@@ -10,6 +10,7 @@ import {
     InitName,
     ReceiveName,
     UpdateContractPayload,
+    AccountAddress,
 } from '@concordium/web-sdk';
 
 export const CONTRACT_NAME = 'PiggyBank';
@@ -26,7 +27,7 @@ export const deposit = (account: string, index: bigint, subindex = 0n, amount = 
     detectConcordiumProvider()
         .then((provider) => {
             provider
-                .sendTransaction(account, AccountTransactionType.Update, {
+                .sendTransaction(AccountAddress.fromBase58(account), AccountTransactionType.Update, {
                     amount: CcdAmount.fromMicroCcd(amount),
                     address: ContractAddress.create(index, subindex),
                     receiveName: ReceiveName.fromString(`${CONTRACT_NAME}.insert`),
@@ -50,7 +51,7 @@ export const smash = (account: string, index: bigint, subindex = 0n) => {
     detectConcordiumProvider()
         .then((provider) => {
             provider
-                .sendTransaction(account, AccountTransactionType.Update, {
+                .sendTransaction(AccountAddress.fromBase58(account), AccountTransactionType.Update, {
                     amount: CcdAmount.fromMicroCcd(0), // This feels weird? Why do I need an amount for a non-payable receive?
                     address: ContractAddress.create(index, subindex),
                     receiveName: ReceiveName.fromString(`${CONTRACT_NAME}.smash`),

--- a/examples/two-step-transfer/index.html
+++ b/examples/two-step-transfer/index.html
@@ -46,8 +46,8 @@
                 document.getElementById('sendTransfer').addEventListener('click', () =>
                     provider
                         .sendTransaction(currentAccountAddress, concordiumSDK.AccountTransactionType.Transfer, {
-                            amount: new concordiumSDK.CcdAmount(1n),
-                            toAddress: new concordiumSDK.AccountAddress(
+                            amount: concordiumSDK.CcdAmount.fromMicroCcd(1n),
+                            toAddress: concordiumSDK.AccountAddress.fromBase58(
                                 '3kBx2h5Y2veb4hZgAJWPrr8RyQESKm5TjzF3ti1QQ4VSYLwK1G'
                             ),
                         })
@@ -103,7 +103,7 @@
                     );
                     provider
                         .signMessage(currentAccountAddress, {
-                            data: serializedMessage.toString('hex'),
+                            data: concordiumSDK.Parameter.toHexString(serializedMessage),
                             schema: SERIALIZATION_HELPER_SCHEMA,
                         })
                         .then((sig) => alert(JSON.stringify(sig)))
@@ -112,7 +112,7 @@
                 document.getElementById('sendDeposit').addEventListener('click', () =>
                     provider
                         .sendTransaction(currentAccountAddress, concordiumSDK.AccountTransactionType.Update, {
-                            amount: new concordiumSDK.CcdAmount(1n),
+                            amount: concordiumSDK.CcdAmount.fromMicroCcd(1n),
                             contractAddress: {
                                 index: 98n,
                                 subindex: 0n,
@@ -129,7 +129,7 @@
                             currentAccountAddress,
                             concordiumSDK.AccountTransactionType.Update,
                             {
-                                amount: new concordiumSDK.CcdAmount(1n),
+                                amount: concordiumSDK.CcdAmount.fromMicroCcd(1n),
                                 contractAddress: {
                                     index: 98n,
                                     subindex: 0n,
@@ -154,8 +154,8 @@
                             currentAccountAddress,
                             concordiumSDK.AccountTransactionType.InitContract,
                             {
-                                amount: new concordiumSDK.CcdAmount(1n),
-                                moduleRef: new concordiumSDK.ModuleReference(
+                                amount: concordiumSDK.CcdAmount.fromMicroCcd(1n),
+                                moduleRef: concordiumSDK.ModuleReference.fromHexString(
                                     '6eab4584bd60b1d82fba3abe16082cde3dbee4c08c9f60b6dc523688bdc421b9'
                                 ),
                                 contractName: 'two-step-transfer',

--- a/examples/two-step-transfer/package.json
+++ b/examples/two-step-transfer/package.json
@@ -5,7 +5,7 @@
         "live-server": "^1.2.2"
     },
     "scripts": {
-        "start": "live-server ../two-step-transfer/index.html --mount=/sdk.js:../../node_modules/@concordium/web-sdk/lib/concordium.min.js --mount=/helpers.js:../../packages/browser-wallet-api-helpers/lib/concordiumHelpers.min.js"
+        "start": "live-server ../two-step-transfer/index.html --mount=/sdk.js:../../node_modules/@concordium/web-sdk/lib/min/concordium.web.min.js --mount=/helpers.js:../../packages/browser-wallet-api-helpers/lib/concordiumHelpers.min.js"
     },
     "dependencies": {
         "@concordium/web-sdk": "^7.0.3"

--- a/packages/browser-wallet-api/src/compatibility.ts
+++ b/packages/browser-wallet-api/src/compatibility.ts
@@ -98,7 +98,7 @@ export function sanitizeAddCIS2TokensInput(
     if (typeof contractAddressSource === 'bigint') {
         contractAddress = ContractAddress.create(contractAddressSource, contractSubindex);
     } else {
-        contractAddress = ContractAddress.create(contractAddressSource.index, contractSubindex);
+        contractAddress = ContractAddress.create(contractAddressSource.index, contractAddressSource.subindex);
     }
 
     return { accountAddress, tokenIds, contractAddress };

--- a/packages/browser-wallet-api/src/compatibility.ts
+++ b/packages/browser-wallet-api/src/compatibility.ts
@@ -42,7 +42,9 @@ export function isGtuAmount(cand: any): cand is GtuAmount {
 }
 
 function sanitizeAccountAddress(accountAddress: AccountAddressSource): AccountAddress.Type {
-    return AccountAddress.instanceOf(accountAddress) ? accountAddress : AccountAddress.fromBase58(accountAddress);
+    return typeof accountAddress === 'string'
+        ? AccountAddress.fromBase58(accountAddress)
+        : AccountAddress.fromBase58(accountAddress.address);
 }
 
 export type SanitizedSignMessageInput = {
@@ -92,10 +94,10 @@ export function sanitizeAddCIS2TokensInput(
 ): SanitizedAddCIS2TokensInput {
     const accountAddress = sanitizeAccountAddress(_accountAddress);
     let contractAddress: ContractAddress.Type;
-    if (ContractAddress.instanceOf(contractAddressSource)) {
-        contractAddress = contractAddressSource;
-    } else {
+    if (typeof contractAddressSource === 'bigint') {
         contractAddress = ContractAddress.create(contractAddressSource, contractSubindex);
+    } else {
+        contractAddress = ContractAddress.create(contractAddressSource.index, contractSubindex);
     }
 
     return { accountAddress, tokenIds, contractAddress };

--- a/packages/browser-wallet-api/test/compatibility.test.ts
+++ b/packages/browser-wallet-api/test/compatibility.test.ts
@@ -501,7 +501,7 @@ describe(sanitizeSendTransactionInput, () => {
         };
         const result = sanitizeSendTransactionInput(accountAddress, type, payload);
         expect(result).toEqual(expected);
-        expect(result.payload).toBe(payload);
+        expect((result.payload as RegisterDataPayload).data).toStrictEqual(payload.data);
     });
 
     test('Transforms "UpdateCredentials" transaction input as expected', () => {

--- a/packages/browser-wallet-api/test/compatibility.test.ts
+++ b/packages/browser-wallet-api/test/compatibility.test.ts
@@ -15,6 +15,8 @@ import {
     Energy,
     EntrypointName,
     IdStatementBuilder,
+    jsonParse,
+    jsonStringify,
     ModuleReference,
     OpenStatus,
     ReceiveName,
@@ -23,8 +25,6 @@ import {
     SimpleTransferPayload,
     SimpleTransferWithMemoPayload,
     UpdateCredentialsPayload,
-    jsonParse,
-    jsonStringify,
 } from '@concordium/web-sdk';
 import {
     SendTransactionInitContractPayload,
@@ -393,6 +393,46 @@ describe(sanitizeSendTransactionInput, () => {
         expect(result).toEqual(expected);
     });
 
+    test('Transforms "TransferWithMemo" transaction input with incorrect type as expected', () => {
+        const type = AccountTransactionType.TransferWithMemo;
+        const memo = new DataBlob(Buffer.from('Some memo message'));
+        const address = AccountAddress.fromBase58(accountAddress);
+
+        const expectedPayload: SimpleTransferWithMemoPayload = {
+            toAddress: AccountAddress.fromBase58(accountAddress),
+            amount: CcdAmount.fromMicroCcd(amount),
+            memo,
+        };
+
+        const expected: SanitizedSendTransactionInput = {
+            accountAddress: AccountAddress.fromBase58(accountAddress),
+            type,
+            payload: expectedPayload,
+        };
+
+        const payload: SimpleTransferWithMemoPayload = {
+            toAddress: {
+                address: address.address,
+                decodedAddress: address.decodedAddress,
+                __type: 'ccd_account_address',
+            },
+            amount: {
+                microCcdAmount: amount,
+                __type: 'ccd_ccd_amount',
+            },
+            memo: {
+                data: memo.data,
+                __type: 'ccd_data_blob',
+            },
+        } as unknown as SimpleTransferWithMemoPayload;
+
+        const result = sanitizeSendTransactionInput(accountAddress, type, payload);
+        expect(result).toEqual(expected);
+        const parsed = jsonParse(jsonStringify(result));
+        expect(() => parsed.payload.memo.toJSON()).not.toThrow();
+        expect(parsed).toEqual(expected);
+    });
+
     test('Transforms "ConfigureBaker" transaction input as expected', () => {
         const type = AccountTransactionType.ConfigureBaker;
         const keys: BakerKeysWithProofs = {
@@ -511,7 +551,7 @@ describe(sanitizeSendTransactionInput, () => {
 
         const payload: RegisterDataPayload = {
             data: {
-                __type: 'ccd_block_hash',
+                __type: 'ccd_data_blob',
                 data: new DataBlob(Buffer.from('This is data!')).data,
             } as unknown as DataBlob,
         };
@@ -525,9 +565,8 @@ describe(sanitizeSendTransactionInput, () => {
         };
 
         const result = sanitizeSendTransactionInput(accountAddress, type, payload);
-
+        expect(result).toEqual(expected);
         const parsed = jsonParse(jsonStringify(result));
-
         expect(() => parsed.payload.data.toJSON()).not.toThrow();
         expect(parsed).toEqual(expected);
     });

--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -8,6 +8,7 @@
 -   Sign message's stringification failing with new `deserializeTypeValue`.
 -   An issue where the max contract execution energy was not rendered correctly for init contract transactions.
 -   Updated web-sdk to fix an issue where init contract transactions were not serialized correctly.
+-   Errors in wallet-api from version mismatch between wallet and dApps.
 
 ## 1.1.10
 


### PR DESCRIPTION
## Purpose

Fix potential errors caused by version mismatch in SDK version with dApps.

## Changes

- Remove usage of instanceOf when sanitizing wallet-api inputs.
- Use AccountAddress in piggybank.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

