### PR TITLE
Fixed amount of CCD drop displayed in pending transaction

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+-   Fixed amount of CCD drop displayed in pending transaction from 2,000 to actual amount of 20,000
+
 ## 1.7.1
 
 ### Changed

--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
--   Fixed amount of CCD drop displayed in pending transaction from 2,000 to actual amount of 20,000
+-   Fixed amount of CCD drop (Testnet) displayed in pending transaction from 2,000 to actual amount of 20,000
 
 ## 1.7.1
 

--- a/packages/browser-wallet/src/popup/shared/utils/wallet-proxy.ts
+++ b/packages/browser-wallet/src/popup/shared/utils/wallet-proxy.ts
@@ -270,7 +270,7 @@ export async function getCcdDrop(accountAddress: string): Promise<BrowserWalletA
     return createPendingTransaction(
         AccountTransactionType.Transfer,
         response.data.submissionId,
-        BigInt(2000000000),
+        BigInt(20000000000),
         undefined,
         undefined,
         accountAddress


### PR DESCRIPTION
## Changes

Fixed amount of CCD drop (testnet) displayed in pending transaction from 2,000 to actual amount of 20,000
![image](https://github.com/user-attachments/assets/200d1406-6153-42b3-b46f-50da07b4d08b)


## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
