### PR TITLE
Fix: Error when using bigint in smart contract parameters

### DIFF
--- a/packages/browser-wallet-api-helpers/CHANGELOG.md
+++ b/packages/browser-wallet-api-helpers/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Fixed
+
+-   Extend type `SmartContractParameters` with `bigint` allowing large numbers in smart contract parameters.
+
 ## 3.0.0
 
 ### Breaking changes

--- a/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
+++ b/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
@@ -70,6 +70,7 @@ export type SmartContractParameters =
     | { [key: string]: SmartContractParameters }
     | SmartContractParameters[]
     | number
+    | bigint
     | string
     | boolean;
 

--- a/packages/browser-wallet-api/package.json
+++ b/packages/browser-wallet-api/package.json
@@ -12,9 +12,11 @@
         "@concordium/web-sdk": "^7.1.0",
         "@protobuf-ts/grpcweb-transport": "^2.8.2",
         "@protobuf-ts/runtime-rpc": "^2.8.2",
-        "buffer": "^6.0.3"
+        "buffer": "^6.0.3",
+        "json-bigint": "^1.0.0"
     },
     "devDependencies": {
+        "@types/json-bigint": "^1.0.2",
         "jest": "^29.7.0",
         "ts-jest": "^29.1.1"
     },

--- a/packages/browser-wallet-api/src/wallet-api.ts
+++ b/packages/browser-wallet-api/src/wallet-api.ts
@@ -30,6 +30,7 @@ import EventEmitter from 'events';
 import { IdProofOutput, IdStatement } from '@concordium/web-sdk/id';
 import { ConcordiumGRPCClient } from '@concordium/web-sdk/grpc';
 import { RpcTransport } from '@protobuf-ts/runtime-rpc';
+import * as JSONBig from 'json-bigint';
 import { stringify } from './util';
 import { BWGRPCTransport } from './gRPC-transport';
 import {
@@ -138,6 +139,7 @@ class WalletApi extends EventEmitter implements IWalletApi {
                 ...input,
                 accountAddress: AccountAddress.toBase58(input.accountAddress),
                 payload: stringify(input.payload),
+                parameters: JSONBig.stringify(input.parameters),
             }
         );
 

--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -11,6 +11,7 @@
 -   Inject script loading wasm module, unnecessarily.
 -   Missing date for delegation/validation stake decrease/stop has been restored.
 -   Changing restake preference is no longer blocked when below minimum stake threshold.
+-   `SendTransaction` in wallet-api now supports `bigint` as part of smart contract parameters, fixing an issue with using large numbers.
 
 ## 1.3.0
 

--- a/packages/browser-wallet/src/popup/pages/SendTransaction/SendTransaction.tsx
+++ b/packages/browser-wallet/src/popup/pages/SendTransaction/SendTransaction.tsx
@@ -25,6 +25,8 @@ import { BackgroundSendTransactionPayload } from '@shared/utils/types';
 import { convertEnergyToMicroCcd, getEnergyCost } from '@shared/utils/energy-helpers';
 import { useBlockChainParameters } from '@popup/shared/BlockChainParametersProvider';
 import { getPublicAccountAmounts } from 'wallet-common-helpers';
