### PR TITLE
[COR-2443] Locks, funds at disposal display

### DIFF
--- a/packages/browser-wallet/CHANGELOG.md
+++ b/packages/browser-wallet/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 -   Added support for Transaction Locks handling and Meta Updates. With new payload type `MetaUpdatePayload` in wallet-api.
+-   Added locked and at-disposal fund balances to the PLT token details page.
+-   Added validation for available PLT funds on the Send Funds page.
 
 ## 2.12.1
 

--- a/packages/browser-wallet/src/popup/popupX/pages/EarningRewards/Delegator/Stake/DelegatorStake.tsx
+++ b/packages/browser-wallet/src/popup/popupX/pages/EarningRewards/Delegator/Stake/DelegatorStake.tsx
@@ -188,7 +188,7 @@ export default function DelegatorStake({ title, target, initialValues, existingV
                                 tokenType="ccd"
                                 buttonMaxLabel={t('inputAmount.buttonMax')}
                                 form={f as unknown as UseFormReturn<AmountForm>}
-                                ccdBalance="total"
+                                balanceType="total"
                             />
                             {target.type === DelegationTargetType.Baker && (
                                 <PoolInfo validatorId={BigInt(target.bakerId!)} />

--- a/packages/browser-wallet/src/popup/popupX/pages/EarningRewards/Validator/Stake/ValidatorStake.tsx
+++ b/packages/browser-wallet/src/popup/popupX/pages/EarningRewards/Validator/Stake/ValidatorStake.tsx
@@ -198,7 +198,7 @@ export default function ValidatorStake({ title, initialValues, existingValues, o
                                 tokenType="ccd"
                                 buttonMaxLabel={t('inputAmount.buttonMax')}
                                 form={f as unknown as UseFormReturn<AmountForm>}
-                                ccdBalance="total"
+                                balanceType="total"
                                 validateAmount={validateAmount}
                             />
                             <div className="register-validator__reward">

--- a/packages/browser-wallet/src/popup/popupX/pages/TokenDetails/TokenDetails.scss
+++ b/packages/browser-wallet/src/popup/popupX/pages/TokenDetails/TokenDetails.scss
@@ -18,6 +18,10 @@
         margin-bottom: rem(16px);
         padding-top: rem(12px);
 
+        &.locks {
+            padding-top: unset;
+        }
+
         &_group {
             display: flex;
             flex-direction: row;

--- a/packages/browser-wallet/src/popup/popupX/pages/TokenDetails/TokenDetailsPlt.tsx
+++ b/packages/browser-wallet/src/popup/popupX/pages/TokenDetails/TokenDetailsPlt.tsx
@@ -3,7 +3,7 @@ import { useUpdateAtom } from 'jotai/utils';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { AccountAddress } from '@concordium/web-sdk';
-import { TokenId, TokenInfo, TokenModuleState, TokenModuleAccountState } from '@concordium/web-sdk/plt';
+import { Cbor, TokenId, TokenInfo, TokenModuleAccountState, TokenModuleState } from '@concordium/web-sdk/plt';
 import { absoluteRoutes, relativeRoutes, sendFundsRoute } from '@popup/popupX/constants/routes';
 import Page from '@popup/popupX/shared/Page';
 import Text from '@popup/popupX/shared/Text';
@@ -26,30 +26,12 @@ import Eye from '@assets/svgX/eye-slash.svg';
 import { grpcClientAtom } from '@popup/store/settings';
 import { removeTokenFromCurrentAccountAtom } from '@popup/store/token';
 import { useAccountInfo } from '@popup/shared/AccountInfoListenerContext/AccountInfoListenerContext';
-import { cborDecode } from '@popup/popupX/shared/utils/helpers';
+import { sumTokenAmounts } from '@popup/popupX/shared/utils/helpers';
 import { SendFundsLocationState } from '@popup/popupX/pages/SendFunds/SendFunds';
 import { useFlattenedAccountTokens } from '@popup/pages/Account/Tokens/utils';
 import { PLT } from '@shared/constants/token';
 
-function usePltInfoAndBalance(pltSymbol: string, credential: WalletCredential) {
-    const client = useAtomValue(grpcClientAtom);
-    const accountInfo = useAccountInfo(credential);
-    const { metadata } = useFlattenedAccountTokens(credential).find((token) => token.id === pltSymbol) || {
-        metadata: { name: '', symbol: '', thumbnail: { url: '' }, description: '' },
-    };
-    const [pltInfo, setPltInfo] = useState<TokenInfo>();
-    useEffect(() => {
-        client.getTokenInfo(TokenId.fromString(pltSymbol)).then((tokenDetails) => {
-            setPltInfo(tokenDetails);
-        });
-    }, []);
-
-    const currentToken = accountInfo?.accountTokens.find((accountToken) => accountToken.id.toString() === pltSymbol);
-    const balance = currentToken?.state.balance || { decimals: 0, value: 0n };
-    const renderedBalance = pipe(integerToFractional(balance.decimals), addThousandSeparators)(balance.value);
-
-    return { pltInfo, renderedBalance, currentToken, metadata };
-}
+const ZERO_TOKEN_BALANCE = { decimals: 0, value: 0n };
 
 enum TokenStatus {
     PAUSED,
@@ -87,6 +69,55 @@ function StatusLabel({ status }: { status: TokenStatus }) {
     }[status];
 }
 
+function usePltInfoAndBalance(pltSymbol: string, credential: WalletCredential) {
+    const client = useAtomValue(grpcClientAtom);
+    const accountInfo = useAccountInfo(credential);
+    const { metadata } = useFlattenedAccountTokens(credential).find((token) => token.id === pltSymbol) || {
+        metadata: { name: '', symbol: '', thumbnail: { url: '' }, description: '' },
+    };
+    const [pltInfo, setPltInfo] = useState<TokenInfo>();
+    useEffect(() => {
+        client.getTokenInfo(TokenId.fromString(pltSymbol)).then((tokenDetails) => {
+            setPltInfo(tokenDetails);
+        });
+    }, []);
+
+    const renderAmount = (decimals: number, value: bigint) =>
+        pipe(integerToFractional(decimals), addThousandSeparators)(value);
+
+    const currentToken = accountInfo?.accountTokens.find((accountToken) => accountToken.id.toString() === pltSymbol);
+    const tokenModuleState = (pltInfo ? Cbor.decode(pltInfo.state.moduleState) : {}) as TokenModuleState;
+    const accountModuleState = (
+        currentToken?.state.moduleState
+            ? Cbor.decode(Cbor.fromHexString(currentToken.state.moduleState.toString()))
+            : {}
+    ) as TokenModuleAccountState;
+
+    const balance = currentToken?.state.balance || ZERO_TOKEN_BALANCE;
+    const renderedBalance = renderAmount(balance.decimals, balance.value);
+
+    const lockedAmount = accountModuleState.locks?.length
+        ? sumTokenAmounts(accountModuleState.locks.map(({ amount }) => amount))
+        : undefined;
+
+    const renderedLocked = lockedAmount ? renderAmount(lockedAmount.decimals, lockedAmount.value) : undefined;
+    const renderedAtDisposal = accountModuleState.available
+        ? renderAmount(accountModuleState.available.decimals, accountModuleState.available.value)
+        : undefined;
+
+    const status = getTokenStatus(tokenModuleState, accountModuleState);
+
+    return {
+        pltInfo,
+        renderedBalance,
+        currentToken,
+        metadata,
+        status,
+        renderedAtDisposal,
+        renderedLocked,
+    };
+}
+
 function getNavState(pltSymbol: string) {
     return {
         tokenType: 'plt',
@@ -100,6 +131,7 @@ type Params = {
 
 function TokenDetails({ credential }: { credential: WalletCredential }) {
     const { t } = useTranslation('x', { keyPrefix: 'tokenDetails' });
+    const remove = useUpdateAtom(removeTokenFromCurrentAccountAtom);
 
     // Need to call this function, so tokens synced at this moment
     // Otherwise user need to reload page, before removing token
@@ -108,18 +140,12 @@ function TokenDetails({ credential }: { credential: WalletCredential }) {
     const nav = useNavigate();
 
     const { pltSymbol = '' } = useParams<Params>();
-    const { pltInfo, renderedBalance, currentToken, metadata } = usePltInfoAndBalance(pltSymbol, credential);
-    const remove = useUpdateAtom(removeTokenFromCurrentAccountAtom);
-    if (!pltInfo) {
-        return null;
-    }
-    const {
-        state: { decimals, moduleState },
-    } = pltInfo;
+    const { pltInfo, renderedBalance, status, metadata, renderedAtDisposal, renderedLocked } = usePltInfoAndBalance(
+        pltSymbol,
+        credential
+    );
 
-    const tokenModuleState = cborDecode(moduleState.toString()) as TokenModuleState;
-    const accountModuleState = cborDecode(currentToken?.state?.moduleState?.toString()) as TokenModuleAccountState;
-    const status = getTokenStatus(tokenModuleState, accountModuleState);
+    if (!pltInfo) return null;
 
     const navToReceive = () => nav(absoluteRoutes.home.receive.path);
     const navToRaw = () => nav(relativeRoutes.home.token.plt.raw.path);
@@ -138,6 +164,24 @@ function TokenDetails({ credential }: { credential: WalletCredential }) {
                 <Text.DynamicSize baseFontSize={32} baseTextLength={17} className="heading_big plt">
                     {renderedBalance} {trunctateSymbol(pltSymbol)}
                 </Text.DynamicSize>
+                {renderedLocked && (
+                    <div className="token-details-x__stake locks">
+                        <div className="token-details-x__stake_group">
+                            <Text.Capture>{t('locked')}</Text.Capture>
+                            <Text.CaptureAdditional>
+                                {renderedLocked} {trunctateSymbol(pltSymbol)}
+                            </Text.CaptureAdditional>
+                        </div>
+                        {renderedAtDisposal && (
+                            <div className="token-details-x__stake_group">
+                                <Text.Capture>{t('atDisposal')}</Text.Capture>
+                                <Text.CaptureAdditional>
+                                    {renderedAtDisposal} {trunctateSymbol(pltSymbol)}
+                                </Text.CaptureAdditional>
+                            </div>
+                        )}
+                    </div>
+                )}
                 <div className="token-details-x__action-buttons">
                     <Button.IconTile
                         icon={<ArrowDown />}
@@ -169,7 +213,7 @@ function TokenDetails({ credential }: { credential: WalletCredential }) {
                         <StatusLabel status={status} />
                     </div>
                     <Card.RowDetails title={t('description')} value={metadata.description || t('noDescription')} />
-                    <Card.RowDetails title={t('decimals')} value={`0 - ${decimals}`} />
+                    <Card.RowDetails title={t('decimals')} value={`0 - ${pltInfo.state.decimals}`} />
                 </Card>
                 <Button.IconText icon={<Notebook />} label={t('showRawMetadata')} onClick={navToRaw} />
                 <Button.IconText icon={<Eye />} label={t('hideToken')} onClick={removeToken} />

--- a/packages/browser-wallet/src/popup/popupX/pages/TokenDetails/i18n/en.ts
+++ b/packages/browser-wallet/src/popup/popupX/pages/TokenDetails/i18n/en.ts
@@ -12,6 +12,7 @@ const t = {
     showRawMetadata: 'Show raw metadata',
     hideToken: 'Hide token from account',
     atDisposal: 'At disposal',
+    locked: 'Locked',
     delegated: 'Delegated',
     validated: 'Validated',
     cooldown: 'Cooldown',

--- a/packages/browser-wallet/src/popup/popupX/shared/Form/TokenAmount/TokenAmount.tsx
+++ b/packages/browser-wallet/src/popup/popupX/shared/Form/TokenAmount/TokenAmount.tsx
@@ -1,8 +1,10 @@
 import React, { useRef } from 'react';
 import { atomFamily, selectAtom, useAtomValue } from 'jotai/utils';
-import { AccountAddress, AccountInfo, ContractAddress, CIS2 } from '@concordium/web-sdk';
+import { AccountAddress, AccountInfo, CIS2, ContractAddress } from '@concordium/web-sdk';
+import { Cbor, TokenModuleAccountState } from '@concordium/web-sdk/plt';
 import { atom } from 'jotai';
 
+import { accountInfoFamily } from '@popup/shared/AccountInfoListenerContext/AccountInfoListenerContext';
 import { contractBalancesFamily } from '@popup/store/token';
 import { PLT } from '@shared/constants/token';
 import TokenAmountView, { TokenAmountViewProps } from './View';
@@ -16,17 +18,37 @@ const tokenAddressEq = (a: CIS2.TokenAddress | null, b: CIS2.TokenAddress | null
     return a === b;
 };
 
-type CcdBalanceType = 'total' | 'available';
+type BalanceType = 'total' | 'available';
 
 const balanceAtomFamily = atomFamily(
-    ([account, ccdBalance, tokenAddress]: [AccountInfo, CcdBalanceType, CIS2.TokenAddress | null, number]) => {
+    ([account, balanceType, tokenAddress]: [AccountInfo, BalanceType, CIS2.TokenAddress | null, number]) => {
         if (tokenAddress === null) {
             return atom(
-                ccdBalance === 'available'
+                balanceType === 'available'
                     ? account.accountAvailableBalance.microCcdAmount
                     : account.accountAmount.microCcdAmount
             );
         }
+
+        if (tokenAddress.contract.index.toString() === PLT) {
+            return atom((get) => {
+                const latestAccountInfo = get(accountInfoFamily(account.accountAddress.address));
+                const tokenState = latestAccountInfo?.accountTokens.find(
+                    (accountToken) => accountToken.id.toString() === tokenAddress.id
+                )?.state;
+
+                if (balanceType === 'available' && tokenState?.moduleState) {
+                    const accountModuleState = Cbor.decode(
+                        Cbor.fromHexString(tokenState.moduleState.toString())
+                    ) as TokenModuleAccountState;
+
+                    return accountModuleState.available?.value ?? tokenState.balance.value;
+                }
+
+                return tokenState?.balance.value;
+            });
+        }
+
         const tokens = contractBalancesFamily(account.accountAddress.address, tokenAddress.contract.index.toString());
         return selectAtom(tokens, (ts) => ts[tokenAddress.id]);
     },
@@ -38,8 +60,8 @@ const balanceAtomFamily = atomFamily(
 type Props = Omit<TokenAmountViewProps, 'tokens' | 'accountTokens' | 'balance' | 'onSelectToken' | 'ccdBalance'> & {
     /** The account info of the account to take the amount from */
     accountInfo: AccountInfo;
-    /** The ccd balance to use. Defaults to 'available' */
-    ccdBalance?: CcdBalanceType;
+    /** The type of balance to use. Defaults to 'available' */
+    balanceType?: BalanceType;
 };
 
 /**
@@ -81,7 +103,7 @@ type Props = Omit<TokenAmountViewProps, 'tokens' | 'accountTokens' | 'balance' |
  *   address={{ id: '', contract: ContractAddress.create(1) }}
  * />
  */
-export default function TokenAmount({ accountInfo, ccdBalance = 'available', ...props }: Props) {
+export default function TokenAmount({ accountInfo, balanceType = 'available', ...props }: Props) {
     const { current: timestamp } = useRef(Date.now());
     const { token } = props.form.watch();
     const tokenAddress =
@@ -94,7 +116,7 @@ export default function TokenAmount({ accountInfo, ccdBalance = 'available', ...
         null;
 
     const tokenInfo = useTokenInfo(accountInfo.accountAddress);
-    const tokenBalance = useAtomValue(balanceAtomFamily([accountInfo, ccdBalance, tokenAddress, timestamp]));
+    const tokenBalance = useAtomValue(balanceAtomFamily([accountInfo, balanceType, tokenAddress, timestamp]));
 
     if (tokenInfo.loading) {
         return null;

--- a/packages/browser-wallet/src/popup/popupX/shared/utils/helpers.ts
+++ b/packages/browser-wallet/src/popup/popupX/shared/utils/helpers.ts
@@ -1,5 +1,6 @@
 import { decode, encode } from 'cbor2';
 import { CcdAmount, Ratio, toBuffer } from '@concordium/web-sdk';
+import { TokenAmount } from '@concordium/web-sdk/plt';
 import { DataBlob } from '@concordium/web-sdk/types';
 import { CCD_METADATA } from '@shared/constants/token-metadata';
 import { useLocation } from 'react-router-dom';
@@ -82,6 +83,23 @@ export function displayCcdAsEur(microCcdPerEur: Ratio, microCcd: bigint, decimal
     }
 
     return eurFormatter.format(eur);
+}
+
+/** Sum token amounts with matching decimals into a single token amount. */
+export function sumTokenAmounts(amounts: TokenAmount.Type[]): TokenAmount.Type | undefined {
+    if (amounts.length === 0) return undefined;
+    const { decimals } = amounts[0];
+
+    return TokenAmount.create(
+        amounts.reduce((sum, amount) => {
+            if (amount.decimals !== decimals) {
+                throw new Error('Cannot sum token amounts with different decimals');
+            }
+
+            return sum + amount.value;
+        }, 0n),
+        decimals
+    );
 }
 
 export function decodeMemo(memo: string | undefined): string {


### PR DESCRIPTION
## Purpose

Update the token page UI to display lock-related balance information for the selected token.

## Changes

Added locked and At disposal fund balances to the PLT token details page.
Added validation for available PLT funds on the Send Funds page.

<img width="388" height="609" alt="Screenshot 2026-07-04 at 23 05 46" src="https://github.com/user-attachments/assets/2021299b-ee09-41f1-977f-7e780f7609bd" />

<img width="383" height="609" alt="Screenshot 2026-07-04 at 23 06 12" src="https://github.com/user-attachments/assets/e1725782-87d6-4930-8afd-2f4249551797" />


## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
