### PR TITLE
Make CIS-2 token lookup more lenient

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+-   CIS-2 token lookup no longer blocks choosing a contract, if looking up metadata or balance only fails for some tokens.
+
 ## 1.2.1
 
 ### Fixed

--- a/packages/browser-wallet/src/popup/pages/Account/Tokens/ManageTokens/ChooseContract.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/Tokens/ManageTokens/ChooseContract.tsx
@@ -97,9 +97,11 @@ export default function ChooseContract() {
                         )}`
                     );
                 }
+
                 if (response.tokens.length === 0) {
                     return t('noTokensError');
                 }
+
                 validContract.current = { details: cd, tokens: response };
                 return true;
             },

--- a/packages/browser-wallet/src/popup/pages/Account/Tokens/ManageTokens/ChooseContract.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/Tokens/ManageTokens/ChooseContract.tsx
@@ -13,6 +13,7 @@ import { selectedAccountAtom } from '@popup/store/account';
 import { ensureDefined } from '@shared/utils/basic-helpers';
 import { debouncedAsyncValidate } from '@popup/shared/utils/validation-helpers';
 import { ContractAddress } from '@concordium/web-sdk';
+import { logWarningMessage } from '@shared/utils/log-helpers';
 import { contractDetailsAtom, contractTokensAtom } from './state';
 import { fetchTokensConfigure, FetchTokensResponse } from './utils';
 import { tokensRoutes } from '../routes';
@@ -90,12 +91,15 @@ export default function ChooseContract() {
                 })();
 
                 if (fetchErrors.length > 0) {
-                    return t('failedTokensError', { errors: fetchErrors.join('\n') });
+                    logWarningMessage(
+                        `Tokens in contract ${cd.index.toString()}:${cd.subindex.toString()} failed: \n${fetchErrors.join(
+                            '\n'
+                        )}`
+                    );
                 }
                 if (response.tokens.length === 0) {
                     return t('noTokensError');
                 }
-
                 validContract.current = { details: cd, tokens: response };
                 return true;
             },

--- a/packages/browser-wallet/src/popup/pages/Account/Tokens/ManageTokens/state.ts
+++ b/packages/browser-wallet/src/popup/pages/Account/Tokens/ManageTokens/state.ts
@@ -65,7 +65,7 @@ export const contractTokensAtom = (() => {
                     set(loadingAtom, true);
 
                     const tokens = get(listAtom);
-                    const topId = [...tokens].reverse()[0]?.pageId;
+                    const topId = tokens[tokens.length - 1]?.pageId;
 
                     const { hasMore, tokens: next } = await fetchTokens(topId);
 

--- a/packages/browser-wallet/src/popup/pages/Account/i18n/da.ts
+++ b/packages/browser-wallet/src/popup/pages/Account/i18n/da.ts
@@ -76,7 +76,6 @@ const t: typeof en = {
             invalidIndex: 'Kontraktindeks skal være et heltal',
             noContractFound: 'Ingen kontrakt fundet på indeks',
             noTokensError: 'Ingen tokens fundet i kontrakten',
-            failedTokensError: 'En fejl skete under tjekket efter tokens',
             contractIndex: 'Kontraktindeks',
             hexId: 'Ugyldigt token ID (skal være HEX encodet)',
             updateTokens: 'Opdater tokens',

--- a/packages/browser-wallet/src/popup/pages/Account/i18n/en.ts
+++ b/packages/browser-wallet/src/popup/pages/Account/i18n/en.ts
@@ -73,9 +73,7 @@ const t = {
             invalidIndex: 'Contract index must be an integer',
             indexMax: 'Contract index can not exceed 18446744073709551615',
             noContractFound: 'No contract found on index',
-            noTokensError: 'No tokens found in contract',
-            failedTokensError:
-                'The following errors were encountered while checking for tokens in the contract: \n{{ errors }}',
+            noTokensError: 'No valid tokens found in contract',
             contractIndex: 'Contract index',
             hexId: 'Invalid token ID (must be HEX encoded)',
             updateTokens: 'Update tokens',

--- a/packages/browser-wallet/src/popup/store/token.ts
+++ b/packages/browser-wallet/src/popup/store/token.ts
@@ -6,6 +6,7 @@ import { ChromeStorageKey, TokenIdAndMetadata, TokenMetadata, TokenStorage } fro
 import { ContractBalances, getContractBalances } from '@shared/utils/token-helpers';
 import { addToastAtom } from '@popup/state';
 import { ContractAddress } from '@concordium/web-sdk';
+import { getContractName } from '@shared/utils/contract-helpers';
 import { AsyncWrapper, atomWithChromeStorage } from './utils';
 import { grpcClientAtom } from './settings';
 import { selectedAccountAtom } from './account';
@@ -137,7 +138,7 @@ const cbf = atomFamily<string, Atom<ContractBalances>>((identifier: string) => {
             const tokenIds = tokens.value[contractIndex]?.map((t) => t.id) ?? [];
 
             if (tokenIds.length !== 0) {
-                const instanceInfo = await client.getInstanceInfo(ContractAddress.create(BigInt(contractIndex), 0n));
+                const instanceInfo = await client.getInstanceInfo(ContractAddress.create(BigInt(contractIndex)));
 
                 let balances = {};
                 if (instanceInfo !== undefined) {
@@ -146,7 +147,7 @@ const cbf = atomFamily<string, Atom<ContractBalances>>((identifier: string) => {
                         {
                             index: BigInt(contractIndex),
                             subindex: 0n,
-                            contractName: instanceInfo.name.value.substring(5),
+                            contractName: getContractName(instanceInfo),
                         },
                         tokenIds,
                         accountAddress,

--- a/packages/browser-wallet/src/shared/utils/contract-helpers.ts
+++ b/packages/browser-wallet/src/shared/utils/contract-helpers.ts
@@ -16,7 +16,7 @@ export function applyExecutionNRGBuffer(estimatedExecutionEnergy: bigint) {
  * @param instanceInfo the instance info to extract the contract name from
  * @returns the contract's name to be used as a prefix when setting the receive name for a contract method
  */
-export function getContractName(instanceInfo: InstanceInfo): string | undefined {
+export function getContractName(instanceInfo: InstanceInfo): string {
     return instanceInfo.name.value.substring(5);
 }
 


### PR DESCRIPTION
## Purpose

Make CIS-2 token lookup more lenient

## Changes

- Redo `getTokens` so that metadataURL and balances are fetched individually.
- Log errors from token lookup, don't show them in UI.
- Don't fail "Choose Contract" unless all tokens are missing either metadata or balance.
- `fetchTokensConfigure` now keeps looking until 1 valid token is found (/or all tokens in the contract have been checked)

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

