### PR TITLE
Wrong identity providers

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Recovery can now be aborted when an identity has not yet been found.
 
+### Fixed
+
+-   An issue where, in some cases, the wrong list of identity providers was used when recovering from the wallet settings menu.
+
 ## 1.3.2
 
 ### Added

--- a/packages/browser-wallet/package.json
+++ b/packages/browser-wallet/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@concordium/browser-wallet",
     "private": true,
-    "version": "1.3.2",
+    "version": "1.4.0",
     "description": "Browser extension wallet for the Concordium blockchain",
     "author": "Concordium Software",
     "license": "Apache-2.0",


### PR DESCRIPTION
## Purpose
Fix a bug where recovery from the wallet settings menu would use a list of identity providers from the wrong network.

## Changes
- Reset the identity provider atom when updating the network.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.