### PR TITLE
[BRO-13] Payload decoding in the browser wallet of the CIS3 standard

### DIFF
--- a/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
+++ b/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
@@ -258,7 +258,7 @@ interface MainWalletApi {
      * @param contractAddress the {@link ContractAddress} of the contract
      * @param contractName the {@link ContractName} of the contract
      * @param entrypointName the {@link EntrypointName} of the contract
-     * @param nonce the revocation nonce
+     * @param nonce the nonce (CIS3 standard) that was part of the message that was signed
      * @param expiryTimeSignature RFC 3339 format (e.g. 2030-08-08T05:15:00Z)
      * @param accountAddress the address of the account that should sign the message
      * @param payloadMessage payload message to be signed, complete CIS3 message will be created from provided parameters. Note that the wallet will prepend some bytes to ensure the message cannot be a transaction. The message should be { @link SignMessageObject }.
@@ -269,7 +269,7 @@ interface MainWalletApi {
         contractAddress: ContractAddress.Type,
         contractName: ContractName.Type,
         entrypointName: EntrypointName.Type,
-        nonce: bigint,
+        nonce: bigint | number,
         expiryTimeSignature: string,
         accountAddress: AccountAddressSource,
         payloadMessage: SignMessageObject

--- a/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
+++ b/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
@@ -254,12 +254,14 @@ interface MainWalletApi {
 
     /**
      * Sends a message of the CIS3 contract standard, to the Concordium Wallet and awaits the users action. If the user signs the message, this will resolve to the signature.
-     * Note that if the user rejects signing the message, this will throw an error.
+     * 
      * @param contractAddress the {@link ContractAddress} of the contract
      * @param contractName the {@link ContractName} of the contract
      * @param entrypointName the {@link EntrypointName} of the contract
      * @param accountAddress the address of the account that should sign the message
      * @param message message to be signed. Note that the wallet will prepend some bytes to ensure the message cannot be a transaction. The message should be { @link SignMessageObject }.
+     *
+     * @throws if the user rejects signing the message.
      */
     signCIS3Message(
         contractAddress: ContractAddress.Type,

--- a/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
+++ b/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
@@ -266,7 +266,7 @@ interface MainWalletApi {
         contractName: ContractName.Type,
         entrypointName: EntrypointName.Type,
         accountAddress: AccountAddressSource,
-        message: string | SignMessageObject
+        message: SignMessageObject
     ): Promise<AccountTransactionSignature>;
 
     /**

--- a/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
+++ b/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
@@ -259,7 +259,7 @@ interface MainWalletApi {
      * @param contractName the {@link ContractName} of the contract
      * @param entrypointName the {@link EntrypointName} of the contract
      * @param accountAddress the address of the account that should sign the message
-     * @param message message to be signed. Note that the wallet will prepend some bytes to ensure the message cannot be a transaction. The message should either be a utf8 string or { @link SignMessageObject }.
+     * @param message message to be signed. Note that the wallet will prepend some bytes to ensure the message cannot be a transaction. The message should be { @link SignMessageObject }.
      */
     signCIS3Message(
         contractAddress: ContractAddress.Type,

--- a/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
+++ b/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
@@ -22,6 +22,8 @@ import type {
     DeployModulePayload,
     ConfigureBakerPayload,
     ConfigureDelegationPayload,
+    ContractName,
+    EntrypointName,
 } from '@concordium/web-sdk';
 import type { RpcTransport } from '@protobuf-ts/runtime-rpc';
 import { LaxNumberEnumValue, LaxStringEnumValue } from './util';
@@ -246,6 +248,23 @@ interface MainWalletApi {
      * @param message message to be signed. Note that the wallet will prepend some bytes to ensure the message cannot be a transaction. The message should either be a utf8 string or { @link SignMessageObject }.
      */
     signMessage(
+        accountAddress: AccountAddressSource,
+        message: string | SignMessageObject
+    ): Promise<AccountTransactionSignature>;
+
+    /**
+     * Sends a message of the CIS3 contract standard, to the Concordium Wallet and awaits the users action. If the user signs the message, this will resolve to the signature.
+     * Note that if the user rejects signing the message, this will throw an error.
+     * @param contractAddress the {@link ContractAddress} of the contract
+     * @param contractName the {@link ContractName} of the contract
+     * @param entrypointName the {@link EntrypointName} of the contract
+     * @param accountAddress the address of the account that should sign the message
+     * @param message message to be signed. Note that the wallet will prepend some bytes to ensure the message cannot be a transaction. The message should either be a utf8 string or { @link SignMessageObject }.
+     */
+    signCIS3Message(
+        contractAddress: ContractAddress.Type,
+        contractName: ContractName.Type,
+        entrypointName: EntrypointName.Type,
         accountAddress: AccountAddressSource,
         message: string | SignMessageObject
     ): Promise<AccountTransactionSignature>;

--- a/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
+++ b/packages/browser-wallet-api-helpers/src/wallet-api-types.ts
@@ -254,12 +254,14 @@ interface MainWalletApi {
 
     /**
      * Sends a message of the CIS3 contract standard, to the Concordium Wallet and awaits the users action. If the user signs the message, this will resolve to the signature.
-     * 
+     *
      * @param contractAddress the {@link ContractAddress} of the contract
      * @param contractName the {@link ContractName} of the contract
      * @param entrypointName the {@link EntrypointName} of the contract
+     * @param nonce the revocation nonce
+     * @param expiryTimeSignature RFC 3339 format (e.g. 2030-08-08T05:15:00Z)
      * @param accountAddress the address of the account that should sign the message
-     * @param message message to be signed. Note that the wallet will prepend some bytes to ensure the message cannot be a transaction. The message should be { @link SignMessageObject }.
+     * @param payloadMessage payload message to be signed, complete CIS3 message will be created from provided parameters. Note that the wallet will prepend some bytes to ensure the message cannot be a transaction. The message should be { @link SignMessageObject }.
      *
      * @throws if the user rejects signing the message.
      */
@@ -267,8 +269,10 @@ interface MainWalletApi {
         contractAddress: ContractAddress.Type,
         contractName: ContractName.Type,
         entrypointName: EntrypointName.Type,
+        nonce: bigint,
+        expiryTimeSignature: string,
         accountAddress: AccountAddressSource,
-        message: SignMessageObject
+        payloadMessage: SignMessageObject
     ): Promise<AccountTransactionSignature>;
 
     /**

--- a/packages/browser-wallet-api/src/wallet-api.ts
+++ b/packages/browser-wallet-api/src/wallet-api.ts
@@ -85,10 +85,12 @@ class WalletApi extends EventEmitter implements IWalletApi {
         contractAddress: ContractAddress.Type,
         contractName: ContractName.Type,
         entrypointName: EntrypointName.Type,
+        nonce: bigint,
+        expiryTimeSignature: string,
         accountAddress: AccountAddressSource,
-        message: SignMessageObject
+        payloadMessage: SignMessageObject
     ): Promise<AccountTransactionSignature> {
-        const input = sanitizeSignMessageInput(accountAddress, message);
+        const input = sanitizeSignMessageInput(accountAddress, payloadMessage);
         const response = await this.messageHandler.sendMessage<MessageStatusWrapper<AccountTransactionSignature>>(
             MessageType.SignCIS3Message,
             {
@@ -98,6 +100,8 @@ class WalletApi extends EventEmitter implements IWalletApi {
                     contractAddress,
                     contractName,
                     entrypointName,
+                    nonce,
+                    expiryTimeSignature,
                 },
             }
         );

--- a/packages/browser-wallet-api/src/wallet-api.ts
+++ b/packages/browser-wallet-api/src/wallet-api.ts
@@ -85,7 +85,7 @@ class WalletApi extends EventEmitter implements IWalletApi {
         contractAddress: ContractAddress.Type,
         contractName: ContractName.Type,
         entrypointName: EntrypointName.Type,
-        nonce: bigint,
+        nonce: bigint | number,
         expiryTimeSignature: string,
         accountAddress: AccountAddressSource,
         payloadMessage: SignMessageObject

--- a/packages/browser-wallet-api/src/wallet-api.ts
+++ b/packages/browser-wallet-api/src/wallet-api.ts
@@ -12,6 +12,8 @@ import {
     SchemaVersion,
     ContractAddress,
     VerifiablePresentation,
+    ContractName,
+    EntrypointName,
 } from '@concordium/web-sdk/types';
 import { CredentialStatements } from '@concordium/web-sdk/web3-id';
 import {
@@ -69,6 +71,34 @@ class WalletApi extends EventEmitter implements IWalletApi {
             {
                 ...input,
                 accountAddress: AccountAddress.toBase58(input.accountAddress),
+            }
+        );
+
+        if (!response.success) {
+            throw new Error(response.message);
+        }
+
+        return response.result;
+    }
+
+    public async signCIS3Message(
+        contractAddress: ContractAddress.Type,
+        contractName: ContractName.Type,
+        entrypointName: EntrypointName.Type,
+        accountAddress: AccountAddressSource,
+        message: string | SignMessageObject
+    ): Promise<AccountTransactionSignature> {
+        const input = sanitizeSignMessageInput(accountAddress, message);
+        const response = await this.messageHandler.sendMessage<MessageStatusWrapper<AccountTransactionSignature>>(
+            MessageType.SignMessage,
+            {
+                message: input.message,
+                accountAddress: AccountAddress.toBase58(input.accountAddress),
+                cis3ContractDetails: {
+                    contractAddress,
+                    contractName,
+                    entrypointName,
+                },
             }
         );
 

--- a/packages/browser-wallet-api/src/wallet-api.ts
+++ b/packages/browser-wallet-api/src/wallet-api.ts
@@ -86,11 +86,11 @@ class WalletApi extends EventEmitter implements IWalletApi {
         contractName: ContractName.Type,
         entrypointName: EntrypointName.Type,
         accountAddress: AccountAddressSource,
-        message: string | SignMessageObject
+        message: SignMessageObject
     ): Promise<AccountTransactionSignature> {
         const input = sanitizeSignMessageInput(accountAddress, message);
         const response = await this.messageHandler.sendMessage<MessageStatusWrapper<AccountTransactionSignature>>(
-            MessageType.SignMessage,
+            MessageType.SignCIS3Message,
             {
                 message: input.message,
                 accountAddress: AccountAddress.toBase58(input.accountAddress),

--- a/packages/browser-wallet-message-hub/src/message.ts
+++ b/packages/browser-wallet-message-hub/src/message.ts
@@ -19,6 +19,7 @@ export enum MessageType {
     ConnectAccounts = 'M_ConnectAccounts',
     AddWeb3IdCredential = 'M_AddWeb3IdCredential',
     AddWeb3IdCredentialFinish = 'M_AddWeb3IdCredentialFinish',
+    SignCIS3Message = 'M_SignCIS3Message',
 }
 
 /**
@@ -49,6 +50,7 @@ export enum InternalMessageType {
     ImportWeb3IdBackup = 'I_ImportWeb3IdBackup',
     AbortRecovery = 'I_AbortRecovery',
     OpenFullscreen = 'I_OpenFullscreen',
+    SignCIS3Message = 'I_SignCIS3Message',
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/browser-wallet/src/background/index.ts
+++ b/packages/browser-wallet/src/background/index.ts
@@ -588,6 +588,14 @@ forwardToPopup(
     withPromptEnd
 );
 forwardToPopup(
+    MessageType.SignCIS3Message,
+    InternalMessageType.SignCIS3Message,
+    runConditionComposer(runIfAccountIsAllowlisted, ensureMessageWithSchemaParse, withPromptStart()),
+    appendUrlToPayload,
+    undefined,
+    withPromptEnd
+);
+forwardToPopup(
     MessageType.AddTokens,
     InternalMessageType.AddTokens,
     runConditionComposer(runIfAccountIsAllowlisted, withPromptStart()),

--- a/packages/browser-wallet/src/popup/constants/routes.ts
+++ b/packages/browser-wallet/src/popup/constants/routes.ts
@@ -57,6 +57,9 @@ export const relativeRoutes = {
         signMessage: {
             path: 'sign-message',
         },
+        signCIS3Message: {
+            path: 'sign-cis3-message',
+        },
         sendTransaction: {
             path: 'send-transaction',
         },

--- a/packages/browser-wallet/src/popup/pages/SignCIS3Message/SignCIS3Message.scss
+++ b/packages/browser-wallet/src/popup/pages/SignCIS3Message/SignCIS3Message.scss
@@ -1,0 +1,26 @@
+$message-details-horizontal-padding: rem(20px);
+
+.sign-cis3-message {
+    &__details {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        background-color: $color-bg;
+        height: 100%;
+        border: rem(1px) solid $color-grey;
+        border-radius: rem(10px);
+        padding: rem(10px) $message-details-horizontal-padding;
+
+        :where(&) h5 {
+            margin-top: rem(10px);
+            margin-bottom: 0;
+        }
+    }
+
+    &__details-text-area textarea {
+        border-top-left-radius: 0;
+        border-top-right-radius: 0;
+        font-family: $font-family-mono;
+        padding: rem(10px);
+    }
+}

--- a/packages/browser-wallet/src/popup/pages/SignCIS3Message/SignCIS3Message.scss
+++ b/packages/browser-wallet/src/popup/pages/SignCIS3Message/SignCIS3Message.scss
@@ -18,6 +18,7 @@ $message-details-horizontal-padding: rem(20px);
     }
 
     &__details-text-area textarea {
+        min-height: 10rem;
         border-top-left-radius: 0;
         border-top-right-radius: 0;
         font-family: $font-family-mono;

--- a/packages/browser-wallet/src/popup/pages/SignCIS3Message/SignCIS3Message.tsx
+++ b/packages/browser-wallet/src/popup/pages/SignCIS3Message/SignCIS3Message.tsx
@@ -91,8 +91,8 @@ function MessageDetailsDisplay({
 
     useEffect(() => {
         parseMessage(payloadMessage)
-          .then((m) => setParsedMessage(m))
-          .catch((_) => setParsedMessage(t('unableToDeserialize')));
+            .then((m) => setParsedMessage(m))
+            .catch(() => setParsedMessage(t('unableToDeserialize')));
     }, []);
 
     return (

--- a/packages/browser-wallet/src/popup/pages/SignCIS3Message/SignCIS3Message.tsx
+++ b/packages/browser-wallet/src/popup/pages/SignCIS3Message/SignCIS3Message.tsx
@@ -49,7 +49,7 @@ type Cis3ContractDetailsObject = {
     contractAddress: ContractAddress.Type;
     contractName: ContractName.Type;
     entrypointName: EntrypointName.Type;
-    nonce: bigint;
+    nonce: bigint | number;
     expiryTimeSignature: string;
 };
 

--- a/packages/browser-wallet/src/popup/pages/SignCIS3Message/SignCIS3Message.tsx
+++ b/packages/browser-wallet/src/popup/pages/SignCIS3Message/SignCIS3Message.tsx
@@ -1,0 +1,176 @@
+import React, { useCallback, useContext, useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import clsx from 'clsx';
+import { stringify } from 'json-bigint';
+import { useTranslation } from 'react-i18next';
+import { useAtomValue, useSetAtom } from 'jotai';
+import { Buffer } from 'buffer/';
+import {
+    AccountAddress,
+    AccountTransactionSignature,
+    buildBasicAccountSigner,
+    ConcordiumGRPCClient,
+    ContractAddress,
+    ContractName,
+    deserializeTypeValue,
+    EntrypointName,
+    getUpdateContractParameterSchema,
+    ModuleReference,
+    signMessage,
+} from '@concordium/web-sdk';
+import { fullscreenPromptContext } from '@popup/page-layouts/FullscreenPromptLayout';
+import { usePrivateKey } from '@popup/shared/utils/account-helpers';
+import { displayUrl } from '@popup/shared/utils/string-helpers';
+import { TextArea } from '@popup/shared/Form/TextArea';
+import ConnectedBox from '@popup/pages/Account/ConnectedBox';
+import Button from '@popup/shared/Button';
+import { addToastAtom } from '@popup/state';
+import ExternalRequestLayout from '@popup/page-layouts/ExternalRequestLayout';
+import { grpcClientAtom } from '@popup/store/settings';
+import { SignMessageObject } from '@concordium/browser-wallet-api-helpers';
+
+type Props = {
+    onSubmit(signature: AccountTransactionSignature): void;
+    onReject(): void;
+};
+
+interface Location {
+    state: {
+        payload: {
+            accountAddress: string;
+            message: SignMessageObject;
+            url: string;
+            cis3ContractDetails: Cis3ContractDetailsObject;
+        };
+    };
+}
+
+type Cis3ContractDetailsObject = {
+    contractAddress: ContractAddress.Type;
+    contractName: ContractName.Type;
+    entrypointName: EntrypointName.Type;
+};
+
+type DeserializedMessageObject = {
+    payload: bigint[] | [];
+};
+
+async function parseMessage(
+    message: SignMessageObject,
+    client: ConcordiumGRPCClient,
+    cis3ContractDetails: Cis3ContractDetailsObject
+) {
+    const deserializedMessage = deserializeTypeValue(
+        Buffer.from(message.data, 'hex'),
+        Buffer.from(message.schema, 'base64')
+    ) as DeserializedMessageObject;
+
+    const { contractAddress, contractName, entrypointName } = cis3ContractDetails;
+    const instanceInfo = await client.getInstanceInfo(contractAddress);
+
+    const schema = await client.getEmbeddedSchema(ModuleReference.fromHexString(instanceInfo.sourceModule.moduleRef));
+
+    const updateContractParameterSchema = getUpdateContractParameterSchema(
+        schema,
+        contractName,
+        entrypointName,
+        instanceInfo.version
+    );
+
+    return stringify(
+        deserializeTypeValue(
+            BigInt64Array.from(deserializedMessage.payload).buffer,
+            updateContractParameterSchema.buffer
+        ),
+        undefined,
+        2
+    );
+}
+
+function MessageDetailsDisplay({
+    message,
+    cis3ContractDetails,
+}: {
+    message: SignMessageObject;
+    cis3ContractDetails: Cis3ContractDetailsObject;
+}) {
+    const { t } = useTranslation('signCIS3Message');
+    const client = useAtomValue(grpcClientAtom);
+    const { contractAddress, contractName, entrypointName } = cis3ContractDetails;
+    const [parsedMessage, setParsedMessage] = useState<string>('');
+
+    useEffect(() => {
+        try {
+            parseMessage(message, client, cis3ContractDetails).then((m) => setParsedMessage(m));
+        } catch (e) {
+            setParsedMessage(t('unableToDeserialize'));
+        }
+    }, []);
+
+    return (
+        <div className="m-10 sign-cis3-message__details">
+            <h5>{t('contractIndex')}:</h5>
+            <div>
+                {contractAddress.index.toString()} ({contractAddress.subindex.toString()})
+            </div>
+            <h5>{t('receiveName')}:</h5>
+            <div>
+                {contractName.value.toString()}.{entrypointName.value.toString()}
+            </div>
+            <h5>{t('parameter')}:</h5>
+            <TextArea
+                readOnly
+                className={clsx('m-b-10 w-full flex-child-fill sign-cis3-message__details-text-area')}
+                value={parsedMessage}
+            />
+        </div>
+    );
+}
+
+export default function SignCIS3Message({ onSubmit, onReject }: Props) {
+    const { state } = useLocation() as Location;
+    const { t } = useTranslation('signCIS3Message');
+    const { withClose } = useContext(fullscreenPromptContext);
+    const { accountAddress, url, message, cis3ContractDetails } = state.payload;
+    const key = usePrivateKey(accountAddress);
+    const addToast = useSetAtom(addToastAtom);
+
+    const onClick = useCallback(async () => {
+        if (!key) {
+            throw new Error('Missing key for the chosen address');
+        }
+
+        return signMessage(
+            AccountAddress.fromBase58(accountAddress),
+            Buffer.from(message.data, 'hex'),
+            buildBasicAccountSigner(key)
+        );
+    }, [state.payload.message, state.payload.accountAddress, key]);
+
+    return (
+        <ExternalRequestLayout className="p-10">
+            <ConnectedBox accountAddress={accountAddress} url={new URL(url).origin} />
+            <div className="h-full flex-column align-center">
+                <h3 className="m-t-0 text-center">{t('description', { dApp: displayUrl(url) })}</h3>
+                <p className="m-t-0 text-center">{t('descriptionWithSchema', { dApp: displayUrl(url) })}</p>
+                <MessageDetailsDisplay message={message} cis3ContractDetails={cis3ContractDetails} />
+                <br />
+                <div className="flex p-b-10 p-t-10  m-t-auto">
+                    <Button width="narrow" className="m-r-10" onClick={withClose(onReject)}>
+                        {t('reject')}
+                    </Button>
+                    <Button
+                        width="narrow"
+                        onClick={() =>
+                            onClick()
+                                .then(withClose(onSubmit))
+                                .catch((e) => addToast(e.message))
+                        }
+                    >
+                        {t('sign')}
+                    </Button>
+                </div>
+            </div>
+        </ExternalRequestLayout>
+    );
+}

--- a/packages/browser-wallet/src/popup/pages/SignCIS3Message/SignCIS3Message.tsx
+++ b/packages/browser-wallet/src/popup/pages/SignCIS3Message/SignCIS3Message.tsx
@@ -90,11 +90,9 @@ function MessageDetailsDisplay({
     const expiry = new Date(expiryTimeSignature).toString();
 
     useEffect(() => {
-        try {
-            parseMessage(payloadMessage).then((m) => setParsedMessage(m));
-        } catch (e) {
-            setParsedMessage(t('unableToDeserialize'));
-        }
+        parseMessage(payloadMessage)
+          .then((m) => setParsedMessage(m))
+          .catch((_) => setParsedMessage(t('unableToDeserialize')));
     }, []);
 
     return (

--- a/packages/browser-wallet/src/popup/pages/SignCIS3Message/i18n/da.ts
+++ b/packages/browser-wallet/src/popup/pages/SignCIS3Message/i18n/da.ts
@@ -8,6 +8,8 @@ const t: typeof en = {
     contractIndex: 'Kontrakt indeks (under indeks)',
     receiveName: 'Kontrakt og funktions navn',
     parameter: 'Parameter',
+    nonce: 'Nonce',
+    expiry: 'Udløber',
     sign: 'Signér',
     reject: 'Afvis',
 };

--- a/packages/browser-wallet/src/popup/pages/SignCIS3Message/i18n/da.ts
+++ b/packages/browser-wallet/src/popup/pages/SignCIS3Message/i18n/da.ts
@@ -1,0 +1,15 @@
+import type en from './en';
+
+const t: typeof en = {
+    description: '{{ dApp }} anmoder om en signatur på følgende besked',
+    descriptionWithSchema:
+        '{{ dApp }} har sendt en rå besked og et schema til at oversætte den. Vi har oversat beskeden, men du burde kun underskrive hvis du stoler på {{ dApp }}',
+    unableToDeserialize: 'Det var ikke muligt at oversætte beskeden',
+    contractIndex: 'Kontrakt indeks (under indeks)',
+    receiveName: 'Kontrakt og funktions navn',
+    parameter: 'Parameter',
+    sign: 'Signér',
+    reject: 'Afvis',
+};
+
+export default t;

--- a/packages/browser-wallet/src/popup/pages/SignCIS3Message/i18n/en.ts
+++ b/packages/browser-wallet/src/popup/pages/SignCIS3Message/i18n/en.ts
@@ -6,6 +6,8 @@ const t = {
     contractIndex: 'Contract index (subindex)',
     receiveName: 'Contract and function name',
     parameter: 'Parameter',
+    nonce: 'Nonce',
+    expiry: 'Expiry time',
     sign: 'Sign',
     reject: 'Reject',
 };

--- a/packages/browser-wallet/src/popup/pages/SignCIS3Message/i18n/en.ts
+++ b/packages/browser-wallet/src/popup/pages/SignCIS3Message/i18n/en.ts
@@ -1,0 +1,13 @@
+const t = {
+    description: '{{ dApp }} requests a signature on a message',
+    descriptionWithSchema:
+        "{{ dApp }} has provided the raw message and a schema to render it. We've rendered the message but you should only sign it if you trust {{ dApp }}.",
+    unableToDeserialize: 'Unable to render message',
+    contractIndex: 'Contract index (subindex)',
+    receiveName: 'Contract and function name',
+    parameter: 'Parameter',
+    sign: 'Sign',
+    reject: 'Reject',
+};
+
+export default t;

--- a/packages/browser-wallet/src/popup/pages/SignCIS3Message/index.ts
+++ b/packages/browser-wallet/src/popup/pages/SignCIS3Message/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SignCIS3Message';

--- a/packages/browser-wallet/src/popup/shell/Routes.tsx
+++ b/packages/browser-wallet/src/popup/shell/Routes.tsx
@@ -15,6 +15,7 @@ import FullscreenPromptLayout from '@popup/page-layouts/FullscreenPromptLayout';
 import Account from '@popup/pages/Account';
 import Identity from '@popup/pages/Identity';
 import SignMessage from '@popup/pages/SignMessage';
+import SignCIS3Message from '@popup/pages/SignCIS3Message';
 import SendTransaction from '@popup/pages/SendTransaction';
 import Setup from '@popup/pages/Setup';
 import ConnectionRequest from '@popup/pages/ConnectionRequest';
@@ -106,6 +107,10 @@ export default function Routes() {
         InternalMessageType.SignMessage,
         'signMessage'
     );
+    const handleSignCIS3MessageResponse = useMessagePrompt<MessageStatusWrapper<AccountTransactionSignature>>(
+        InternalMessageType.SignCIS3Message,
+        'signCIS3Message'
+    );
     const handleAddTokensResponse = useMessagePrompt<MessageStatusWrapper<string[]>>(
         InternalMessageType.AddTokens,
         'addTokens'
@@ -151,6 +156,19 @@ export default function Routes() {
                             onSubmit={(signature) => handleSignMessageResponse({ success: true, result: signature })}
                             onReject={() =>
                                 handleSignMessageResponse({ success: false, message: 'Signing was rejected' })
+                            }
+                        />
+                    }
+                />{' '}
+                <Route
+                    path={relativeRoutes.prompt.signCIS3Message.path}
+                    element={
+                        <SignCIS3Message
+                            onSubmit={(signature) =>
+                                handleSignCIS3MessageResponse({ success: true, result: signature })
+                            }
+                            onReject={() =>
+                                handleSignCIS3MessageResponse({ success: false, message: 'Signing was rejected' })
                             }
                         />
                     }

--- a/packages/browser-wallet/src/popup/shell/Routes.tsx
+++ b/packages/browser-wallet/src/popup/shell/Routes.tsx
@@ -159,7 +159,7 @@ export default function Routes() {
                             }
                         />
                     }
-                />{' '}
+                />
                 <Route
                     path={relativeRoutes.prompt.signCIS3Message.path}
                     element={

--- a/packages/browser-wallet/src/popup/shell/i18n/locales/da.ts
+++ b/packages/browser-wallet/src/popup/shell/i18n/locales/da.ts
@@ -4,6 +4,7 @@ import account from '@popup/pages/Account/i18n/da';
 import setup from '@popup/pages/Setup/i18n/da';
 import sendTransaction from '@popup/pages/SendTransaction/i18n/da';
 import signMessage from '@popup/pages/SignMessage/i18n/da';
+import signCIS3Message from '@popup/pages/SignCIS3Message/i18n/da';
 import connectionRequest from '@popup/pages/ConnectionRequest/i18n/da';
 import settings from '@popup/pages/Settings/i18n/da';
 import networkSettings from '@popup/pages/NetworkSettings/i18n/da';
@@ -37,6 +38,7 @@ const t: typeof en = {
     setup,
     sendTransaction,
     signMessage,
+    signCIS3Message,
     connectionRequest,
     settings,
     networkSettings,

--- a/packages/browser-wallet/src/popup/shell/i18n/locales/en.ts
+++ b/packages/browser-wallet/src/popup/shell/i18n/locales/en.ts
@@ -4,6 +4,7 @@ import account from '@popup/pages/Account/i18n/en';
 import setup from '@popup/pages/Setup/i18n/en';
 import sendTransaction from '@popup/pages/SendTransaction/i18n/en';
 import signMessage from '@popup/pages/SignMessage/i18n/en';
+import signCIS3Message from '@popup/pages/SignCIS3Message/i18n/en';
 import connectionRequest from '@popup/pages/ConnectionRequest/i18n/en';
 import settings from '@popup/pages/Settings/i18n/en';
 import networkSettings from '@popup/pages/NetworkSettings/i18n/en';
@@ -34,6 +35,7 @@ const t = {
     setup,
     sendTransaction,
     signMessage,
+    signCIS3Message,
     connectionRequest,
     settings,
     networkSettings,

--- a/packages/browser-wallet/src/popup/styles/_components.scss
+++ b/packages/browser-wallet/src/popup/styles/_components.scss
@@ -27,6 +27,7 @@
 // Pages
 @import '../pages/Account';
 @import '../pages/SignMessage/SignMessage';
+@import '../pages/SignCIS3Message/SignCIS3Message';
 @import '../pages/Setup/Setup';
 @import '../pages/ConnectionRequest/ConnectionRequest';
 @import '../pages/Settings/Settings';


### PR DESCRIPTION
## Purpose

The browser wallet can also decode the payload field by looking up the parameter schema of the entry_point_name and using this schema to decode the payload. The payload is the input parameter that is sent to the entry_point_name.

## Changes

Proposal on how to decode the payload for the CIS3 contract.
![Screenshot from 2024-04-15 15-32-01](https://github.com/Concordium/concordium-browser-wallet/assets/164325149/f427aa11-b87c-469a-bf27-21f37d99869d)


## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
