### PR TITLE
[WAL-935] Remove EUROe from the Wallet as default token

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+-   Removed EUROe as default token and associated migrations with EUROe as default token. EUROe can still be added by the "Manage token list" menu manually.
+
 ## 2.5.0
 
 ### Added

--- a/packages/browser-wallet/src/background/index.ts
+++ b/packages/browser-wallet/src/background/index.ts
@@ -13,28 +13,17 @@ import {
     sessionPasscode,
     storedAcceptedTerms,
     storedAllowlist,
-    storedCredentials,
     storedCurrentNetwork,
-    storedMigrations,
     storedSelectedAccount,
-    storedTokenMetadata,
-    storedTokens,
 } from '@shared/storage/access';
 
 import { mainnet, stagenet, testnet } from '@shared/constants/networkConfiguration';
-import { ChromeStorageKey, NetworkConfiguration, TokenStorage } from '@shared/storage/types';
+import { ChromeStorageKey, NetworkConfiguration } from '@shared/storage/types';
 import { getTermsAndConditionsConfig } from '@shared/utils/network-helpers';
 import { parsePayload } from '@shared/utils/payload-helpers';
 import { BackgroundSendTransactionPayload } from '@shared/utils/types';
 import { buildURLwithSearchParameters } from '@shared/utils/url-helpers';
 import { Buffer } from 'buffer/';
-import { Migrations } from '@shared/constants/migrations';
-import {
-    EUROE_MAINNET_INDEX,
-    EUROE_METADATA,
-    EUROE_TESTNET_INDEX,
-    euroeTokenStorage,
-} from '@shared/constants/token-metadata';
 import { startMonitoringPendingStatus } from './confirmation';
 import { sendCredentialHandler } from './credential-deployment';
 import { createIdProofHandler, runIfValidProof } from './id-proof';
@@ -51,12 +40,12 @@ import {
     testPopupOpen,
 } from './window-management';
 import {
-    runIfValidWeb3IdCredentialRequest,
-    web3IdAddCredentialFinishHandler,
     createWeb3IdProofHandler,
-    runIfValidWeb3IdProof,
-    loadWeb3IdBackupHandler,
     isAgeProof,
+    loadWeb3IdBackupHandler,
+    runIfValidWeb3IdCredentialRequest,
+    runIfValidWeb3IdProof,
+    web3IdAddCredentialFinishHandler,
 } from './web3Id';
 
 const rpcCallNotAllowedMessage = 'RPC Call can only be performed by whitelisted sites';
@@ -151,51 +140,10 @@ async function migrateNetwork(network: NetworkConfiguration) {
     }
 }
 
