### PR TITLE
[WAL-850] Hide memo for CIS-2 token

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Fixed
+
+-   Memo input at Send Transaction screen should not be displayed for CIS-2 tokens
+
 ### Changed
 
 -   Updated delegation description help link from `node` list to `staking`

--- a/packages/browser-wallet/src/popup/popupX/pages/TransactionLog/i18n/en.ts
+++ b/packages/browser-wallet/src/popup/popupX/pages/TransactionLog/i18n/en.ts
@@ -37,7 +37,7 @@ const t = {
     details: {
         backTitle: 'To Activity',
         title: 'Transaction details',
-        tHash: ' Transaction hash',
+        tHash: 'Transaction hash',
         bHash: 'Block hash',
         from: 'From address',
         to: 'To address',

--- a/packages/browser-wallet/src/popup/popupX/shared/Form/TokenAmount/TokenAmount.scss
+++ b/packages/browser-wallet/src/popup/popupX/shared/Form/TokenAmount/TokenAmount.scss
@@ -118,6 +118,10 @@
         padding-bottom: rem(8px);
         border-bottom: 1px solid rgba($color-black, 0.1);
 
+        &:last-child {
+            margin-bottom: unset;
+        }
+
         .address-selector {
             display: flex;
             justify-content: space-between;

--- a/packages/browser-wallet/src/popup/popupX/shared/Form/TokenAmount/View.tsx
+++ b/packages/browser-wallet/src/popup/popupX/shared/Form/TokenAmount/View.tsx
@@ -540,22 +540,24 @@ export default function TokenAmountView(props: TokenAmountViewProps) {
                             {props.form.formState.errors.receiver?.message}
                         </ErrorMessage>
                     </div>
-                    <div className="token-amount_memo">
-                        <div className="token-amount_memo_title">
-                            <span className="text__main_medium">{t('form.tokenAmount.memo.label')}</span>
-                            <ErrorMessage className="capture__main_small">
-                                {props.form.formState.errors.memo?.message}
-                            </ErrorMessage>
+                    {token.tokenType !== 'cis2' && (
+                        <div className="token-amount_memo">
+                            <div className="token-amount_memo_title">
+                                <span className="text__main_medium">{t('form.tokenAmount.memo.label')}</span>
+                                <ErrorMessage className="capture__main_small">
+                                    {props.form.formState.errors.memo?.message}
+                                </ErrorMessage>
+                            </div>
+                            <FormMemoInput
+                                control={props.form.control}
+                                name="memo"
+                                placeholder={t('form.tokenAmount.memo.placeholder')}
+                                rules={{
+                                    validate: validateMemoByteLength,
+                                }}
+                            />
                         </div>
-                        <FormMemoInput
-                            control={props.form.control}
-                            name="memo"
-                            placeholder={t('form.tokenAmount.memo.placeholder')}
-                            rules={{
-                                validate: validateMemoByteLength,
-                            }}
-                        />
-                    </div>
+                    )}
                 </>
             )}
         </div>


### PR DESCRIPTION
## Purpose
Memo text should be available only for CCD (and PLT in future)
<table>
  <tr>
    <th><img width="381" alt="Screenshot 2025-05-28 at 13 22 22" src="https://github.com/user-attachments/assets/400d638a-c1a5-4e48-a8b8-3291960b4377" /></th>
    <th><img width="381" alt="Screenshot 2025-05-28 at 13 20 16" src="https://github.com/user-attachments/assets/03285099-8b1b-481c-a60e-a59edfaf8693" /></th>
    <th>
<img width="378" alt="Screenshot 2025-05-28 at 13 20 04" src="https://github.com/user-attachments/assets/184815f5-80a9-4427-9b54-945646bceb85" />
</th>
  </tr>
</table>

## Changes

Check for token type

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
