### PR TITLE
Add EuroE token by default

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.3.0
+
+### Added
+
+-   The EuroE token is now added to all accounts by default.
+
 ## 1.2.1
 
 ### Fixed

--- a/packages/browser-wallet/package.json
+++ b/packages/browser-wallet/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@concordium/browser-wallet",
     "private": true,
-    "version": "1.2.1",
+    "version": "1.3.0",
     "description": "Browser extension wallet for the Concordium blockchain",
     "author": "Concordium Software",
     "license": "Apache-2.0",

--- a/packages/browser-wallet/src/background/index.ts
+++ b/packages/browser-wallet/src/background/index.ts
@@ -185,7 +185,7 @@ async function addTokenToAccounts(network: NetworkConfiguration, contractIndex: 
 }
 
 /**
- * Add euroe tokens to all accounts that don't already have it, if the migration have no already been run, and sets the euroe migration check.
+ * Add euroe tokens to all accounts that don't already have it, if the migration has not atlready been run, and sets the euroe migration check.
  */
 async function euroeMigration() {
     const migrations = (await storedMigrations.get()) || [];
@@ -203,12 +203,18 @@ async function euroeMigration() {
     }
 }
 
-const startupHandler = async () => {
-    const network = await storedCurrentNetwork.get();
+async function runMigrations(network?: NetworkConfiguration) {
     if (network) {
         await migrateNetwork(network);
+    }
+    await euroeMigration();
+}
+
+const startupHandler = async () => {
+    const network = await storedCurrentNetwork.get();
+    runMigrations(network);
+    if (network) {
         await startMonitoringPendingStatus(network);
-        await euroeMigration();
     }
     checkForNewTermsAndConditions();
 

--- a/packages/browser-wallet/src/background/update.ts
+++ b/packages/browser-wallet/src/background/update.ts
@@ -1,10 +1,13 @@
-import { storedCredentials, storedIdentities, useIndexedStorage } from '@shared/storage/access';
-import { addToList, editList } from '@shared/storage/update';
+import { storedCredentials, storedIdentities, storedTokens, useIndexedStorage } from '@shared/storage/access';
+import { addToList, editList, updateRecord } from '@shared/storage/update';
 import { Identity, WalletCredential } from '@shared/storage/types';
 import { identityMatch } from '@shared/utils/identity-helpers';
+import { EUROE_MAINNET_INDEX, EUROE_TESTNET_INDEX, euroeTokenStorage } from '@shared/constants/token-metadata';
+import { mainnet, testnet } from '@shared/constants/networkConfiguration';
 
 const identityLock = 'concordium_identity_lock';
 const credentialLock = 'concordium_credential_lock';
+const tokenLock = 'concordium_token_lock';
 
 export async function addIdentity(identity: Identity | Identity[], genesisHash: string): Promise<void> {
     return addToList(
@@ -14,7 +17,29 @@ export async function addIdentity(identity: Identity | Identity[], genesisHash: 
     );
 }
 
+// Add the euroe token to the credential(s)
+async function addEuroeToken(cred: WalletCredential | WalletCredential[], genesisHash: string): Promise<void> {
+    const storage = useIndexedStorage(storedTokens, async () => genesisHash);
+    const add = async (index: string) => {
+        for (const { address } of Array.isArray(cred) ? cred : [cred]) {
+            await updateRecord(tokenLock, storage, address, { [index]: [euroeTokenStorage] });
+        }
+    };
+    switch (genesisHash) {
+        case mainnet.genesisHash:
+            await add(EUROE_MAINNET_INDEX.toString());
+            break;
+        case testnet.genesisHash:
+            await add(EUROE_TESTNET_INDEX.toString());
+            break;
+        default:
+    }
+}
+
 export async function addCredential(cred: WalletCredential | WalletCredential[], genesisHash: string): Promise<void> {
+    // All accounts should have euroe token added as default
+    addEuroeToken(cred, genesisHash);
+
     return addToList(
         credentialLock,
         cred,

--- a/packages/browser-wallet/src/background/update.ts
+++ b/packages/browser-wallet/src/background/update.ts
@@ -33,6 +33,7 @@ async function addEuroeToken(cred: WalletCredential | WalletCredential[], genesi
             await add(EUROE_TESTNET_INDEX.toString());
             break;
         default:
+        // The euroe Token only exists on mainnet and testnet, so for other networks we don't do anything.
     }
 }
 

--- a/packages/browser-wallet/src/popup/store/utils.ts
+++ b/packages/browser-wallet/src/popup/store/utils.ts
@@ -33,6 +33,7 @@ import {
     sessionVerifiableCredentials,
     sessionVerifiableCredentialMetadataUrls,
     storedLog,
+    storedMigrations,
 } from '@shared/storage/access';
 import { ChromeStorageKey } from '@shared/storage/types';
 import { atom, PrimitiveAtom, WritableAtom } from 'jotai';
@@ -73,6 +74,7 @@ const accessorMap: Record<ChromeStorageKey, StorageAccessor<any>> = {
         getGenesisHash
     ),
     [ChromeStorageKey.Log]: storedLog,
+    [ChromeStorageKey.Migrations]: storedMigrations,
 };
 
 export function resetOnUnmountAtom<V>(initial: V): PrimitiveAtom<V> {

--- a/packages/browser-wallet/src/shared/constants/migrations.ts
+++ b/packages/browser-wallet/src/shared/constants/migrations.ts
@@ -1,0 +1,3 @@
+export enum Migrations {
+    euroe = "euroe_migration"
+}

--- a/packages/browser-wallet/src/shared/constants/migrations.ts
+++ b/packages/browser-wallet/src/shared/constants/migrations.ts
@@ -1,3 +1,3 @@
 export enum Migrations {
-    euroe = "euroe_migration"
+    euroe = 'euroe_migration',
 }

--- a/packages/browser-wallet/src/shared/constants/token-metadata.ts
+++ b/packages/browser-wallet/src/shared/constants/token-metadata.ts
@@ -12,3 +12,26 @@ export const CCD_METADATA: TokenMetadata = {
     display: CCD_IMAGE,
     thumbnail: CCD_IMAGE,
 };
+
+export const EUROE_METADATA: TokenMetadata = {
+    name: 'EUROe Stablecoin',
+    symbol: 'EUROe',
+    decimals: 6,
+    unique: false,
+    description: 'EUROe is a modern European stablecoin - a digital representation of fiat Euros.',
+    thumbnail: {
+        url: 'https://dev.euroe.com/persistent/token-icon/png/32x32.png',
+    },
+    display: {
+        url: 'https://dev.euroe.com/persistent/token-icon/png/256x256.png',
+    },
+    attributes: [],
+};
+
+export const euroeTokenStorage = {
+    id: '',
+    metadataLink: 'https://euroesolanametadadev.blob.core.windows.net/euroesolanametadatadev/metadata-concordium.json',
+};
+
+export const EUROE_MAINNET_INDEX = 9390;
+export const EUROE_TESTNET_INDEX = 7260;

--- a/packages/browser-wallet/src/shared/storage/access.ts
+++ b/packages/browser-wallet/src/shared/storage/access.ts
@@ -2,6 +2,7 @@ import { stringify } from '@concordium/browser-wallet-api/src/util';
 import { parse } from '@shared/utils/payload-helpers';
 import { VerifiableCredentialMetadata } from '@shared/utils/verifiable-credential-helpers';
 import { Log } from '@shared/utils/log-helpers';
+import { Migrations } from '@shared/constants/migrations';
 import {
     ChromeStorageKey,
     EncryptedData,
@@ -237,3 +238,4 @@ export const sessionVerifiableCredentialMetadataUrls = makeIndexedStorageAccesso
     'session',
     ChromeStorageKey.TemporaryVerifiableCredentialMetadataUrls
 );
+export const storedMigrations = makeStorageAccessor<Migrations[]>('local', ChromeStorageKey.Migrations);

--- a/packages/browser-wallet/src/shared/storage/types.ts
+++ b/packages/browser-wallet/src/shared/storage/types.ts
@@ -41,6 +41,7 @@ export enum ChromeStorageKey {
     TemporaryVerifiableCredentialMetadataUrls = 'tempVerifiableCredentialMetadataUrls',
     Allowlist = 'allowlist',
     Log = 'log',
+    Migrations = 'migrations',
 }
 
 export enum Theme {


### PR DESCRIPTION
## Purpose

Show EuroE in wallet

## Changes

- Added migration to add EuroE to all existing accounts.
- Now EuroE is added by default to new/restored accounts.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