-/*
- * Add the given token to all accounts of the given network, that don't already have it.
- */
-async function addTokenToAccounts(network: NetworkConfiguration, contractIndex: number, token: TokenStorage) {
-    const tokens = await storedTokens.get(network.genesisHash);
-    const creds = await storedCredentials.get(network.genesisHash);
-    if (creds && creds.length > 0) {
-        const accountAddresses = creds.map((cred) => cred.address);
-        const newTokens = accountAddresses.reduce((accumulator, address) => {
-            const accTokens = tokens?.[address] || {};
-            if (contractIndex in accTokens) {
-                accumulator[address] = accTokens;
-            } else {
-                accumulator[address] = { [contractIndex]: [token], ...accTokens };
-            }
-            return accumulator;
-        }, {} as Record<string, Record<string, TokenStorage[]>>);
-        await storedTokens.set(network.genesisHash, newTokens);
-    }
-}
-
-/**
- * Add euroe tokens to all accounts that don't already have it, if the migration has not atlready been run, and sets the euroe migration check.
- */
-async function euroeMigration() {
-    const migrations = (await storedMigrations.get()) || [];
-    if (!migrations.includes(Migrations.euroe)) {
-        // Add metadata, if not present
-        const metadata = (await storedTokenMetadata.get()) || {};
-        const { metadataLink } = euroeTokenStorage;
-        if (!(metadataLink in metadata)) {
-            metadata[metadataLink] = EUROE_METADATA;
-            await storedTokenMetadata.set(metadata);
-        }
-        await addTokenToAccounts(mainnet, EUROE_MAINNET_INDEX, euroeTokenStorage);
-        await addTokenToAccounts(testnet, EUROE_TESTNET_INDEX, euroeTokenStorage);
-        await storedMigrations.set([...migrations, Migrations.euroe]);
-    }
-}
-
 async function runMigrations(network?: NetworkConfiguration) {
     if (network) {
         await migrateNetwork(network);
     }
-    await euroeMigration();
 }
 
 const startupHandler = async () => {

--- a/packages/browser-wallet/src/background/update.ts
+++ b/packages/browser-wallet/src/background/update.ts
@@ -1,13 +1,10 @@
-import { storedCredentials, storedIdentities, storedTokens, useIndexedStorage } from '@shared/storage/access';
-import { addToList, editList, updateRecord } from '@shared/storage/update';
+import { storedCredentials, storedIdentities, useIndexedStorage } from '@shared/storage/access';
+import { addToList, editList } from '@shared/storage/update';
 import { Identity, WalletCredential } from '@shared/storage/types';
 import { identityMatch } from '@shared/utils/identity-helpers';
-import { EUROE_MAINNET_INDEX, EUROE_TESTNET_INDEX, euroeTokenStorage } from '@shared/constants/token-metadata';
-import { mainnet, testnet } from '@shared/constants/networkConfiguration';
 
 const identityLock = 'concordium_identity_lock';
 const credentialLock = 'concordium_credential_lock';
-const tokenLock = 'concordium_token_lock';
 
 export async function addIdentity(identity: Identity | Identity[], genesisHash: string): Promise<void> {
     return addToList(
@@ -17,30 +14,7 @@ export async function addIdentity(identity: Identity | Identity[], genesisHash: 
     );
 }
 
-// Add the euroe token to the credential(s)
-async function addEuroeToken(cred: WalletCredential | WalletCredential[], genesisHash: string): Promise<void> {
-    const storage = useIndexedStorage(storedTokens, async () => genesisHash);
-    const add = async (index: string) => {
-        for (const { address } of Array.isArray(cred) ? cred : [cred]) {
-            await updateRecord(tokenLock, storage, address, { [index]: [euroeTokenStorage] });
-        }
-    };
-    switch (genesisHash) {
-        case mainnet.genesisHash:
-            await add(EUROE_MAINNET_INDEX.toString());
-            break;
-        case testnet.genesisHash:
-            await add(EUROE_TESTNET_INDEX.toString());
-            break;
-        default:
-        // The euroe Token only exists on mainnet and testnet, so for other networks we don't do anything.
-    }
-}
-
 export async function addCredential(cred: WalletCredential | WalletCredential[], genesisHash: string): Promise<void> {
-    // All accounts should have euroe token added as default
-    addEuroeToken(cred, genesisHash);
-
     return addToList(
         credentialLock,
         cred,

--- a/packages/browser-wallet/src/popup/store/utils.ts
+++ b/packages/browser-wallet/src/popup/store/utils.ts
@@ -33,7 +33,6 @@ import {
     sessionVerifiableCredentials,
     sessionVerifiableCredentialMetadataUrls,
     storedLog,
-    storedMigrations,
     storedUiStyle,
 } from '@shared/storage/access';
 import { ChromeStorageKey } from '@shared/storage/types';
@@ -76,7 +75,6 @@ const accessorMap: Record<ChromeStorageKey, StorageAccessor<any>> = {
         getGenesisHash
     ),
     [ChromeStorageKey.Log]: storedLog,
-    [ChromeStorageKey.Migrations]: storedMigrations,
 };
 
 export function resetOnUnmountAtom<V>(initial: V): PrimitiveAtom<V> {

--- a/packages/browser-wallet/src/shared/constants/migrations.ts
+++ b/packages/browser-wallet/src/shared/constants/migrations.ts
@@ -1,3 +1,0 @@
-export enum Migrations {
-    euroe = 'euroe_migration',
-}

--- a/packages/browser-wallet/src/shared/constants/token-metadata.ts
+++ b/packages/browser-wallet/src/shared/constants/token-metadata.ts
@@ -12,26 +12,3 @@ export const CCD_METADATA: TokenMetadata = {
     display: CCD_IMAGE,
     thumbnail: CCD_IMAGE,
 };
-
-export const EUROE_METADATA: TokenMetadata = {
-    name: 'EUROe Stablecoin',
-    symbol: 'EUROe',
-    decimals: 6,
-    unique: false,
-    description: 'EUROe is a modern European stablecoin - a digital representation of fiat Euros.',
-    thumbnail: {
-        url: 'https://dev.euroe.com/persistent/token-icon/png/32x32.png',
-    },
-    display: {
-        url: 'https://dev.euroe.com/persistent/token-icon/png/256x256.png',
-    },
-    attributes: [],
-};
-
-export const euroeTokenStorage = {
-    id: '',
-    metadataLink: 'https://euroesolanametadadev.blob.core.windows.net/euroesolanametadatadev/metadata-concordium.json',
-};
-
-export const EUROE_MAINNET_INDEX = 9390;
-export const EUROE_TESTNET_INDEX = 7260;

--- a/packages/browser-wallet/src/shared/storage/access.ts
+++ b/packages/browser-wallet/src/shared/storage/access.ts
@@ -2,7 +2,6 @@ import { stringify } from '@wallet-api/util';
 import { parse } from '@shared/utils/payload-helpers';
 import { VerifiableCredentialMetadata } from '@shared/utils/verifiable-credential-helpers';
 import { Log } from '@shared/utils/log-helpers';
-import { Migrations } from '@shared/constants/migrations';
 import {
     ChromeStorageKey,
     EncryptedData,
@@ -240,4 +239,3 @@ export const sessionVerifiableCredentialMetadataUrls = makeIndexedStorageAccesso
     'session',
     ChromeStorageKey.TemporaryVerifiableCredentialMetadataUrls
 );
-export const storedMigrations = makeStorageAccessor<Migrations[]>('local', ChromeStorageKey.Migrations);

--- a/packages/browser-wallet/src/shared/storage/types.ts
+++ b/packages/browser-wallet/src/shared/storage/types.ts
@@ -42,7 +42,6 @@ export enum ChromeStorageKey {
     TemporaryVerifiableCredentialMetadataUrls = 'tempVerifiableCredentialMetadataUrls',
     Allowlist = 'allowlist',
     Log = 'log',
-    Migrations = 'migrations',
 }
 
 export enum Theme {


### PR DESCRIPTION
## Purpose

Remove EUROe from the default token list in Crypto X. If a user already has 0 EUROe, it will still be visible on the list. This will only affect new account creation.

## Changes

Removed EUROe as default token and associated migrations with EUROe as default token
<img width="380" alt="image" src="https://github.com/user-attachments/assets/2f74d82c-e8b6-431d-bbc9-ef4fd5041442" />


## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.