### PR TITLE
Ensure inject script does not load wasm.

### DIFF
--- a/packages/browser-wallet-api/package.json
+++ b/packages/browser-wallet-api/package.json
@@ -10,7 +10,6 @@
         "@concordium/browser-wallet-api-helpers": "workspace:^",
         "@concordium/browser-wallet-message-hub": "workspace:^",
         "@concordium/web-sdk": "^7.1.0",
-        "@concordium/web-sdk-legacy": "npm:@concordium/web-sdk@6",
         "@protobuf-ts/grpcweb-transport": "^2.8.2",
         "@protobuf-ts/runtime-rpc": "^2.8.2",
         "buffer": "^6.0.3"

--- a/packages/browser-wallet-api/src/compatibility.ts
+++ b/packages/browser-wallet-api/src/compatibility.ts
@@ -21,7 +21,6 @@ import {
     DeployModulePayload,
     Energy,
     HexString,
-    IdStatement,
     InitContractPayload,
     ModuleReference,
     ReceiveName,
@@ -31,7 +30,8 @@ import {
     SimpleTransferWithMemoPayload,
     UpdateCredentialsPayload,
     DataBlob,
-} from '@concordium/web-sdk';
+} from '@concordium/web-sdk/types';
+import { IdStatement } from '@concordium/web-sdk/id';
 
 export type GtuAmount = { microGtuAmount: bigint };
 

--- a/packages/browser-wallet-api/src/wallet-api.ts
+++ b/packages/browser-wallet-api/src/wallet-api.ts
@@ -13,6 +13,7 @@ import {
     ContractAddress,
     VerifiablePresentation,
 } from '@concordium/web-sdk/types';
