### PR TITLE
Fix token transfer energy cost estimate

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.4.2
 
 ### Fixed
 

--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+-   The token transfer estimate now takes the transfer amount into account.
 -   No longer blocks creating the last possible account for an identity.
 
 ## 1.4.1

--- a/packages/browser-wallet/package.json
+++ b/packages/browser-wallet/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@concordium/browser-wallet",
     "private": true,
-    "version": "1.4.1",
+    "version": "1.4.2",
     "description": "Browser extension wallet for the Concordium blockchain",
     "author": "Concordium Software",
     "license": "Apache-2.0",

--- a/packages/browser-wallet/src/shared/utils/energy-helpers.ts
+++ b/packages/browser-wallet/src/shared/utils/energy-helpers.ts
@@ -16,7 +16,7 @@ const CONFIGURE_BAKER_WITH_KEYS_BASE_COST = 4050n;
 
 // TODO: replace this with helpers from SDK
 export function determineUpdatePayloadSize(parameterSize: number, receiveName: string) {
-    return 8n + 8n + 8n + 2n + BigInt(parameterSize) + 2n + BigInt(receiveName.length);
+    return 8n + 8n + 8n + 2n + BigInt(parameterSize) + 2n + BigInt(receiveName.length) + 1n;
 }
 
 // TODO: Replace this with helpers from SDK

--- a/packages/browser-wallet/src/shared/utils/token-helpers.ts
+++ b/packages/browser-wallet/src/shared/utils/token-helpers.ts
@@ -303,9 +303,10 @@ export async function getTokenTransferEnergy(
     address: string,
     recipient: string,
     tokenId: string,
+    amount: bigint,
     contractIndex: bigint
 ) {
-    const parameters = getTokenTransferParameters(address, recipient, tokenId, 1n);
+    const parameters = getTokenTransferParameters(address, recipient, tokenId, amount);
     const serializedParameters = serializeTokenTransferParameters(parameters);
     const contractName = (await fetchContractName(client, contractIndex)) || '';
     const execution = await getTokenTransferExecutionEnergyEstimate(


### PR DESCRIPTION
## Purpose

Fix the token transfer estimate not aligning with other wallets / wallet proxy.

## Changes

- Use the transfer amount for token transfers, when calculating cost.
- Fix update payload size to contain the 1 byte that represent transaction type.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
