### PR TITLE
[BRO-39] Migrate away from injecting API (Draft example of chrome API)

### DIFF
--- a/examples/voting/src/Wallet.jsx
+++ b/examples/voting/src/Wallet.jsx
@@ -6,7 +6,7 @@
 /* eslint-disable import/no-unresolved */
 /* eslint-disable no-plusplus */
 import React from 'react';
-import { detectConcordiumProvider } from '@concordium/browser-wallet-api-helpers';
+import { concordiumWalletApiProxy } from '@concordium/browser-wallet-api-helpers';
 import { Alert, Button } from 'react-bootstrap';
 import {
     AccountTransactionType,
@@ -19,7 +19,7 @@ import moment from 'moment';
 import { RAW_SCHEMA_BASE64, TESTNET_GENESIS_BLOCK_HASH } from './config';
 
 export async function init(setConnectedAccount) {
-    const client = await detectConcordiumProvider();
+    const client = concordiumWalletApiProxy;
     // Listen for relevant events from the wallet.
     client.on('accountChanged', (account) => {
         console.debug('browserwallet event: accountChange', { account });

--- a/packages/browser-wallet-api-helpers/src/index.ts
+++ b/packages/browser-wallet-api-helpers/src/index.ts
@@ -1,3 +1,3 @@
 export * from './wallet-api-types';
 export * from './util';
-export { detectConcordiumProvider } from './detector';
+export { detectConcordiumProvider, concordiumWalletApiProxy } from './detector';


### PR DESCRIPTION
Example of forwarding requests to walletApi with **Proxy**

The general concept of this example is quite simple

In **api-helper**
We need a proxy with an empty object of WalletApi type
`new Proxy({} as WalletApi, proxyHandler)`
This enables TS annotations
<img src="https://github.com/Concordium/concordium-browser-wallet/assets/164325149/516f6c7a-f2de-432c-8a13-da312bd8df90" width="600">

And we can intercept all requests and forward them through the chrome API
With `chrome.runtime.sendMessage`

In **background.js**
With `chrome.runtime.onMessageExternal` listen to this requests

Main difficulty I encountered is the inability to simply import the walletApi. 
A new class needs to be created, which in turn requires many additional changes to BW. 
In this case, it looks like a lot of risky changes.