+import * as JSONBig from 'json-bigint';
+import { SmartContractParameters } from '@concordium/browser-wallet-api-helpers';
 
 interface Location {
     state: {
@@ -59,6 +61,13 @@ export default function SendTransaction({ onSubmit, onReject }: Props) {
                 state.payload.schemaVersion
             ),
         [JSON.stringify(state.payload)]
+    );
+    const parameters = useMemo(
+        () =>
+            state.payload.parameters === undefined
+                ? undefined
+                : (JSONBig.parse(state.payload.parameters) as SmartContractParameters),
+        [state.payload.parameters]
     );
 
     const cost = useMemo(() => {
@@ -116,7 +125,7 @@ export default function SendTransaction({ onSubmit, onReject }: Props) {
                 <TransactionReceipt
                     transactionType={transactionType}
                     payload={payload}
-                    parameters={state.payload.parameters}
+                    parameters={parameters}
                     sender={accountAddress}
                     cost={cost}
                     className="m-10"

--- a/packages/browser-wallet/src/popup/shared/TransactionReceipt/DisplayParameters.tsx
+++ b/packages/browser-wallet/src/popup/shared/TransactionReceipt/DisplayParameters.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { SmartContractParameters } from '@concordium/browser-wallet-api-helpers';
+import * as JSONBig from 'json-bigint';
 
 type Props = {
     parameters?: SmartContractParameters;
@@ -16,7 +17,7 @@ export default function DisplayParameters({ parameters }: Props) {
             {hasParameters && (
                 <>
                     <h5 className="m-b-5">{t('parameter')}:</h5>
-                    <pre className="transaction-receipt__parameter">{JSON.stringify(parameters, null, 2)}</pre>
+                    <pre className="transaction-receipt__parameter">{JSONBig.stringify(parameters, null, 2)}</pre>
                 </>
             )}
             {!hasParameters && <h5>{t('noParameter')}</h5>}

--- a/packages/browser-wallet/src/shared/utils/payload-helpers.ts
+++ b/packages/browser-wallet/src/shared/utils/payload-helpers.ts
@@ -16,6 +16,7 @@ import {
 import { Buffer } from 'buffer/';
 import { SmartContractParameters, SchemaType, SchemaWithContext } from '@concordium/browser-wallet-api-helpers';
 import { serializationTypes } from '@concordium/browser-wallet-api/src/constants';
+import * as JSONBig from 'json-bigint';
 
 export type HeadlessTransaction =
     | { type: AccountTransactionType.Update; payload: UpdateContractPayload }
@@ -56,11 +57,15 @@ export function parse(input: string | undefined) {
 export function parsePayload(
     type: AccountTransactionType,
     stringifiedPayload: string,
-    parameters?: SmartContractParameters,
+    stringifiedParameters?: string,
     schema?: SchemaWithContext,
     schemaVersion: SchemaVersion = 0
 ): HeadlessTransaction {
     const payload = parse(stringifiedPayload);
+    const parameters =
+        stringifiedParameters === undefined
+            ? undefined
+            : (JSONBig.parse(stringifiedParameters) as SmartContractParameters);
 
     switch (type) {
         case AccountTransactionType.Update: {

--- a/packages/browser-wallet/src/shared/utils/types.ts
+++ b/packages/browser-wallet/src/shared/utils/types.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-types */
-import { SchemaWithContext, SmartContractParameters } from '@concordium/browser-wallet-api-helpers';
+import { SchemaWithContext } from '@concordium/browser-wallet-api-helpers';
 import type { SchemaVersion, AccountTransactionType } from '@concordium/web-sdk';
 import { RefAttributes } from 'react';
 /**
@@ -80,7 +80,8 @@ export type BackgroundSendTransactionPayload = {
     accountAddress: string;
     type: AccountTransactionType;
     payload: string;
-    parameters?: SmartContractParameters;
+    /** This is a stringified version of SmartContractParameters (Using JSONBig.stringify). */
+    parameters?: string;
     schema?: SchemaWithContext;
     schemaVersion?: SchemaVersion;
     url: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2187,8 +2187,10 @@ __metadata:
     "@concordium/web-sdk": ^7.1.0
     "@protobuf-ts/grpcweb-transport": ^2.8.2
     "@protobuf-ts/runtime-rpc": ^2.8.2
+    "@types/json-bigint": ^1.0.2
     buffer: ^6.0.3
     jest: ^29.7.0
+    json-bigint: ^1.0.0
     ts-jest: ^29.1.1
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Purpose

Closes #420.

## Changes

- The injected script will now send the smart contract parameters _stringified_ using `json-bigint`, which is then parsed in the extension when parsing the payload. This is all internal and should not result in any breaking changes.
- The type `SmartContractParameters` is extended with `bigint`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
