### PR TITLE
Fix issue with multiple injected scripts

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+-   Inject script being loaded on every tab update event, instead now only when loading is completed.
+
 ## 1.5.0
 
 ### Added


### PR DESCRIPTION
## Purpose

Closes #457 

This PR is a quick fix ensuring that the script is only injected when the tab is done loading, instead of the current solution which results in on every change to any of the tab information.

See documentation for [`tabs.onUpdated`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onUpdated).

## Changes

- Remove the listener for messages from the content script to inject the script.
- Change the `tabs.onUpdated` listener to only inject when tab is done loading page.