### PR TITLE
Fix missing date for when stake changes take effect

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+-   Missing date for delegation/validation stake decrease/stop has been restored.
+
 ## 1.2.1
 
 ### Fixed

--- a/packages/browser-wallet/package.json
+++ b/packages/browser-wallet/package.json
@@ -53,7 +53,7 @@
         "react-window-infinite-loader": "^1.0.8",
         "readable-stream": "^4.2.0",
         "uuid": "^8.3.2",
-        "wallet-common-helpers": "https://github.com/Concordium/concordium-wallet-common-helpers.git#6ffa41dc5f7bd345f4ef07860982d6d290880c44"
+        "wallet-common-helpers": "https://github.com/Concordium/concordium-wallet-common-helpers.git#b5b8acd7304f297a1aa67c91b735e90f3edef5a5"
     },
     "devDependencies": {
         "@babel/core": "^7.18.2",

--- a/packages/browser-wallet/package.json
+++ b/packages/browser-wallet/package.json
@@ -53,7 +53,7 @@
         "react-window-infinite-loader": "^1.0.8",
         "readable-stream": "^4.2.0",
         "uuid": "^8.3.2",
-        "wallet-common-helpers": "https://github.com/Concordium/concordium-wallet-common-helpers.git#d6dd106aa892d683bcaad33189ed4043bcfc55a0"
+        "wallet-common-helpers": "https://github.com/Concordium/concordium-wallet-common-helpers.git#6ffa41dc5f7bd345f4ef07860982d6d290880c44"
     },
     "devDependencies": {
         "@babel/core": "^7.18.2",

--- a/packages/browser-wallet/src/popup/pages/Account/Earn/Earn.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/Earn/Earn.tsx
@@ -7,7 +7,8 @@ import {
     ChainParametersV0,
     isBakerAccount,
     isDelegatorAccount,
-    isRewardStatusV1,
+    RewardStatus,
+    RewardStatusV0,
 } from '@concordium/web-sdk';
 
 import Button from '@popup/shared/Button';
@@ -72,6 +73,10 @@ function Earn({ chainParameters }: EarnProps) {
     );
 }
 
+function isNotRewardStatusV0(rewardStatus?: RewardStatus): rewardStatus is Exclude<RewardStatus, RewardStatusV0> {
+    return rewardStatus ? rewardStatus.version !== 0 : false;
+}
+
 export default function EarnRoutes() {
     const { setDetailsExpanded } = useContext(accountPageContext);
     const accountInfo = ensureDefined(useSelectedAccountInfo(), 'Expected to find account info for selected account');
@@ -107,7 +112,7 @@ export default function EarnRoutes() {
 
     const consensusStatus = useAsyncMemo(() => client.getConsensusStatus(), undefined, []);
     const tokenomicsInfo = useAsyncMemo(
-        () => client.getTokenomicsInfo().then(filterType(isRewardStatusV1)),
+        () => client.getTokenomicsInfo().then(filterType(isNotRewardStatusV0)),
         undefined,
         []
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2280,7 +2280,7 @@ __metadata:
     tsconfig-paths-webpack-plugin: ^3.5.2
     typescript: ^5.2.2
     uuid: ^8.3.2
-    wallet-common-helpers: "https://github.com/Concordium/concordium-wallet-common-helpers.git#d6dd106aa892d683bcaad33189ed4043bcfc55a0"
+    wallet-common-helpers: "https://github.com/Concordium/concordium-wallet-common-helpers.git#6ffa41dc5f7bd345f4ef07860982d6d290880c44"
   languageName: unknown
   linkType: soft
 
@@ -23299,9 +23299,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wallet-common-helpers@https://github.com/Concordium/concordium-wallet-common-helpers.git#d6dd106aa892d683bcaad33189ed4043bcfc55a0":
+"wallet-common-helpers@https://github.com/Concordium/concordium-wallet-common-helpers.git#6ffa41dc5f7bd345f4ef07860982d6d290880c44":
   version: 2.0.0
-  resolution: "wallet-common-helpers@https://github.com/Concordium/concordium-wallet-common-helpers.git#commit=d6dd106aa892d683bcaad33189ed4043bcfc55a0"
+  resolution: "wallet-common-helpers@https://github.com/Concordium/concordium-wallet-common-helpers.git#commit=6ffa41dc5f7bd345f4ef07860982d6d290880c44"
   dependencies:
     buffer: ^6.0.3
     cbor: ^8.0.0
@@ -23311,7 +23311,7 @@ __metadata:
     "@concordium/web-sdk": 7.x
     react: ">=16"
     react-dom: ">=16"
-  checksum: 508bf6f0d52f72ff110090e4ee2ec0e58affe2d93cdb55e26a7962d2fbe2714b9bd169ce196556a54aa4d16f13541bd6fcf6b32adc709845591cf97fc61a746a
+  checksum: 44d3f75d2547b3bf3242f4783110bf21dedec6b142dcbad749040a64d017665c6fa3012d791e85160f6b79188adddd9dc89e65bb75d567accd12affc17bde635
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2280,7 +2280,7 @@ __metadata:
     tsconfig-paths-webpack-plugin: ^3.5.2
     typescript: ^5.2.2
     uuid: ^8.3.2
-    wallet-common-helpers: "https://github.com/Concordium/concordium-wallet-common-helpers.git#6ffa41dc5f7bd345f4ef07860982d6d290880c44"
+    wallet-common-helpers: "https://github.com/Concordium/concordium-wallet-common-helpers.git#b5b8acd7304f297a1aa67c91b735e90f3edef5a5"
   languageName: unknown
   linkType: soft
 
@@ -23299,9 +23299,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wallet-common-helpers@https://github.com/Concordium/concordium-wallet-common-helpers.git#6ffa41dc5f7bd345f4ef07860982d6d290880c44":
+"wallet-common-helpers@https://github.com/Concordium/concordium-wallet-common-helpers.git#b5b8acd7304f297a1aa67c91b735e90f3edef5a5":
   version: 2.0.0
-  resolution: "wallet-common-helpers@https://github.com/Concordium/concordium-wallet-common-helpers.git#commit=6ffa41dc5f7bd345f4ef07860982d6d290880c44"
+  resolution: "wallet-common-helpers@https://github.com/Concordium/concordium-wallet-common-helpers.git#commit=b5b8acd7304f297a1aa67c91b735e90f3edef5a5"
   dependencies:
     buffer: ^6.0.3
     cbor: ^8.0.0


### PR DESCRIPTION
## Purpose

Restore missing date for when stake changes take effect.

## Changes

- Stop using deprecated (and erroneous) `isRewardStatusV1`.
- Update common wallet helpers to a version that doesn't use `isRewardStatusV1`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

