### PR TITLE
CRE-463  BUG: Proof Explorer Fix

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -3,11 +3,6 @@
 ## Unreleased
 
 -   Removed EUROe as default token and associated migrations with EUROe as default token. EUROe can still be added by the "Manage token list" menu manually.
-
-## 2.5.1
-
-### Fixed
-
 -   Added a fix where the user was not able to do web3id age verification
 
 ## 2.5.0

--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 -   Removed EUROe as default token and associated migrations with EUROe as default token. EUROe can still be added by the "Manage token list" menu manually.
 
+## 2.5.1
+
+### Fixed
+
+-   Added a fix where the user was not able to do web3id age verification
+
 ## 2.5.0
 
 ### Added

--- a/packages/browser-wallet/src/popup/popupX/shell/Routes.tsx
+++ b/packages/browser-wallet/src/popup/popupX/shell/Routes.tsx
@@ -82,6 +82,7 @@ export default function Routes({ messagePromptHandlers }: { messagePromptHandler
         handleAddWeb3IdCredentialResponse,
         handleWeb3IdProofResponse,
         handleIdProofResponse,
+        handleAgeProofResponse,
     } = messagePromptHandlers;
     return (
         <ReactRoutes>
@@ -396,10 +397,10 @@ export default function Routes({ messagePromptHandlers }: { messagePromptHandler
                         element={
                             <VerifiablePresentationRequest
                                 onSubmit={(presentationString) =>
-                                    handleWeb3IdProofResponse({ success: true, result: presentationString })
+                                    handleAgeProofResponse({ success: true, result: presentationString })
                                 }
                                 onReject={(reason) =>
-                                    handleWeb3IdProofResponse({
+                                    handleAgeProofResponse({
                                         success: false,
                                         message: `Proof generation was rejected${reason ? `: ${reason}` : ''}`,
                                     })


### PR DESCRIPTION
## Purpose

Added a fix where the user was not able to do web3id age verification 

## Changes

Updated handleWeb3IdProofResponse to handleAgeProofResponse

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

By submitting the contribution, I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
