### PR TITLE
Allow restaking when below minimum stake

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 -   Inject script loading wasm module, unnecessarily.
 -   Missing date for delegation/validation stake decrease/stop has been restored.
+-   Changing restake preference is no longer blocked when below minimum stake threshold.
 
 ## 1.3.0
 

--- a/packages/browser-wallet/src/popup/shared/utils/transaction-helpers.ts
+++ b/packages/browser-wallet/src/popup/shared/utils/transaction-helpers.ts
@@ -17,6 +17,7 @@ import {
     InitContractPayload,
     UpdateContractPayload,
     SimpleTransferWithMemoPayload,
+    AccountInfoType,
 } from '@concordium/web-sdk';
 import {
     isValidResolutionString,
@@ -91,7 +92,10 @@ export function validateBakerStake(
     const bakerStakeThreshold = chainParameters?.minimumEquityCapital.microCcdAmount || 0n;
     const amount = ccdToMicroCcd(amountToValidate);
 
-    if (bakerStakeThreshold > amount) {
+    const amountNotChanged =
+        accountInfo?.type === AccountInfoType.Baker && amount === accountInfo.accountBaker.stakedAmount.microCcdAmount;
+
+    if (!amountNotChanged && bakerStakeThreshold > amount) {
         return i18n.t('utils.ccdAmount.belowBakerThreshold', { threshold: displayAsCcd(bakerStakeThreshold) });
     }
 


### PR DESCRIPTION
## Purpose

Fix "Changing restaking options not possible for validators below minimum stake"

## Changes

- During validation, handle case of below minimum, but amount has not changed.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

