### PR TITLE
Fix ChooseIdentity component using wrong identity index

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+-   An issue where the identity selected for creating a new account was swapped with another identity if the wallet contained failed identities.
+
 ## 1.4.0
 
 ### Added

--- a/packages/browser-wallet/src/popup/pages/AddAccount/ChooseIdentity.tsx
+++ b/packages/browser-wallet/src/popup/pages/AddAccount/ChooseIdentity.tsx
@@ -5,7 +5,7 @@ import { useAtomValue, useSetAtom } from 'jotai';
 import IdentityProviderIcon from '@popup/shared/IdentityProviderIcon';
 
 import IdCard from '@popup/shared/IdCard';
-import { selectedIdentityIndexAtom, identityProvidersAtom } from '@popup/store/identity';
+import { selectedIdentityIndexAtom, identityProvidersAtom, identitiesAtomWithLoading } from '@popup/store/identity';
 import { Identity, WalletCredential, ConfirmedIdentity } from '@shared/storage/types';
 import { absoluteRoutes } from '@popup/constants/routes';
 import Button from '@popup/shared/Button';
@@ -14,7 +14,7 @@ import { getMaxAccountsForIdentity, isIdentityOfCredential } from '@shared/utils
 import { getNextEmptyCredNumber } from '@popup/shared/utils/account-helpers';
 import Modal from '@popup/shared/Modal';
 import i18n from '@popup/shell/i18n';
-import { useConfirmedIdentities } from '@popup/shared/utils/identity-helpers';
+import { isConfirmedIdentity } from '@popup/shared/utils/identity-helpers';
 
 function validateValidForAccountCreation(identity: ConfirmedIdentity, creds: WalletCredential[]): string | undefined {
     const nextCredNumber = getNextEmptyCredNumber(creds);
@@ -26,7 +26,7 @@ function validateValidForAccountCreation(identity: ConfirmedIdentity, creds: Wal
 
 export default function ChooseIdentity() {
     const { t } = useTranslation('addAccount');
-    const identities = useConfirmedIdentities();
+    const identities = useAtomValue(identitiesAtomWithLoading);
     const setSelectedIdentityIndex = useSetAtom(selectedIdentityIndexAtom);
     const nav = useNavigate();
     const providers = useAtomValue(identityProvidersAtom);
@@ -64,6 +64,11 @@ export default function ChooseIdentity() {
             </Modal>
             <p className="m-t-20 text-center p-h-10">{t('chooseIdentity')}</p>
             {identities.value.map((identity, i) => {
+                // Do not allow the user to select an un-confirmed identity.
+                if (!isConfirmedIdentity(identity)) {
+                    return null;
+                }
+
                 const credsOfCurrentIdentity = credentials.filter(isIdentityOfCredential(identity));
                 const reason = validateValidForAccountCreation(identity, credsOfCurrentIdentity);
 


### PR DESCRIPTION
## Purpose
Fix an issue where the wrong identity was used for creating an account if the wallet contained failed identities.

## Changes
- Gather all identities to be able to set the correct identity storage index, so that on the following page the correct identity is shown as the selected one.

Note that this is just a quickfix. In general the fact that this is controlled by a global value in storage is bad, and ideally we would refactor it.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.