### PR TITLE
Remove unused "downloads" permission

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.7.2
+
+### Fixed
+
+-   Remove unused "downloads" permission from manifest.
+
 ## 1.7.1
 
 ### Changed

--- a/packages/browser-wallet/manifest.json
+++ b/packages/browser-wallet/manifest.json
@@ -11,7 +11,7 @@
         }
     ],
     "host_permissions": ["<all_urls>"],
-    "permissions": ["tabs", "activeTab", "storage", "scripting", "webRequest", "downloads", "alarms"],
+    "permissions": ["tabs", "activeTab", "storage", "scripting", "webRequest", "alarms"],
     "background": {
         "service_worker": "entryPoint!src/background/index.ts"
     },

--- a/packages/browser-wallet/package.json
+++ b/packages/browser-wallet/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@concordium/browser-wallet",
     "private": true,
-    "version": "1.7.1",
+    "version": "1.7.2",
     "description": "Browser extension wallet for the Concordium blockchain",
     "author": "Concordium Software",
     "license": "Apache-2.0",


### PR DESCRIPTION
## Purpose

Web extension is being rejected because of an unused `"downloads"` permission.
This PR removes it and prepares a release.
