### PR TITLE
Key export for account in list

### DIFF
--- a/packages/browser-wallet/src/popup/popupX/constants/routes.ts
+++ b/packages/browser-wallet/src/popup/popupX/constants/routes.ts
@@ -110,7 +110,7 @@ export const relativeRoutes = {
                 },
             },
             privateKey: {
-                path: 'privateKey',
+                path: 'private-key/:account',
             },
         },
         seedPhrase: {

--- a/packages/browser-wallet/src/popup/popupX/pages/Accounts/Accounts.tsx
+++ b/packages/browser-wallet/src/popup/popupX/pages/Accounts/Accounts.tsx
@@ -94,7 +94,8 @@ type AccountListItemProps = {
 function AccountListItem({ credential }: AccountListItemProps) {
     const { t } = useTranslation('x', { keyPrefix: 'accounts' });
     const nav = useNavigate();
-    const navToPrivateKey = () => nav(absoluteRoutes.settings.accounts.privateKey.path);
+    const navToPrivateKey = () =>
+        nav(generatePath(absoluteRoutes.settings.accounts.privateKey.path, { account: credential.address }));
     const navToConnectedSites = () =>
         nav(generatePath(absoluteRoutes.settings.accounts.connectedSites.path, { account: credential.address }));
     const navToIdCards = () => nav(absoluteRoutes.settings.idCards.path);


### PR DESCRIPTION
## Purpose

Change key export page to show the key for the account in the list and not the selected account.

## Changes

- Add account to the path for the page.
- Have two empty lines during loading of the key to avoid UI jumping. This will have to be revised when responsive version is implemented.

