### PR TITLE
Remove check of redirectUri

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+-   Remove check for redirectUri when launching identity issuance. This check was causing issues with an upcoming identity provider and seems to provide no value.
+
 ## 1.5.1
 
 ### Fixed

--- a/packages/browser-wallet/src/background/identity-issuance.ts
+++ b/packages/browser-wallet/src/background/identity-issuance.ts
@@ -176,8 +176,10 @@ async function startIdentityIssuance({
                 status: BackgroundResponseStatus.Error,
                 reason: `Initial location did not redirect as expected.`,
             });
-        } else if (!response.url.includes(redirectUri)) {
+        } else if (!response.url.includes(`${redirectUri}#`)) {
             launchExternalIssuance(response.url);
+        } else {
+            throw new Error('Unexpected redirected');
         }
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (e: any) {

--- a/packages/browser-wallet/src/background/identity-issuance.ts
+++ b/packages/browser-wallet/src/background/identity-issuance.ts
@@ -176,10 +176,8 @@ async function startIdentityIssuance({
                 status: BackgroundResponseStatus.Error,
                 reason: `Initial location did not redirect as expected.`,
             });
-        } else if (!response.url.includes(`${redirectUri}#`)) {
-            launchExternalIssuance(response.url);
         } else {
-            throw new Error('Unexpected redirected');
+            launchExternalIssuance(response.url);
         }
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (e: any) {


### PR DESCRIPTION
## Purpose

When launching identity issuance, the browser wallet will send a request the ID provider and be redirected to the onboarding flow.
The browser wallet checks the redirected URL does not contain the `redirectUrl` which is later used for signalling the end of the flow, but there is no error handling for this case, so the wallet fails silently and is stuck on the page for generating the request.

One fix could be to produce an actual error, but this check seems arbitrary and provide no value, so instead I have removed it.
Also, it was hit by accident by an upcoming identity provider.
I have checked that this still works with every identity provider on testnet.

## Changes

- Remove the check of the redirected identity issuance url.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

