### PR TITLE
Fix bug in check for EU country set

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   A button in settings that opens the wallet in fullscreen mode in a tab.
 
+### Fixed
+
+-   An issue where some proof requests for nationality or country of residence would be misintrepreted as asking whether in the EU or not.
+
 ## 1.4.2
 
 ### Fixed

--- a/packages/browser-wallet/src/popup/pages/IdProofRequest/DisplayStatement/utils.ts
+++ b/packages/browser-wallet/src/popup/pages/IdProofRequest/DisplayStatement/utils.ts
@@ -22,8 +22,8 @@ export type SecretStatement = Exclude<AtomicStatement, RevealStatement>;
 export const getYearFromDateString = (ds: string): number => Number(ds.substring(0, 4));
 const formatDateString = (ds: string): string => `${ds.substring(0, 4)}-${ds.substring(4, 6)}-${ds.substring(6)}`;
 
-const isEuCountrySet = (countries: string[]) =>
-    countries.length === EU_MEMBERS.length && countries.every((n) => EU_MEMBERS.includes(n));
+export const isEuCountrySet = (countries: string[]) =>
+    countries.length === EU_MEMBERS.length && EU_MEMBERS.every((euCountry) => countries.includes(euCountry));
 
 const getTextForSet =
     <T extends (...args: any) => any>(t: T, statement: MembershipStatement | NonMembershipStatement) =>

--- a/packages/browser-wallet/test/id-proof-util.test.ts
+++ b/packages/browser-wallet/test/id-proof-util.test.ts
@@ -1,0 +1,16 @@
+import { EU_MEMBERS } from '@concordium/web-sdk';
+import { isEuCountrySet } from '../src/popup/pages/IdProofRequest/DisplayStatement/utils';
+
+test('not eu country set if only one country in set', () => {
+    const countries = 'DK,DK,DK,DK,DK,DK,DK,DK,DK,DK,DK,DK,DK,DK,DK,DK,DK,DK,DK,DK,DK,DK,DK,DK,DK,DK,DK'.split(',');
+
+    const isEu = isEuCountrySet(countries);
+
+    expect(isEu).toBeFalsy();
+});
+
+test('eu country set returns true when checking if eu country set', () => {
+    const isEu = isEuCountrySet(EU_MEMBERS);
+
+    expect(isEu).toBeTruthy();
+});


### PR DESCRIPTION
## Purpose
Fix a bug in the check for EU country set.

## Changes
- Invert the check to actually check if the set of countries is exactly the EU members.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.