### PR TITLE
[COR-2423] Fix message display size

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+-   Updated text area size for string message in binary display
+
 ## 2.12.0
 
 ### Updated

--- a/packages/browser-wallet/src/popup/popupX/shared/BinaryDisplay/BinaryDisplay.scss
+++ b/packages/browser-wallet/src/popup/popupX/shared/BinaryDisplay/BinaryDisplay.scss
@@ -7,6 +7,10 @@
         color: $color-white;
     }
 
+    .string-render {
+        word-break: break-word;
+    }
+
     .sign-message {
         &__binary-text-area {
             border: 1px solid $color-input-border;

--- a/packages/browser-wallet/src/popup/popupX/shared/BinaryDisplay/BinaryDisplay.tsx
+++ b/packages/browser-wallet/src/popup/popupX/shared/BinaryDisplay/BinaryDisplay.tsx
@@ -18,7 +18,7 @@ type MessageObject = {
 function StringRender({ message }: { message: string }) {
     return (
         <div className="binary-display-x">
-            <TextArea readOnly value={message} />
+            <div className="string-render">{message}</div>
         </div>
     );
 }


### PR DESCRIPTION
## Purpose

Changed string message textarea to div. Increased message area.

## Changes

<table>
    <tr>
        <td>Old</td>
        <td>New</td>
    </tr>
    <tr>
        <td>
<img width="374" height="628" alt="Screenshot 2026-06-15 at 14 08 13" src="https://github.com/user-attachments/assets/383939af-5de2-4c21-a23e-16d96052bfc9" />
</td>
        <td>
<img width="376" height="634" alt="image" src="https://github.com/user-attachments/assets/55f77f14-f9b4-4d37-aed6-daa5d9b7cdf6" />
</td>
    </tr>
</table>


## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
