### PR TITLE
[BRO-15] Address of QR code difficult to scan in dark mode

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 -   Remove check for redirectUri when launching identity issuance. This check was causing issues with an upcoming identity provider and seems to provide no value.
+-   Increased padding for QR code background. In dark mode, QR code not blending with background.
 
 ## 1.5.1
 

--- a/packages/browser-wallet/src/popup/pages/Account/DisplayAddress/DisplayAddress.scss
+++ b/packages/browser-wallet/src/popup/pages/Account/DisplayAddress/DisplayAddress.scss
@@ -2,8 +2,10 @@ $display-address-copy-left-margin: rem(5px);
 
 .display-address {
     &__address-qr {
-        height: rem(130px);
-        width: rem(130px);
+        height: rem(140px);
+        width: rem(140px);
+        padding: rem(5px);
+        background-color: $color-white;
     }
 
     &__address-text {


### PR DESCRIPTION
## Purpose

Padding for QR code background. In dark mode, QR code not blending with background.
![Screenshot from 2024-05-02 18-21-38](https://github.com/Concordium/concordium-browser-wallet/assets/164325149/c3e52907-4e77-47f3-bb37-ffc4ac641638)

## Changes

Updated styles

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