+import { CredentialStatements } from '@concordium/web-sdk/web3-id';
 import {
     WalletApi as IWalletApi,
     EventType,
@@ -27,8 +28,7 @@ import {
 } from '@concordium/browser-wallet-api-helpers';
 import EventEmitter from 'events';
 import { IdProofOutput, IdStatement } from '@concordium/web-sdk/id';
-import { CredentialStatements } from '@concordium/web-sdk/web3-id';
-import { ConcordiumGRPCClient } from '@concordium/web-sdk-legacy';
+import { ConcordiumGRPCClient } from '@concordium/web-sdk/grpc';
 import { RpcTransport } from '@protobuf-ts/runtime-rpc';
 import { stringify } from './util';
 import { BWGRPCTransport } from './gRPC-transport';

--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+-   Inject script loading wasm module, unnecessarily.
+
 ## 1.2.1
 
 ### Fixed

--- a/yarn.lock
+++ b/yarn.lock
@@ -2185,7 +2185,6 @@ __metadata:
     "@concordium/browser-wallet-api-helpers": "workspace:^"
     "@concordium/browser-wallet-message-hub": "workspace:^"
     "@concordium/web-sdk": ^7.1.0
-    "@concordium/web-sdk-legacy": "npm:@concordium/web-sdk@6"
     "@protobuf-ts/grpcweb-transport": ^2.8.2
     "@protobuf-ts/runtime-rpc": ^2.8.2
     buffer: ^6.0.3
@@ -2284,27 +2283,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@concordium/common-sdk@npm:9.4.0":
-  version: 9.4.0
-  resolution: "@concordium/common-sdk@npm:9.4.0"
-  dependencies:
-    "@concordium/rust-bindings": 1.2.0
-    "@grpc/grpc-js": ^1.3.4
-    "@noble/ed25519": ^1.7.1
-    "@protobuf-ts/runtime-rpc": ^2.8.2
-    "@scure/bip39": ^1.1.0
-    big.js: ^6.2.0
-    bs58check: ^2.1.2
-    buffer: ^6.0.3
-    cross-fetch: 3.1.5
-    hash.js: ^1.1.7
-    iso-3166-1: ^2.1.1
-    json-bigint: ^1.0.0
-    uuid: ^8.3.2
-  checksum: 09b4f3303cca7677f48842c26dcc5692ef6c38bfd8c86f8b790a9f57ce942637264aaeccbcc4bf45313b88afbfff4bd3ef46bc6cbced5a29271df486819c41ad
-  languageName: node
-  linkType: hard
-
 "@concordium/react-components@npm:^0.4.0":
   version: 0.4.0
   resolution: "@concordium/react-components@npm:0.4.0"
@@ -2314,13 +2292,6 @@ __metadata:
     "@concordium/web-sdk": 7.x
     react: ^18
   checksum: 7b4cb906228f514c7d180c67fdef369c0aacde549c7a3237473732bf797c6188647e25f16d4ca300559a6db3e9fa9492632d37428a5af86d3411b1286208e332
-  languageName: node
-  linkType: hard
-
-"@concordium/rust-bindings@npm:1.2.0":
-  version: 1.2.0
-  resolution: "@concordium/rust-bindings@npm:1.2.0"
-  checksum: a0deb7d2a8bea7b32487a85fd9981e40a1e0ad5ca72c625887e7d735933abae9adac34ab3047a0ac2f3e690ac8c5ac5d7a763a5fef9efe2c6d209860aa5cf6ec
   languageName: node
   linkType: hard
 
@@ -2341,20 +2312,6 @@ __metadata:
   peerDependencies:
     "@concordium/web-sdk": 7.x
   checksum: 038e4f9b35404e03dfcffae3a5891f583654296e0fadcce17066798ba3df9be3ea321cecad6e1d9a3e6056403fe571c539202a00d9e95bb7de052546ed8a9cb0
-  languageName: node
-  linkType: hard
-
-"@concordium/web-sdk-legacy@npm:@concordium/web-sdk@6":
-  version: 6.4.0
-  resolution: "@concordium/web-sdk@npm:6.4.0"
-  dependencies:
-    "@concordium/common-sdk": 9.4.0
-    "@concordium/rust-bindings": 1.2.0
-    "@grpc/grpc-js": ^1.3.4
-    "@protobuf-ts/grpcweb-transport": ^2.8.2
-    buffer: ^6.0.3
-    process: ^0.11.10
-  checksum: 7553e594e07fec3081bfb73b88f615c3a6e438e84cb22d3d3ba57e91803a5c2660d8181fc58e9c23871d8d47ffee5b79eeeb9f5f783ae934614c295b65bc6fde
   languageName: node
   linkType: hard
 
@@ -2866,7 +2823,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grpc/grpc-js@npm:^1.3.4, @grpc/grpc-js@npm:^1.9.4":
+"@grpc/grpc-js@npm:^1.9.4":
   version: 1.9.5
   resolution: "@grpc/grpc-js@npm:1.9.5"
   dependencies:
@@ -3472,7 +3429,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/ed25519@npm:^1.7.0, @noble/ed25519@npm:^1.7.1":
+"@noble/ed25519@npm:^1.7.0":
   version: 1.7.3
   resolution: "@noble/ed25519@npm:1.7.3"
   checksum: 45169927d51de513e47bbeebff3a603433c4ac7579e1b8c5034c380a0afedbe85e6959be3d69584a7a5ed6828d638f8f28879003b9bb2fb5f22d8aa2d88fd5fe
@@ -8540,15 +8497,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base-x@npm:^3.0.2":
-  version: 3.0.9
-  resolution: "base-x@npm:3.0.9"
-  dependencies:
-    safe-buffer: ^5.0.1
-  checksum: 957101d6fd09e1903e846fd8f69fd7e5e3e50254383e61ab667c725866bec54e5ece5ba49ce385128ae48f9ec93a26567d1d5ebb91f4d56ef4a9cc0d5a5481e8
-  languageName: node
-  linkType: hard
-
 "base-x@npm:^4.0.0":
   version: 4.0.0
   resolution: "base-x@npm:4.0.0"
@@ -8940,32 +8888,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bs58@npm:^4.0.0":
-  version: 4.0.1
-  resolution: "bs58@npm:4.0.1"
-  dependencies:
-    base-x: ^3.0.2
-  checksum: b3c5365bb9e0c561e1a82f1a2d809a1a692059fae016be233a6127ad2f50a6b986467c3a50669ce4c18929dcccb297c5909314dd347a25a68c21b68eb3e95ac2
-  languageName: node
-  linkType: hard
-
 "bs58@npm:^5.0.0":
   version: 5.0.0
   resolution: "bs58@npm:5.0.0"
   dependencies:
     base-x: ^4.0.0
   checksum: 2475cb0684e07077521aac718e604a13e0f891d58cff923d437a2f7e9e28703ab39fce9f84c7c703ab369815a675f11e3bd394d38643bfe8969fbe42e6833d45
-  languageName: node
-  linkType: hard
-
-"bs58check@npm:^2.1.2":
-  version: 2.1.2
-  resolution: "bs58check@npm:2.1.2"
-  dependencies:
-    bs58: ^4.0.0
-    create-hash: ^1.1.0
-    safe-buffer: ^5.1.2
-  checksum: 43bdf08a5dd04581b78f040bc4169480e17008da482ffe2a6507327bbc4fc5c28de0501f7faf22901cfe57fbca79cbb202ca529003fedb4cb8dccd265b38e54d
   languageName: node
   linkType: hard
 
@@ -10286,15 +10214,6 @@ __metadata:
     cross-env: src/bin/cross-env.js
     cross-env-shell: src/bin/cross-env-shell.js
   checksum: 26f2f3ea2ab32617f57effb70d329c2070d2f5630adc800985d8b30b56e8bf7f5f439dd3a0358b79cee6f930afc23cf8e23515f17ccfb30092c6b62c6b630a79
-  languageName: node
-  linkType: hard
-
-"cross-fetch@npm:3.1.5":
-  version: 3.1.5
-  resolution: "cross-fetch@npm:3.1.5"
-  dependencies:
-    node-fetch: 2.6.7
-  checksum: f6b8c6ee3ef993ace6277fd789c71b6acf1b504fd5f5c7128df4ef2f125a429e29cd62dc8c127523f04a5f2fa4771ed80e3f3d9695617f441425045f505cf3bb
   languageName: node
   linkType: hard
 
@@ -17396,7 +17315,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:2.6.7, node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.7":
+"node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.7":
   version: 2.6.7
   resolution: "node-fetch@npm:2.6.7"
   dependencies:


### PR DESCRIPTION
## Purpose

Some websites throw errors because our inject script tries to load wasm. It doesn't need any wasm though, so this makes sure it doesn't try to load it anyway. (By using the new web-sdk version)

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
