### PR TITLE
Release workflow versions update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,20 +10,20 @@ env:
 
 jobs:
     dependencies:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-24.04
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
 
             - name: Cache dependencies
               id: fetch-dependencies
-              uses: actions/cache@v2
+              uses: actions/cache@v4
               with:
                   path: |
                       **/node_modules
                   key: ${{ runner.os }}-${{ env.dummy }}-${{ hashFiles('**/package.json', '**/yarn.lock') }}
 
-            - uses: actions/setup-node@v2
+            - uses: actions/setup-node@v4
               if: steps.fetch-dependencies.outputs.cache-hit != 'true'
               with:
                   node-version: '${{ env.node_version }}'
@@ -37,13 +37,13 @@ jobs:
         needs: [dependencies]
 
         steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v2
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
               with:
                   node-version: '${{ env.node_version }}'
 
             - name: Get cached dependencies
-              uses: actions/cache@v2
+              uses: actions/cache@v4
               with:
                   path: |
                       **/node_modules


### PR DESCRIPTION
## Purpose

Git-hub actions v2 is deprecated
Update to v4

Ubuntu-20.04 is deprecated
Update to 24.04

Details in 
Notice of upcoming releases and breaking changes for GitHub Actions
https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down

## Changes

Version update

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
