### PR TITLE
Add pipeline for building releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: Release browser wallet
+
+on:
+    # Triggers the workflow on push or pull request events but only for the main branch and release branches
+    push:
+        branches: [release-pipeline]
+
+    # Allows us to run the workflow manually from the Actions tab
+    workflow_dispatch:
+
+env:
+    dummy: 1 # change to force cache invalidation
+    node_version: 18.14.2
+
+jobs:
+    dependencies:
+        runs-on: ubuntu-20.04
+
+        steps:
+            - uses: actions/checkout@v2
+
+            - name: Cache dependencies
+              id: fetch-dependencies
+              uses: actions/cache@v2
+              with:
+                  path: |
+                      **/node_modules
+                  key: ${{ runner.os }}-${{ env.dummy }}-${{ hashFiles('**/package.json', '**/yarn.lock') }}
+
+            - uses: actions/setup-node@v2
+              if: steps.fetch-dependencies.outputs.cache-hit != 'true'
+              with:
+                  node-version: '${{ env.node_version }}'
+
+            - name: Download dependencies
+              if: steps.fetch-dependencies.outputs.cache-hit != 'true'
+              run: YARN_CHECKSUM_BEHAVIOR=ignore yarn
+
+    build:
+        runs-on: ubuntu-20.04
+        needs: [dependencies]
+
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-node@v2
+              with:
+                  node-version: '${{ env.node_version }}'
+
+            - name: Get cached dependencies
+              uses: actions/cache@v2
+              with:
+                  path: |
+                      **/node_modules
+                  key: ${{ runner.os }}-${{ env.dummy }}-${{ hashFiles('**/package.json', '**/yarn.lock') }}
+
+            - name: Build
+              run: yarn build:all
+
+            - name: TypeCheck
+              run: yarn type:check
+
+            - name: Upload release
+              uses: actions/upload-artifact@master
+              with:
+                  name: concordium-browser-wallet
+                  path: ./packages/browser-wallet/dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,6 @@
 name: Release browser wallet
 
 on:
-    # Triggers the workflow on push or pull request events but only for the main branch and release branches
-    push:
-        branches: [release-pipeline]
-
     # Allows us to run the workflow manually from the Actions tab
     workflow_dispatch:
 
@@ -36,7 +32,7 @@ jobs:
               if: steps.fetch-dependencies.outputs.cache-hit != 'true'
               run: YARN_CHECKSUM_BEHAVIOR=ignore yarn
 
-    release:
+    build-and-upload:
         runs-on: ubuntu-20.04
         needs: [dependencies]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,5 +77,5 @@ jobs:
             - name: Upload development release
               uses: actions/upload-artifact@master
               with:
-                  name: concordium-browser-wallet-dev-${{steps.package-version.outputs.current-version}}
+                  name: concordium-browser-wallet-${{steps.package-version.outputs.current-version}}-dev
                   path: ./packages/browser-wallet/dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
               if: steps.fetch-dependencies.outputs.cache-hit != 'true'
               run: YARN_CHECKSUM_BEHAVIOR=ignore yarn
 
-    build:
+    release:
         runs-on: ubuntu-20.04
         needs: [dependencies]
 
@@ -53,6 +53,12 @@ jobs:
                       **/node_modules
                   key: ${{ runner.os }}-${{ env.dummy }}-${{ hashFiles('**/package.json', '**/yarn.lock') }}
 
+            - name: get-npm-version
+              id: package-version
+              uses: martinbeentjes/npm-get-version-action@v1.3.1
+              with:
+                  path: packages/browser-wallet
+
             - name: Build
               run: yarn build:all
 
@@ -62,7 +68,7 @@ jobs:
             - name: Upload release
               uses: actions/upload-artifact@master
               with:
-                  name: concordium-browser-wallet
+                  name: concordium-browser-wallet-${{steps.package-version.outputs.current-version}}
                   path: ./packages/browser-wallet/dist
 
             - name: Make development build
@@ -71,5 +77,5 @@ jobs:
             - name: Upload development release
               uses: actions/upload-artifact@master
               with:
-                  name: concordium-browser-wallet-dev
+                  name: concordium-browser-wallet-dev-${{steps.package-version.outputs.current-version}}
                   path: ./packages/browser-wallet/dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,3 +64,12 @@ jobs:
               with:
                   name: concordium-browser-wallet
                   path: ./packages/browser-wallet/dist
+
+            - name: Make development build
+              run: cd ./packages/browser-wallet && yarn build:dev
+
+            - name: Upload development release
+              uses: actions/upload-artifact@master
+              with:
+                  name: concordium-browser-wallet-dev
+                  path: ./packages/browser-wallet/dist


### PR DESCRIPTION
## Purpose
Build the prod build and the development build in a GitHub action. The files are just uploaded to GitHub for now but will ensure consist builds, and we can stop building releases locally. An additional step would be to publish the release to the Chrome extension store.

## Changes
- GitHub action that builds and uploads the browser wallet for production and development.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.