### PR TITLE
Use new wallet-proxy endpoint and prepare release of 1.6.3

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.6.3
+
+### Fixed
+
+-   Use new wallet proxy endpoint `/v2/ip_info` which include Company ID Providers, as these are now removed from the `/v1/ip_info`.
+
 ## 1.6.2
 
 ### Fixed

--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
--   Use new wallet proxy endpoint `/v2/ip_info` which include Company ID Providers, as these are now removed from the `/v1/ip_info`.
+-   Use new wallet proxy endpoint `/v2/ip_info` which includes Company ID Providers, as these are now removed from the `/v1/ip_info`.
 
 ## 1.6.2
 

--- a/packages/browser-wallet/package.json
+++ b/packages/browser-wallet/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@concordium/browser-wallet",
     "private": true,
-    "version": "1.6.2",
+    "version": "1.6.3",
     "description": "Browser extension wallet for the Concordium blockchain",
     "author": "Concordium Software",
     "license": "Apache-2.0",

--- a/packages/browser-wallet/src/popup/shared/utils/wallet-proxy.ts
+++ b/packages/browser-wallet/src/popup/shared/utils/wallet-proxy.ts
@@ -259,7 +259,12 @@ export async function getTransactions(
 }
 
 export async function getIdentityProviders(): Promise<IdentityProvider[]> {
-    const proxyPath = `/v2/ip_info`;
+    const currentNetwork = await storedCurrentNetwork.get();
+    if (currentNetwork === undefined) {
+        throw new Error('Tried to access wallet proxy without a loaded network.');
+    }
+    // Use the new endpoint for Testnet only, this logic can be simplified once Company ID as been released on mainnet.
+    const proxyPath = currentNetwork.name === 'Concordium Testnet' ? '/v2/ip_info' : '/v1/ip_info';
     const response = await (await getWalletProxy()).get(proxyPath);
     return response.data;
 }

--- a/packages/browser-wallet/src/popup/shared/utils/wallet-proxy.ts
+++ b/packages/browser-wallet/src/popup/shared/utils/wallet-proxy.ts
@@ -259,7 +259,7 @@ export async function getTransactions(
 }
 
 export async function getIdentityProviders(): Promise<IdentityProvider[]> {
-    const proxyPath = `/v1/ip_info`;
+    const proxyPath = `/v2/ip_info`;
     const response = await (await getWalletProxy()).get(proxyPath);
     return response.data;
 }


### PR DESCRIPTION
## Purpose

- Use new wallet proxy endpoint with company ID providers
- Prepare release of 1.6.3
