### PR TITLE
Fullscreen view

### DIFF
--- a/packages/browser-wallet-message-hub/src/message.ts
+++ b/packages/browser-wallet-message-hub/src/message.ts
@@ -48,6 +48,7 @@ export enum InternalMessageType {
     LoadWeb3IdBackup = 'I_LoadWeb3IdBackup',
     ImportWeb3IdBackup = 'I_ImportWeb3IdBackup',
     AbortRecovery = 'I_AbortRecovery',
+    OpenFullscreen = 'I_OpenFullscreen',
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# Unreleased
+
+### Added
+
+-   A button in settings that opens the wallet in fullscreen mode in a tab.
+
 ## 1.4.2
 
 ### Fixed

--- a/packages/browser-wallet/src/background/index.ts
+++ b/packages/browser-wallet/src/background/index.ts
@@ -277,6 +277,10 @@ bgMessageHandler.handleMessage(
     createWeb3IdProofHandler
 );
 
+bgMessageHandler.handleMessage(createMessageTypeFilter(InternalMessageType.OpenFullscreen), () => {
+    chrome.tabs.create({ url: chrome.runtime.getURL('popup.html#fullscreen') });
+});
+
 const NOT_WHITELISTED = 'Site is not whitelisted';
 
 /**

--- a/packages/browser-wallet/src/background/web3Id.ts
+++ b/packages/browser-wallet/src/background/web3Id.ts
@@ -336,14 +336,17 @@ async function waitForClosedPopup(waitIterations: number): Promise<void> {
     });
 }
 
-async function loadWeb3IdBackup(): Promise<void> {
-    await waitForClosedPopup(WAIT_FOR_CLOSED_POPUP_ITERATIONS);
+async function loadWeb3IdBackup(calledFromFullscreenWindow: boolean): Promise<void> {
+    if (!calledFromFullscreenWindow) {
+        await waitForClosedPopup(WAIT_FOR_CLOSED_POPUP_ITERATIONS);
+    }
     await openWindow();
     bgMessageHandler.sendInternalMessage(InternalMessageType.ImportWeb3IdBackup);
 }
 
 export const loadWeb3IdBackupHandler: ExtensionMessageHandler = (_msg, _sender, respond) => {
-    loadWeb3IdBackup();
+    const calledFromFullscreenWindow = _msg.payload as boolean;
+    loadWeb3IdBackup(calledFromFullscreenWindow);
     respond(undefined);
 };
 

--- a/packages/browser-wallet/src/popup/page-layouts/MainLayout/MainLayout.scss
+++ b/packages/browser-wallet/src/popup/page-layouts/MainLayout/MainLayout.scss
@@ -4,6 +4,7 @@ $main-layout-header-height: rem(40px);
     height: 100%;
     position: relative;
     z-index: 0;
+    overflow: hidden;
 
     &__main {
         overflow: overlay;

--- a/packages/browser-wallet/src/popup/pages/Account/Account.tsx
+++ b/packages/browser-wallet/src/popup/pages/Account/Account.tsx
@@ -10,6 +10,7 @@ import { useCurrentOpenTabUrl } from '@popup/shared/utils/tabs';
 import Button from '@popup/shared/Button';
 import { absoluteRoutes } from '@popup/constants/routes';
 import { allowlistRoutes } from '@popup/pages/Allowlist/routes';
+import { isFullscreenWindow } from '@popup/shared/window-helpers';
 import { accountRoutes } from './routes';
 import AccountActions from './AccountActions';
 import DisplayAddress from './DisplayAddress';
@@ -58,14 +59,16 @@ function Account() {
                                 onClick={() => setDetailsExpanded((o) => !o)}
                             />
                             <AccountDetails expanded={detailsExpanded} account={selectedCred} />
-                            <ConnectedBox
-                                url={currentUrl}
-                                accountAddress={selectedCred.address}
-                                link={generatePath(
-                                    `${absoluteRoutes.home.settings.allowlist.path}/${allowlistRoutes.edit}`,
-                                    { serviceName: currentUrl ? encodeURIComponent(currentUrl) : '' }
-                                )}
-                            />
+                            {!isFullscreenWindow && (
+                                <ConnectedBox
+                                    url={currentUrl}
+                                    accountAddress={selectedCred.address}
+                                    link={generatePath(
+                                        `${absoluteRoutes.home.settings.allowlist.path}/${allowlistRoutes.edit}`,
+                                        { serviceName: currentUrl ? encodeURIComponent(currentUrl) : '' }
+                                    )}
+                                />
+                            )}
                         </div>
                         <div className="account-page__routes">
                             {isConfirmed && <Outlet />}

--- a/packages/browser-wallet/src/popup/pages/IdentityIssuance/IdentityIssuanceEnd.tsx
+++ b/packages/browser-wallet/src/popup/pages/IdentityIssuance/IdentityIssuanceEnd.tsx
@@ -17,6 +17,7 @@ import { IdentityIssuanceBackgroundResponse } from '@shared/utils/identity-helpe
 import IdentityProviderIcon from '@popup/shared/IdentityProviderIcon';
 import { BackgroundResponseStatus } from '@shared/utils/types';
 import { CreationStatus } from '@shared/storage/types';
+import { absoluteRoutes } from '@popup/constants/routes';
 
 interface Location {
     state: {
@@ -30,7 +31,7 @@ export default function IdentityIssuanceEnd() {
     const { state } = useLocation() as Location;
     const { t } = useTranslation('identityIssuance');
     const providers = useAtomValue(identityProvidersAtom);
-    const { withClose } = useContext(fullscreenPromptContext);
+    const { withClose, setReturnLocation } = useContext(fullscreenPromptContext);
     const selectedIdentity = useAtomValue(selectedIdentityAtom);
     const identities = useAtomValue(identitiesAtom);
     const setSelectedIdentityIndex = useSetAtom(selectedIdentityIndexAtom);
@@ -45,6 +46,10 @@ export default function IdentityIssuanceEnd() {
             setSelectedIdentityIndex(identities.length - 1);
         }
     }, [identities.length]);
+
+    useEffect(() => {
+        setReturnLocation(absoluteRoutes.home.identities.path);
+    }, [setReturnLocation]);
 
     return (
         <>

--- a/packages/browser-wallet/src/popup/pages/Settings/Settings.scss
+++ b/packages/browser-wallet/src/popup/pages/Settings/Settings.scss
@@ -6,6 +6,11 @@
     &__link {
         display: block;
         padding: rem(10px) 0;
+
+        &--button {
+            width: 100%;
+            text-align: left;
+        }
     }
 
     &__toggle {

--- a/packages/browser-wallet/src/popup/pages/Settings/Settings.tsx
+++ b/packages/browser-wallet/src/popup/pages/Settings/Settings.tsx
@@ -59,7 +59,7 @@ export default function Settings() {
                             popupMessageHandler.sendInternalMessage(InternalMessageType.OpenFullscreen);
                         }}
                     >
-                        Open fullscreen wallet
+                        {t('fullscreenWallet')}
                     </Button>
                 )}
                 <Link className="settings-page__link" to={absoluteRoutes.home.settings.about.path}>

--- a/packages/browser-wallet/src/popup/pages/Settings/Settings.tsx
+++ b/packages/browser-wallet/src/popup/pages/Settings/Settings.tsx
@@ -9,6 +9,10 @@ import { Theme } from '@shared/storage/types';
 import SunIcon from '@assets/svg/sun.svg';
 import MoonIcon from '@assets/svg/moon.svg';
 import { ToggleCheckbox } from '@popup/shared/Form/ToggleCheckbox';
+import { popupMessageHandler } from '@popup/shared/message-handler';
+import { InternalMessageType } from '@concordium/browser-wallet-message-hub';
+import Button from '@popup/shared/Button';
+import { isFullscreenWindow } from '@popup/shared/window-helpers';
 
 function LightDarkModeToggle() {
     const { t } = useTranslation('settings');
@@ -47,6 +51,17 @@ export default function Settings() {
                 <Link className="settings-page__link" to={absoluteRoutes.home.settings.seedPhrase.path}>
                     {t('seedPhrase')}
                 </Link>
+                {!isFullscreenWindow && (
+                    <Button
+                        clear
+                        className="settings-page__link settings-page__link--button"
+                        onClick={() => {
+                            popupMessageHandler.sendInternalMessage(InternalMessageType.OpenFullscreen);
+                        }}
+                    >
+                        Open fullscreen wallet
+                    </Button>
+                )}
                 <Link className="settings-page__link" to={absoluteRoutes.home.settings.about.path}>
                     {t('about')}
                 </Link>

--- a/packages/browser-wallet/src/popup/pages/Settings/i18n/da.ts
+++ b/packages/browser-wallet/src/popup/pages/Settings/i18n/da.ts
@@ -7,6 +7,7 @@ const t: typeof en = {
     recover: 'Genskab ID & konti',
     about: 'Om',
     seedPhrase: 'Vis hemmeligt recovery phrase',
+    fullscreenWallet: 'Åbn i fuldskærm',
     toggle: {
         dark: 'Skift til mørkt udseende',
         light: 'Skift til lyst udseende',

--- a/packages/browser-wallet/src/popup/pages/Settings/i18n/en.ts
+++ b/packages/browser-wallet/src/popup/pages/Settings/i18n/en.ts
@@ -5,6 +5,7 @@ const t = {
     recover: 'Restore IDs & accounts',
     about: 'About',
     seedPhrase: 'View secret recovery phrase',
+    fullscreenWallet: 'Open in fullscreen',
     toggle: {
         dark: 'Switch to dark mode',
         light: 'Switch to light mode',

--- a/packages/browser-wallet/src/popup/pages/VerifiableCredential/VerifiableCredentialList.tsx
+++ b/packages/browser-wallet/src/popup/pages/VerifiableCredential/VerifiableCredentialList.tsx
@@ -16,6 +16,7 @@ import {
 } from '@shared/utils/verifiable-credential-helpers';
 import { popupMessageHandler } from '@popup/shared/message-handler';
 import { InternalMessageType } from '@concordium/browser-wallet-message-hub';
+import { isFullscreenWindow } from '@popup/shared/window-helpers';
 import {
     useCredentialLocalization,
     useCredentialMetadata,
@@ -28,8 +29,10 @@ import VerifiableCredentialDetails from './VerifiableCredentialDetails';
 import { useVerifiableCredentialExport } from '../VerifiableCredentialBackup/utils';
 
 async function goToImportPage() {
-    await popupMessageHandler.sendInternalMessage(InternalMessageType.LoadWeb3IdBackup);
-    window.close();
+    await popupMessageHandler.sendInternalMessage(InternalMessageType.LoadWeb3IdBackup, isFullscreenWindow);
+    if (!isFullscreenWindow) {
+        window.close();
+    }
 }
 
 /**

--- a/packages/browser-wallet/src/popup/shared/window-helpers.ts
+++ b/packages/browser-wallet/src/popup/shared/window-helpers.ts
@@ -2,3 +2,4 @@ import { spawnedPopupUrl, web3IdProofPopupUrl } from '@shared/constants/url';
 
 export const isSpawnedWindow = window.location.href.includes(spawnedPopupUrl);
 export const isSpawnedWeb3IdProofWindow = window.location.href.includes(web3IdProofPopupUrl);
+export const isFullscreenWindow = window.location.hash === '#fullscreen';

--- a/packages/browser-wallet/src/popup/shell/Root.tsx
+++ b/packages/browser-wallet/src/popup/shell/Root.tsx
@@ -6,7 +6,7 @@ import { noOp } from 'wallet-common-helpers';
 
 import { Dimensions, large, medium, small } from '@popup/constants/dimensions';
 import { popupMessageHandler } from '@popup/shared/message-handler';
-import { isSpawnedWeb3IdProofWindow, isSpawnedWindow } from '@popup/shared/window-helpers';
+import { isFullscreenWindow, isSpawnedWeb3IdProofWindow, isSpawnedWindow } from '@popup/shared/window-helpers';
 import { networkConfigurationAtom, themeAtom } from '@popup/store/settings';
 import { Theme as ThemeType } from '@shared/storage/types';
 import { absoluteRoutes } from '@popup/constants/routes';
@@ -36,12 +36,16 @@ function useScaling() {
         }
 
         // When opened by clicking on the extension icon
-        if (!isSpawnedWindow && html) {
+        if (!isSpawnedWindow && body) {
             const { width, height } = dimensions ?? small;
 
             // Mimic what's done on a spawned popup window in the bg script.
-            html.style.width = `${width}px`;
-            html.style.height = `${height}px`;
+            body.style.width = `${width}px`;
+            body.style.height = `${height}px`;
+
+            if (isFullscreenWindow) {
+                body.style.margin = '32px auto';
+            }
         }
 
         if (dimensions && isSpawnedWindow) {


### PR DESCRIPTION
## Purpose
Add a button that opens the browser wallet in fullscreen mode (in a tab).

## Changes
- Added button in settings that will open the wallet in a tab instead of the extension popup window.
- Adjusted the UI of the wallet to work better in the fullscreen mode (centered, some margins, hide some overflows of menus, hide the connected box, go to identities page on issuance end, fix issue with web3id import popup window).

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.